### PR TITLE
refactor: Preparation work for moving into a JIT structure

### DIFF
--- a/src/instructions/common.rs
+++ b/src/instructions/common.rs
@@ -17,7 +17,7 @@ pub fn add<Mac: Machine<R, M>, R: Register, M: Memory>(
 ) {
     let rs1_value = machine.registers()[rs1];
     let rs2_value = machine.registers()[rs2];
-    let (value, _) = rs1_value.overflowing_add(rs2_value);
+    let value = rs1_value.overflowing_add(rs2_value);
     update_register(machine, rd, value);
 }
 
@@ -29,8 +29,8 @@ pub fn addw<Mac: Machine<R, M>, R: Register, M: Memory>(
 ) {
     let rs1_value = machine.registers()[rs1];
     let rs2_value = machine.registers()[rs2];
-    let (value, _) = rs1_value.overflowing_add(rs2_value);
-    update_register(machine, rd, value.sign_extend(32));
+    let value = rs1_value.overflowing_add(rs2_value);
+    update_register(machine, rd, value.sign_extend(R::from_usize(32)));
 }
 
 pub fn sub<Mac: Machine<R, M>, R: Register, M: Memory>(
@@ -41,7 +41,7 @@ pub fn sub<Mac: Machine<R, M>, R: Register, M: Memory>(
 ) {
     let rs1_value = machine.registers()[rs1];
     let rs2_value = machine.registers()[rs2];
-    let (value, _) = rs1_value.overflowing_sub(rs2_value);
+    let value = rs1_value.overflowing_sub(rs2_value);
     update_register(machine, rd, value);
 }
 
@@ -53,8 +53,8 @@ pub fn subw<Mac: Machine<R, M>, R: Register, M: Memory>(
 ) {
     let rs1_value = machine.registers()[rs1];
     let rs2_value = machine.registers()[rs2];
-    let (value, _) = rs1_value.overflowing_sub(rs2_value);
-    update_register(machine, rd, value.sign_extend(32));
+    let value = rs1_value.overflowing_sub(rs2_value);
+    update_register(machine, rd, value.sign_extend(R::from_usize(32)));
 }
 
 pub fn addi<Mac: Machine<R, M>, R: Register, M: Memory>(
@@ -63,7 +63,7 @@ pub fn addi<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     imm: Immediate,
 ) {
-    let (value, _) = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
+    let value = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
     update_register(machine, rd, value);
 }
 
@@ -73,8 +73,8 @@ pub fn addiw<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     imm: Immediate,
 ) {
-    let (value, _) = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
-    update_register(machine, rd, value.sign_extend(32));
+    let value = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
+    update_register(machine, rd, value.sign_extend(R::from_usize(32)));
 }
 
 // =======================
@@ -86,7 +86,7 @@ pub fn lb<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let (address, _) = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
     let value = machine.memory_mut().load8(address.to_usize())?;
     // sign-extened
     update_register(machine, rd, R::from_i8(value as i8));
@@ -99,7 +99,7 @@ pub fn lh<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let (address, _) = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
     let value = machine.memory_mut().load16(address.to_usize())?;
     // sign-extened
     update_register(machine, rd, R::from_i16(value as i16));
@@ -112,7 +112,7 @@ pub fn lw<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let (address, _) = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
     let value = machine.memory_mut().load32(address.to_usize())?;
     update_register(machine, rd, R::from_i32(value as i32));
     Ok(())
@@ -124,7 +124,7 @@ pub fn ld<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let (address, _) = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
     let value = machine.memory_mut().load64(address.to_usize())?;
     update_register(machine, rd, R::from_i64(value as i64));
     Ok(())
@@ -136,7 +136,7 @@ pub fn lbu<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let (address, _) = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
     let value = machine.memory_mut().load8(address.to_usize())?;
     update_register(machine, rd, R::from_u8(value));
     Ok(())
@@ -148,7 +148,7 @@ pub fn lhu<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let (address, _) = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
     let value = machine.memory_mut().load16(address.to_usize())?;
     update_register(machine, rd, R::from_u16(value));
     Ok(())
@@ -160,7 +160,7 @@ pub fn lwu<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let (address, _) = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
     let value = machine.memory_mut().load32(address.to_usize())?;
     update_register(machine, rd, R::from_u32(value));
     Ok(())
@@ -175,7 +175,7 @@ pub fn sb<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs2: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let (address, _) = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
     let value = machine.registers()[rs2].to_u8();
     machine.memory_mut().store8(address.to_usize(), value)?;
     Ok(())
@@ -187,7 +187,7 @@ pub fn sh<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs2: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let (address, _) = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
     let value = machine.registers()[rs2].to_u16();
     machine.memory_mut().store16(address.to_usize(), value)?;
     Ok(())
@@ -199,7 +199,7 @@ pub fn sw<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs2: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let (address, _) = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
     let value = machine.registers()[rs2].to_u32();
     machine.memory_mut().store32(address.to_usize(), value)?;
     Ok(())
@@ -211,7 +211,7 @@ pub fn sd<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs2: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let (address, _) = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
     let value = machine.registers()[rs2].to_u64();
     machine.memory_mut().store64(address.to_usize(), value)?;
     Ok(())
@@ -292,7 +292,7 @@ pub fn slli<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     shamt: UImmediate,
 ) {
-    let value = machine.registers()[rs1] << (shamt as usize);
+    let value = machine.registers()[rs1] << R::from_u32(shamt);
     update_register(machine, rd, value);
 }
 
@@ -302,7 +302,7 @@ pub fn srli<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     shamt: UImmediate,
 ) {
-    let value = machine.registers()[rs1] >> (shamt as usize);
+    let value = machine.registers()[rs1] >> R::from_u32(shamt);
     update_register(machine, rd, value);
 }
 
@@ -312,7 +312,7 @@ pub fn srai<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     shamt: UImmediate,
 ) {
-    let value = machine.registers()[rs1].signed_shr(shamt as usize);
+    let value = machine.registers()[rs1].signed_shr(R::from_u32(shamt));
     update_register(machine, rd, value);
 }
 
@@ -322,8 +322,8 @@ pub fn slliw<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     shamt: UImmediate,
 ) {
-    let value = machine.registers()[rs1] << (shamt as usize);
-    update_register(machine, rd, value.sign_extend(32));
+    let value = machine.registers()[rs1] << R::from_u32(shamt);
+    update_register(machine, rd, value.sign_extend(R::from_usize(32)));
 }
 
 pub fn srliw<Mac: Machine<R, M>, R: Register, M: Memory>(
@@ -332,8 +332,8 @@ pub fn srliw<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     shamt: UImmediate,
 ) {
-    let value = machine.registers()[rs1].zero_extend(32) >> (shamt as usize);
-    update_register(machine, rd, value.sign_extend(32));
+    let value = machine.registers()[rs1].zero_extend(R::from_usize(32)) >> R::from_u32(shamt);
+    update_register(machine, rd, value.sign_extend(R::from_usize(32)));
 }
 
 pub fn sraiw<Mac: Machine<R, M>, R: Register, M: Memory>(
@@ -343,9 +343,9 @@ pub fn sraiw<Mac: Machine<R, M>, R: Register, M: Memory>(
     shamt: UImmediate,
 ) {
     let value = machine.registers()[rs1]
-        .sign_extend(32)
-        .signed_shr(shamt as usize);
-    update_register(machine, rd, value.sign_extend(32));
+        .sign_extend(R::from_usize(32))
+        .signed_shr(R::from_u32(shamt));
+    update_register(machine, rd, value.sign_extend(R::from_usize(32)));
 }
 
 // =======================
@@ -357,7 +357,7 @@ pub fn jal<Mac: Machine<R, M>, R: Register, M: Memory>(
     imm: Immediate,
     xbytes: usize,
 ) -> Option<R> {
-    let (link, _) = machine.pc().overflowing_add(R::from_usize(xbytes));
+    let link = machine.pc().overflowing_add(R::from_usize(xbytes));
     update_register(machine, rd, link);
-    Some(machine.pc().overflowing_add(R::from_i32(imm)).0)
+    Some(machine.pc().overflowing_add(R::from_i32(imm)))
 }

--- a/src/instructions/i.rs
+++ b/src/instructions/i.rs
@@ -186,13 +186,13 @@ impl Execute for Rtype {
             RtypeInstruction::SLT => {
                 let rs1_value = machine.registers()[self.rs1];
                 let rs2_value = machine.registers()[self.rs2];
-                let value = rs1_value.less_than_signed(rs2_value);
+                let value = rs1_value.lt_s(rs2_value);
                 update_register(machine, self.rd, value);
             }
             RtypeInstruction::SLTU => {
                 let rs1_value = machine.registers()[self.rs1];
                 let rs2_value = machine.registers()[self.rs2];
-                let value = rs1_value.less_than(rs2_value);
+                let value = rs1_value.lt(rs2_value);
                 update_register(machine, self.rd, value);
             }
         }
@@ -221,13 +221,13 @@ impl Execute for Itype {
             ItypeInstruction::SLTI => {
                 let rs1_value = machine.registers()[self.rs1];
                 let imm_value = R::from_i32(self.imm);
-                let value = rs1_value.less_than_signed(imm_value);
+                let value = rs1_value.lt_s(imm_value);
                 update_register(machine, self.rd, value);
             }
             ItypeInstruction::SLTIU => {
                 let rs1_value = machine.registers()[self.rs1];
                 let imm_value = R::from_i32(self.imm);
-                let value = rs1_value.less_than(imm_value);
+                let value = rs1_value.lt(imm_value);
                 update_register(machine, self.rd, value);
             }
             ItypeInstruction::JALR => {
@@ -297,10 +297,10 @@ impl Execute for Btype {
         let condition = match &self.inst {
             BtypeInstruction::BEQ => rs1_value.eq(rs2_value),
             BtypeInstruction::BNE => rs1_value.ne(rs2_value),
-            BtypeInstruction::BLT => rs1_value.less_than_signed(rs2_value),
-            BtypeInstruction::BGE => rs1_value.greater_or_equal_than_signed(rs2_value),
-            BtypeInstruction::BLTU => rs1_value.less_than(rs2_value),
-            BtypeInstruction::BGEU => rs1_value.greater_or_equal_than(rs2_value),
+            BtypeInstruction::BLT => rs1_value.lt_s(rs2_value),
+            BtypeInstruction::BGE => rs1_value.ge_s(rs2_value),
+            BtypeInstruction::BLTU => rs1_value.lt(rs2_value),
+            BtypeInstruction::BGEU => rs1_value.ge(rs2_value),
         };
         let next_pc_offset = condition.cond(R::from_i32(self.imm), R::from_usize(4));
         Ok(Some(machine.pc().overflowing_add(next_pc_offset)))

--- a/src/instructions/i.rs
+++ b/src/instructions/i.rs
@@ -10,7 +10,6 @@ use super::{
     common, Execute, Immediate, Instruction as GenericInstruction, Instruction::I, RegisterIndex,
     UImmediate,
 };
-use std::cmp::Ordering;
 
 #[derive(Debug)]
 pub enum RtypeInstruction {
@@ -152,51 +151,49 @@ impl Execute for Rtype {
             RtypeInstruction::OR => common::or(machine, self.rd, self.rs1, self.rs2),
             RtypeInstruction::AND => common::and(machine, self.rd, self.rs1, self.rs2),
             RtypeInstruction::SLL => {
-                let shift_value = machine.registers()[self.rs2].to_usize() & R::SHIFT_MASK;
+                let shift_value = machine.registers()[self.rs2] & R::from_usize(R::SHIFT_MASK);
                 let value = machine.registers()[self.rs1] << shift_value;
                 update_register(machine, self.rd, value);
             }
             RtypeInstruction::SLLW => {
-                let shift_value = machine.registers()[self.rs2].to_usize() & 0x1F;
+                let shift_value = machine.registers()[self.rs2] & R::from_usize(0x1F);
                 let value = machine.registers()[self.rs1] << shift_value;
-                update_register(machine, self.rd, value.sign_extend(32));
+                update_register(machine, self.rd, value.sign_extend(R::from_usize(32)));
             }
             RtypeInstruction::SRL => {
-                let shift_value = machine.registers()[self.rs2].to_usize() & R::SHIFT_MASK;
+                let shift_value = machine.registers()[self.rs2] & R::from_usize(R::SHIFT_MASK);
                 let value = machine.registers()[self.rs1] >> shift_value;
                 update_register(machine, self.rd, value);
             }
             RtypeInstruction::SRLW => {
-                let shift_value = machine.registers()[self.rs2].to_usize() & 0x1F;
-                let value = machine.registers()[self.rs1].zero_extend(32) >> shift_value;
-                update_register(machine, self.rd, value.sign_extend(32));
+                let shift_value = machine.registers()[self.rs2] & R::from_usize(0x1F);
+                let value =
+                    machine.registers()[self.rs1].zero_extend(R::from_usize(32)) >> shift_value;
+                update_register(machine, self.rd, value.sign_extend(R::from_usize(32)));
             }
             RtypeInstruction::SRA => {
-                let shift_value = machine.registers()[self.rs2].to_usize() & R::SHIFT_MASK;
+                let shift_value = machine.registers()[self.rs2] & R::from_usize(R::SHIFT_MASK);
                 let value = machine.registers()[self.rs1].signed_shr(shift_value);
                 update_register(machine, self.rd, value);
             }
             RtypeInstruction::SRAW => {
-                let shift_value = machine.registers()[self.rs2].to_usize() & 0x1F;
+                let shift_value = machine.registers()[self.rs2] & R::from_usize(0x1F);
                 let value = machine.registers()[self.rs1]
-                    .sign_extend(32)
+                    .sign_extend(R::from_usize(32))
                     .signed_shr(shift_value);
-                update_register(machine, self.rd, value.sign_extend(32));
+                update_register(machine, self.rd, value.sign_extend(R::from_usize(32)));
             }
             RtypeInstruction::SLT => {
                 let rs1_value = machine.registers()[self.rs1];
                 let rs2_value = machine.registers()[self.rs2];
-                let value = match rs1_value.signed_cmp(&rs2_value) {
-                    Ordering::Less => 1,
-                    _ => 0,
-                };
-                update_register(machine, self.rd, Register::from_usize(value));
+                let value = rs1_value.less_than_signed(rs2_value);
+                update_register(machine, self.rd, value);
             }
             RtypeInstruction::SLTU => {
                 let rs1_value = machine.registers()[self.rs1];
                 let rs2_value = machine.registers()[self.rs2];
-                let value = if rs1_value < rs2_value { 1 } else { 0 };
-                update_register(machine, self.rd, Register::from_usize(value));
+                let value = rs1_value.less_than(rs2_value);
+                update_register(machine, self.rd, value);
             }
         }
         Ok(None)
@@ -224,21 +221,18 @@ impl Execute for Itype {
             ItypeInstruction::SLTI => {
                 let rs1_value = machine.registers()[self.rs1];
                 let imm_value = R::from_i32(self.imm);
-                let value = match rs1_value.signed_cmp(&imm_value) {
-                    Ordering::Less => 1,
-                    _ => 0,
-                };
-                update_register(machine, self.rd, Register::from_usize(value));
+                let value = rs1_value.less_than_signed(imm_value);
+                update_register(machine, self.rd, value);
             }
             ItypeInstruction::SLTIU => {
                 let rs1_value = machine.registers()[self.rs1];
                 let imm_value = R::from_i32(self.imm);
-                let value = if rs1_value < imm_value { 1 } else { 0 };
-                update_register(machine, self.rd, Register::from_usize(value));
+                let value = rs1_value.less_than(imm_value);
+                update_register(machine, self.rd, value);
             }
             ItypeInstruction::JALR => {
-                let (link, _) = machine.pc().overflowing_add(R::from_usize(4));
-                let (mut next_pc, _) =
+                let link = machine.pc().overflowing_add(R::from_usize(4));
+                let mut next_pc =
                     machine.registers()[self.rs1].overflowing_add(R::from_i32(self.imm));
                 next_pc = next_pc & (!R::one());
                 update_register(machine, self.rd, link);
@@ -298,27 +292,18 @@ impl Execute for Btype {
         &self,
         machine: &mut Mac,
     ) -> Result<Option<R>, Error> {
-        let satisfied = match &self.inst {
-            BtypeInstruction::BEQ => machine.registers()[self.rs1] == machine.registers()[self.rs2],
-            BtypeInstruction::BNE => machine.registers()[self.rs1] != machine.registers()[self.rs2],
-            BtypeInstruction::BLT => {
-                machine.registers()[self.rs1].signed_cmp(&machine.registers()[self.rs2])
-                    == Ordering::Less
-            }
-            BtypeInstruction::BGE => {
-                machine.registers()[self.rs1].signed_cmp(&machine.registers()[self.rs2])
-                    != Ordering::Less
-            }
-            BtypeInstruction::BLTU => machine.registers()[self.rs1] < machine.registers()[self.rs2],
-            BtypeInstruction::BGEU => {
-                machine.registers()[self.rs1] >= machine.registers()[self.rs2]
-            }
+        let rs1_value = machine.registers()[self.rs1];
+        let rs2_value = machine.registers()[self.rs2];
+        let condition = match &self.inst {
+            BtypeInstruction::BEQ => rs1_value.eq(rs2_value),
+            BtypeInstruction::BNE => rs1_value.eq(rs2_value).logical_not(),
+            BtypeInstruction::BLT => rs1_value.less_than_signed(rs2_value),
+            BtypeInstruction::BGE => rs1_value.less_than_signed(rs2_value).logical_not(),
+            BtypeInstruction::BLTU => rs1_value.less_than(rs2_value),
+            BtypeInstruction::BGEU => rs1_value.less_than(rs2_value).logical_not(),
         };
-        if satisfied {
-            Ok(Some(machine.pc().overflowing_add(R::from_i32(self.imm)).0))
-        } else {
-            Ok(None)
-        }
+        let next_pc_offset = condition.cond(R::from_i32(self.imm), R::from_usize(4));
+        Ok(Some(machine.pc().overflowing_add(next_pc_offset)))
     }
 }
 
@@ -332,7 +317,7 @@ impl Execute for Utype {
                 update_register(machine, self.rd, R::from_i32(self.imm));
             }
             UtypeInstruction::AUIPC => {
-                let (value, _) = machine.pc().overflowing_add(R::from_i32(self.imm));
+                let value = machine.pc().overflowing_add(R::from_i32(self.imm));
                 update_register(machine, self.rd, value);
             }
         }
@@ -435,7 +420,7 @@ impl Instruction {
             Instruction::JAL { imm, rd } => common::jal(machine, *rd, *imm, 4),
             Instruction::FENCEI => unimplemented!(),
         };
-        let (default_next_pc, _) = machine.pc().overflowing_add(R::from_usize(4));
+        let default_next_pc = machine.pc().overflowing_add(R::from_usize(4));
         machine.set_pc(next_pc.unwrap_or(default_next_pc));
         Ok(())
     }

--- a/src/instructions/i.rs
+++ b/src/instructions/i.rs
@@ -296,11 +296,11 @@ impl Execute for Btype {
         let rs2_value = machine.registers()[self.rs2];
         let condition = match &self.inst {
             BtypeInstruction::BEQ => rs1_value.eq(rs2_value),
-            BtypeInstruction::BNE => rs1_value.eq(rs2_value).logical_not(),
+            BtypeInstruction::BNE => rs1_value.ne(rs2_value),
             BtypeInstruction::BLT => rs1_value.less_than_signed(rs2_value),
-            BtypeInstruction::BGE => rs1_value.less_than_signed(rs2_value).logical_not(),
+            BtypeInstruction::BGE => rs1_value.greater_or_equal_than_signed(rs2_value),
             BtypeInstruction::BLTU => rs1_value.less_than(rs2_value),
-            BtypeInstruction::BGEU => rs1_value.less_than(rs2_value).logical_not(),
+            BtypeInstruction::BGEU => rs1_value.greater_or_equal_than(rs2_value),
         };
         let next_pc_offset = condition.cond(R::from_i32(self.imm), R::from_usize(4));
         Ok(Some(machine.pc().overflowing_add(next_pc_offset)))

--- a/src/instructions/m.rs
+++ b/src/instructions/m.rs
@@ -36,14 +36,14 @@ impl Execute for Rtype {
         let rs2_value = machine.registers()[self.rs2];
         match &self.inst {
             RtypeInstruction::MUL => {
-                let (value, _) = rs1_value.overflowing_mul(rs2_value);
+                let value = rs1_value.overflowing_mul(rs2_value);
                 update_register(machine, self.rd, value);
             }
             RtypeInstruction::MULW => {
-                let (value, _) = rs1_value
-                    .zero_extend(32)
-                    .overflowing_mul(rs2_value.zero_extend(32));
-                update_register(machine, self.rd, value.sign_extend(32));
+                let value = rs1_value
+                    .zero_extend(R::from_usize(32))
+                    .overflowing_mul(rs2_value.zero_extend(R::from_usize(32)));
+                update_register(machine, self.rd, value.sign_extend(R::from_usize(32)));
             }
             RtypeInstruction::MULH => {
                 let value = rs1_value.overflowing_mul_high_signed(rs2_value);
@@ -57,123 +57,45 @@ impl Execute for Rtype {
                 let value = rs1_value.overflowing_mul_high_unsigned(rs2_value);
                 update_register(machine, self.rd, value);
             }
-
-            // +---------------------------------------------------------------------------------------+
-            // | Condition              | Dividend  | Divisor | DIVU[W] | REMU[W] |  DIV[W]   | REM[W] |
-            // +------------------------+-----------+---------+---------+---------+-----------+--------+
-            // | Division by zero       |     x     |    0    | 2**L-1  |    x    |    -1     |   x    |
-            // +------------------------+-----------+---------+---------+---------+-----------+--------+
-            // | Overflow (signed only) | −2**(L−1) |   −1    |    -    |    -    | -2**(L-1) |   0    |
-            // +---------------------------------------------------------------------------------------+
             RtypeInstruction::DIV => {
-                let value = if rs2_value == R::zero() {
-                    // This is documented in RISC-V spec, when divided by
-                    // 0, RISC-V machine would return -1 in DIV instead of
-                    // trapping.
-                    R::zero().overflowing_sub(R::one()).0
-                } else {
-                    let (value, overflow) = rs1_value.overflowing_div_signed(rs2_value);
-                    if overflow {
-                        // This is actually -2^(L - 1), where L is R::BITS, we are
-                        // calculating it using (-1) << (L - 1). -1 can be further
-                        // calculated using R::zero() - R::one()
-                        (R::zero().overflowing_sub(R::one()).0) << (R::BITS - 1)
-                    } else {
-                        value
-                    }
-                };
+                let value = rs1_value.overflowing_div_signed(rs2_value);
                 update_register(machine, self.rd, value);
             }
             RtypeInstruction::DIVW => {
-                let rs1_value = rs1_value.sign_extend(32);
-                let rs2_value = rs2_value.sign_extend(32);
-                let value = if rs2_value == R::zero() {
-                    // This is documented in RISC-V spec, when divided by
-                    // 0, RISC-V machine would return -1 in DIV instead of
-                    // trapping.
-                    R::zero().overflowing_sub(R::one()).0
-                } else {
-                    let (value, overflow) = rs1_value.overflowing_div_signed(rs2_value);
-                    if overflow {
-                        // This is actually -2^(L - 1), where L is R::BITS, we are
-                        // calculating it using (-1) << (L - 1). -1 can be further
-                        // calculated using R::zero() - R::one()
-                        (R::zero().overflowing_sub(R::one()).0) << (R::BITS - 1)
-                    } else {
-                        value.sign_extend(32)
-                    }
-                };
-                update_register(machine, self.rd, value);
+                let rs1_value = rs1_value.sign_extend(R::from_usize(32));
+                let rs2_value = rs2_value.sign_extend(R::from_usize(32));
+                let value = rs1_value.overflowing_div_signed(rs2_value);
+                update_register(machine, self.rd, value.sign_extend(R::from_usize(32)));
             }
             RtypeInstruction::DIVU => {
-                let value = if rs2_value == R::zero() {
-                    // This is documented in RISC-V spec, when divided by
-                    // 0, RISC-V machine would return 2**L - 1 for unsigned integer
-                    // in DIV instead of trapping.
-                    R::max_value()
-                } else {
-                    rs1_value.overflowing_div(rs2_value).0
-                };
+                let value = rs1_value.overflowing_div(rs2_value);
                 update_register(machine, self.rd, value);
             }
             RtypeInstruction::DIVUW => {
-                let rs1_value = rs1_value.zero_extend(32);
-                let rs2_value = rs2_value.zero_extend(32);
-                let value = if rs2_value == R::zero() {
-                    // This is documented in RISC-V spec, when divided by
-                    // 0, RISC-V machine would return 2**L - 1 for unsigned integer
-                    // in DIV instead of trapping.
-                    R::max_value()
-                } else {
-                    rs1_value.overflowing_div(rs2_value).0
-                };
-                update_register(machine, self.rd, value.sign_extend(32));
+                let rs1_value = rs1_value.zero_extend(R::from_usize(32));
+                let rs2_value = rs2_value.zero_extend(R::from_usize(32));
+                let value = rs1_value.overflowing_div(rs2_value);
+                update_register(machine, self.rd, value.sign_extend(R::from_usize(32)));
             }
             RtypeInstruction::REM => {
-                let value = if rs2_value == R::zero() {
-                    rs1_value
-                } else {
-                    let (value, overflow) = rs1_value.overflowing_rem_signed(rs2_value);
-                    if overflow {
-                        R::zero()
-                    } else {
-                        value
-                    }
-                };
+                let value = rs1_value.overflowing_rem_signed(rs2_value);
                 update_register(machine, self.rd, value);
             }
             RtypeInstruction::REMW => {
-                let rs1_value = rs1_value.sign_extend(32);
-                let rs2_value = rs2_value.sign_extend(32);
-                let value = if rs2_value == R::zero() {
-                    rs1_value
-                } else {
-                    let (value, overflow) = rs1_value.overflowing_rem_signed(rs2_value);
-                    if overflow {
-                        R::zero()
-                    } else {
-                        value
-                    }
-                };
-                update_register(machine, self.rd, value.sign_extend(32));
+                let rs1_value = rs1_value.sign_extend(R::from_usize(32));
+                let rs2_value = rs2_value.sign_extend(R::from_usize(32));
+                let value = rs1_value.overflowing_rem_signed(rs2_value);
+                update_register(machine, self.rd, value.sign_extend(R::from_usize(32)));
             }
             RtypeInstruction::REMU => {
-                let value = if rs2_value == R::zero() {
-                    rs1_value
-                } else {
-                    rs1_value.overflowing_rem(rs2_value).0
-                };
+                let value = rs1_value.overflowing_rem(rs2_value);
                 update_register(machine, self.rd, value);
             }
             RtypeInstruction::REMUW => {
-                let rs1_value = rs1_value.zero_extend(32);
-                let rs2_value = rs2_value.zero_extend(32);
-                let value = if rs2_value == R::zero() {
-                    rs1_value
-                } else {
-                    rs1_value.overflowing_rem(rs2_value).0
-                };
-                update_register(machine, self.rd, value.sign_extend(32));
+                let rs1_value = rs1_value.zero_extend(R::from_usize(32));
+                let rs2_value = rs2_value.zero_extend(R::from_usize(32));
+                let value = rs1_value.overflowing_rem(rs2_value);
+                update_register(machine, self.rd, value.sign_extend(R::from_usize(32)));
             }
         }
         Ok(None)
@@ -186,7 +108,7 @@ impl Instruction {
         machine: &mut Mac,
     ) -> Result<(), Error> {
         let next_pc = self.0.execute(machine)?;
-        let default_next_pc = machine.pc().overflowing_add(R::from_usize(4)).0;
+        let default_next_pc = machine.pc().overflowing_add(R::from_usize(4));
         machine.set_pc(next_pc.unwrap_or(default_next_pc));
         Ok(())
     }

--- a/src/instructions/register.rs
+++ b/src/instructions/register.rs
@@ -129,35 +129,19 @@ impl Register for u32 {
     }
 
     fn eq(self, other: u32) -> u32 {
-        if self == other {
-            Self::one()
-        } else {
-            Self::zero()
-        }
+        (self == other).into()
     }
 
     fn lt(self, other: u32) -> u32 {
-        if self < other {
-            Self::one()
-        } else {
-            Self::zero()
-        }
+        (self < other).into()
     }
 
     fn lt_s(self, other: u32) -> u32 {
-        if (self as i32) < (other as i32) {
-            Self::one()
-        } else {
-            Self::zero()
-        }
+        ((self as i32) < (other as i32)).into()
     }
 
     fn logical_not(self) -> u32 {
-        if self == Self::one() {
-            Self::zero()
-        } else {
-            Self::one()
-        }
+        (self != Self::one()).into()
     }
 
     fn cond(self, true_value: u32, false_value: u32) -> u32 {
@@ -364,35 +348,19 @@ impl Register for u64 {
     }
 
     fn eq(self, other: u64) -> u64 {
-        if self == other {
-            Self::one()
-        } else {
-            Self::zero()
-        }
+        (self == other).into()
     }
 
     fn lt(self, other: u64) -> u64 {
-        if self < other {
-            Self::one()
-        } else {
-            Self::zero()
-        }
+        (self < other).into()
     }
 
     fn lt_s(self, other: u64) -> u64 {
-        if (self as i64) < (other as i64) {
-            Self::one()
-        } else {
-            Self::zero()
-        }
+        ((self as i64) < (other as i64)).into()
     }
 
     fn logical_not(self) -> u64 {
-        if self == Self::one() {
-            Self::zero()
-        } else {
-            Self::one()
-        }
+        (self != Self::one()).into()
     }
 
     fn cond(self, true_value: u64, false_value: u64) -> u64 {

--- a/src/instructions/register.rs
+++ b/src/instructions/register.rs
@@ -94,6 +94,18 @@ pub trait Register:
     fn from_u32(v: u32) -> Self;
     fn from_u64(v: u64) -> Self;
     fn from_usize(v: usize) -> Self;
+
+    fn ne(self, rhs: Self) -> Self {
+        self.eq(rhs).logical_not()
+    }
+
+    fn greater_or_equal_than(self, other: Self) -> Self {
+        self.less_than(other).logical_not()
+    }
+
+    fn greater_or_equal_than_signed(self, other: Self) -> Self {
+        self.less_than_signed(other).logical_not()
+    }
 }
 
 impl Register for u32 {

--- a/src/instructions/register.rs
+++ b/src/instructions/register.rs
@@ -24,8 +24,8 @@ pub trait Register:
     // Conditional operations, if the condition evaluated here is true, R::one()
     // will be emitted, otherwise R::zero() will be emitted
     fn eq(self, other: Self) -> Self;
-    fn less_than(self, other: Self) -> Self;
-    fn less_than_signed(self, other: Self) -> Self;
+    fn lt(self, other: Self) -> Self;
+    fn lt_s(self, other: Self) -> Self;
     fn logical_not(self) -> Self;
 
     // self here should be the result of one of the conditional operations, if
@@ -99,12 +99,12 @@ pub trait Register:
         self.eq(rhs).logical_not()
     }
 
-    fn greater_or_equal_than(self, other: Self) -> Self {
-        self.less_than(other).logical_not()
+    fn ge(self, other: Self) -> Self {
+        self.lt(other).logical_not()
     }
 
-    fn greater_or_equal_than_signed(self, other: Self) -> Self {
-        self.less_than_signed(other).logical_not()
+    fn ge_s(self, other: Self) -> Self {
+        self.lt_s(other).logical_not()
     }
 }
 
@@ -136,7 +136,7 @@ impl Register for u32 {
         }
     }
 
-    fn less_than(self, other: u32) -> u32 {
+    fn lt(self, other: u32) -> u32 {
         if self < other {
             Self::one()
         } else {
@@ -144,7 +144,7 @@ impl Register for u32 {
         }
     }
 
-    fn less_than_signed(self, other: u32) -> u32 {
+    fn lt_s(self, other: u32) -> u32 {
         if (self as i32) < (other as i32) {
             Self::one()
         } else {
@@ -371,7 +371,7 @@ impl Register for u64 {
         }
     }
 
-    fn less_than(self, other: u64) -> u64 {
+    fn lt(self, other: u64) -> u64 {
         if self < other {
             Self::one()
         } else {
@@ -379,7 +379,7 @@ impl Register for u64 {
         }
     }
 
-    fn less_than_signed(self, other: u64) -> u64 {
+    fn lt_s(self, other: u64) -> u64 {
         if (self as i64) < (other as i64) {
             Self::one()
         } else {

--- a/src/instructions/utils.rs
+++ b/src/instructions/utils.rs
@@ -89,6 +89,6 @@ pub fn update_register<Mac: Machine<R, M>, R: Register, M: Memory>(
     // The goal here is to maintain a place where we can read zeros to allow for
     // compact encoding. Hence we are ignoring all writes to x0 register here.
     if register_index > 0 {
-        machine.registers_mut()[register_index] = value;
+        machine.set_register(register_index, value);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,12 +3,14 @@ pub mod decoder;
 pub mod instructions;
 pub mod machine;
 pub mod memory;
+pub mod runners;
 pub mod syscalls;
 
 pub use crate::{
     instructions::{Instruction, Register},
-    machine::{CoreMachine, DefaultMachine, Machine},
+    machine::{CoreMachine, DefaultMachine, Machine, SupportMachine},
     memory::{flat::FlatMemory, mmu::Mmu, sparse::SparseMemory, Memory},
+    runners::interpreter::run as interpreter_run,
     syscalls::Syscalls,
 };
 use std::io::{Error as IOError, ErrorKind};
@@ -91,5 +93,6 @@ pub fn run<R: Register, M: Memory + Default>(
     program: &[u8],
     args: &[Vec<u8>],
 ) -> Result<u8, Error> {
-    DefaultMachine::<R, M>::default().run(program, args)
+    let mut machine = DefaultMachine::<R, M>::default().load_program(program, args)?;
+    interpreter_run(&mut machine)
 }

--- a/src/runners/interpreter.rs
+++ b/src/runners/interpreter.rs
@@ -1,0 +1,26 @@
+use crate::{
+    decoder::build_imac_decoder, CoreMachine, DefaultMachine, Error, Memory, Register,
+    SupportMachine,
+};
+
+pub fn run<'a, R: Register, M: Memory>(
+    machine: &mut DefaultMachine<'a, R, M>,
+) -> Result<u8, Error> {
+    let decoder = build_imac_decoder::<R>();
+    machine.set_running(true);
+    while machine.running() {
+        let instruction = {
+            let pc = machine.pc().to_usize();
+            let memory = machine.memory_mut();
+            decoder.decode(memory, pc)?
+        };
+        instruction.execute(machine)?;
+        let cycles = machine
+            .instruction_cycle_func()
+            .as_ref()
+            .map(|f| f(&instruction))
+            .unwrap_or(0);
+        machine.add_cycles(cycles)?;
+    }
+    Ok(machine.exit_code())
+}

--- a/src/runners/mod.rs
+++ b/src/runners/mod.rs
@@ -1,0 +1,1 @@
+pub mod interpreter;

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -1,11 +1,11 @@
 use super::instructions::Register;
-use super::machine::CoreMachine;
+use super::machine::SupportMachine;
 use super::memory::Memory;
 use super::Error;
 pub trait Syscalls<R: Register, M: Memory> {
-    fn initialize(&mut self, machine: &mut CoreMachine<R, M>) -> Result<(), Error>;
+    fn initialize(&mut self, machine: &mut SupportMachine<R, M>) -> Result<(), Error>;
     // Returned bool means if the syscall has been processed, if
     // a module returns false, Machine would continue to leverage
     // the next syscall module to process.
-    fn ecall(&mut self, machine: &mut CoreMachine<R, M>) -> Result<bool, Error>;
+    fn ecall(&mut self, machine: &mut SupportMachine<R, M>) -> Result<bool, Error>;
 }


### PR DESCRIPTION
The code here currently has some obstacles that do not favor a JIT implementation:

* Overflow information is exposed outside of register value: https://github.com/nervosnetwork/ckb-vm/blob/ac2b5cf858e30a4080beffa067a8fb9e8085d097/src/instructions/register.rs#L33
* [Certain](https://github.com/nervosnetwork/ckb-vm/blob/master/src/instructions/i.rs#L227) [instruction](https://github.com/nervosnetwork/ckb-vm/blob/master/src/instructions/i.rs#L317) [logic](https://github.com/nervosnetwork/ckb-vm/blob/master/src/instructions/m.rs#L69) is implemented in Rust outside of register types, which makes it hard to JIT
* Basic CoreMachine [contains](https://github.com/nervosnetwork/ckb-vm/blob/ac2b5cf858e30a4080beffa067a8fb9e8085d097/src/machine.rs#L55-L63) too many features that are only needed in actual syscall implementation, but not in instruction implementation
* Current [registers_mut](https://github.com/nervosnetwork/ckb-vm/blob/ac2b5cf858e30a4080beffa067a8fb9e8085d097/src/machine.rs#L53) doesn't allow us to detect when a register is assigned a new value, which is needed in a JIT implementation.

This PR sorts everything out, so we can have a clean JIT structure in future PRs.