### PR TITLE
chore: upgrade crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Nervos Core Dev <dev@nervos.org>"]
 
 [dependencies]
 byteorder = "1"
-goblin = "0.0.17"
+goblin = "0.0.19"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # [Nervos CKB](http://nervos.org) VM
 
 [![Build Status](https://travis-ci.com/nervosnetwork/ckb-vm.svg?branch=master)](https://travis-ci.com/nervosnetwork/ckb-vm)
+[![dependency status](https://deps.rs/repo/github/nervosnetwork/ckb-vm/status.svg)](https://deps.rs/repo/github/nervosnetwork/ckb-vm)
 
 ---
 


### PR DESCRIPTION
Upgrade goblin to 0.0.19. Also add the deps.rs badge into README.