### PR TITLE
feat: Reduce maximum memory to 16M to save resources

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,8 @@ use std::io::{Error as IOError, ErrorKind};
 pub const RISCV_PAGESIZE: usize = 1 << 12;
 pub const RISCV_GENERAL_REGISTER_NUMBER: usize = 32;
 // 128 MB
-pub const RISCV_MAX_MEMORY: usize = 128 << 20;
+pub const RISCV_MAX_MEMORY: usize = 16 << 20;
+pub const DEFAULT_STACK_SIZE: usize = 2 << 20;
 
 // Register ABI names
 pub const ZERO: usize = 0;

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -4,8 +4,8 @@ use super::instructions::{Instruction, Register};
 use super::memory::{Memory, PROT_EXEC, PROT_READ, PROT_WRITE};
 use super::syscalls::Syscalls;
 use super::{
-    Error, A0, A7, REGISTER_ABI_NAMES, RISCV_GENERAL_REGISTER_NUMBER, RISCV_MAX_MEMORY,
-    RISCV_PAGESIZE, SP,
+    Error, A0, A7, DEFAULT_STACK_SIZE, REGISTER_ABI_NAMES, RISCV_GENERAL_REGISTER_NUMBER,
+    RISCV_MAX_MEMORY, RISCV_PAGESIZE, SP,
 };
 use goblin::elf::program_header::{PF_R, PF_W, PF_X, PT_LOAD};
 use goblin::elf::{Elf, Header};
@@ -13,8 +13,6 @@ use std::cmp::max;
 use std::fmt::{self, Display};
 use std::ops::{Deref, DerefMut};
 use std::rc::Rc;
-
-const DEFAULT_STACK_SIZE: usize = 8 * 1024 * 1024;
 
 fn elf_bits(header: &Header) -> Option<usize> {
     // This is documented in ELF specification, we are exacting ELF file


### PR DESCRIPTION
It turns out we won't need that much maximum memory initially here. 128MB is quite a waste of resource, this PR changes it now to 16MB.