### PR TITLE
refactor: Change Register type to only implement Clone, not Copy

### DIFF
--- a/src/instructions/common.rs
+++ b/src/instructions/common.rs
@@ -15,9 +15,9 @@ pub fn add<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     rs2: RegisterIndex,
 ) {
-    let rs1_value = machine.registers()[rs1];
-    let rs2_value = machine.registers()[rs2];
-    let value = rs1_value.overflowing_add(rs2_value);
+    let rs1_value = &machine.registers()[rs1];
+    let rs2_value = &machine.registers()[rs2];
+    let value = rs1_value.overflowing_add(&rs2_value);
     update_register(machine, rd, value);
 }
 
@@ -27,10 +27,10 @@ pub fn addw<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     rs2: RegisterIndex,
 ) {
-    let rs1_value = machine.registers()[rs1];
-    let rs2_value = machine.registers()[rs2];
-    let value = rs1_value.overflowing_add(rs2_value);
-    update_register(machine, rd, value.sign_extend(R::from_usize(32)));
+    let rs1_value = &machine.registers()[rs1];
+    let rs2_value = &machine.registers()[rs2];
+    let value = rs1_value.overflowing_add(&rs2_value);
+    update_register(machine, rd, value.sign_extend(&R::from_usize(32)));
 }
 
 pub fn sub<Mac: Machine<R, M>, R: Register, M: Memory>(
@@ -39,9 +39,9 @@ pub fn sub<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     rs2: RegisterIndex,
 ) {
-    let rs1_value = machine.registers()[rs1];
-    let rs2_value = machine.registers()[rs2];
-    let value = rs1_value.overflowing_sub(rs2_value);
+    let rs1_value = &machine.registers()[rs1];
+    let rs2_value = &machine.registers()[rs2];
+    let value = rs1_value.overflowing_sub(&rs2_value);
     update_register(machine, rd, value);
 }
 
@@ -51,10 +51,10 @@ pub fn subw<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     rs2: RegisterIndex,
 ) {
-    let rs1_value = machine.registers()[rs1];
-    let rs2_value = machine.registers()[rs2];
-    let value = rs1_value.overflowing_sub(rs2_value);
-    update_register(machine, rd, value.sign_extend(R::from_usize(32)));
+    let rs1_value = &machine.registers()[rs1];
+    let rs2_value = &machine.registers()[rs2];
+    let value = rs1_value.overflowing_sub(&rs2_value);
+    update_register(machine, rd, value.sign_extend(&R::from_usize(32)));
 }
 
 pub fn addi<Mac: Machine<R, M>, R: Register, M: Memory>(
@@ -63,7 +63,7 @@ pub fn addi<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     imm: Immediate,
 ) {
-    let value = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
+    let value = machine.registers()[rs1].overflowing_add(&R::from_i32(imm));
     update_register(machine, rd, value);
 }
 
@@ -73,8 +73,8 @@ pub fn addiw<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     imm: Immediate,
 ) {
-    let value = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
-    update_register(machine, rd, value.sign_extend(R::from_usize(32)));
+    let value = machine.registers()[rs1].overflowing_add(&R::from_i32(imm));
+    update_register(machine, rd, value.sign_extend(&R::from_usize(32)));
 }
 
 // =======================
@@ -86,7 +86,7 @@ pub fn lb<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(&R::from_i32(imm));
     let value = machine.memory_mut().load8(address.to_usize())?;
     // sign-extened
     update_register(machine, rd, R::from_i8(value as i8));
@@ -99,7 +99,7 @@ pub fn lh<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(&R::from_i32(imm));
     let value = machine.memory_mut().load16(address.to_usize())?;
     // sign-extened
     update_register(machine, rd, R::from_i16(value as i16));
@@ -112,7 +112,7 @@ pub fn lw<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(&R::from_i32(imm));
     let value = machine.memory_mut().load32(address.to_usize())?;
     update_register(machine, rd, R::from_i32(value as i32));
     Ok(())
@@ -124,7 +124,7 @@ pub fn ld<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(&R::from_i32(imm));
     let value = machine.memory_mut().load64(address.to_usize())?;
     update_register(machine, rd, R::from_i64(value as i64));
     Ok(())
@@ -136,7 +136,7 @@ pub fn lbu<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(&R::from_i32(imm));
     let value = machine.memory_mut().load8(address.to_usize())?;
     update_register(machine, rd, R::from_u8(value));
     Ok(())
@@ -148,7 +148,7 @@ pub fn lhu<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(&R::from_i32(imm));
     let value = machine.memory_mut().load16(address.to_usize())?;
     update_register(machine, rd, R::from_u16(value));
     Ok(())
@@ -160,7 +160,7 @@ pub fn lwu<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(&R::from_i32(imm));
     let value = machine.memory_mut().load32(address.to_usize())?;
     update_register(machine, rd, R::from_u32(value));
     Ok(())
@@ -175,7 +175,7 @@ pub fn sb<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs2: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(&R::from_i32(imm));
     let value = machine.registers()[rs2].to_u8();
     machine.memory_mut().store8(address.to_usize(), value)?;
     Ok(())
@@ -187,7 +187,7 @@ pub fn sh<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs2: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(&R::from_i32(imm));
     let value = machine.registers()[rs2].to_u16();
     machine.memory_mut().store16(address.to_usize(), value)?;
     Ok(())
@@ -199,7 +199,7 @@ pub fn sw<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs2: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(&R::from_i32(imm));
     let value = machine.registers()[rs2].to_u32();
     machine.memory_mut().store32(address.to_usize(), value)?;
     Ok(())
@@ -211,7 +211,7 @@ pub fn sd<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs2: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(&R::from_i32(imm));
     let value = machine.registers()[rs2].to_u64();
     machine.memory_mut().store64(address.to_usize(), value)?;
     Ok(())
@@ -226,8 +226,8 @@ pub fn and<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     rs2: RegisterIndex,
 ) {
-    let rs1_value = machine.registers()[rs1];
-    let rs2_value = machine.registers()[rs2];
+    let rs1_value = machine.registers()[rs1].clone();
+    let rs2_value = machine.registers()[rs2].clone();
     let value = rs1_value & rs2_value;
     update_register(machine, rd, value);
 }
@@ -238,8 +238,8 @@ pub fn xor<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     rs2: RegisterIndex,
 ) {
-    let rs1_value = machine.registers()[rs1];
-    let rs2_value = machine.registers()[rs2];
+    let rs1_value = machine.registers()[rs1].clone();
+    let rs2_value = machine.registers()[rs2].clone();
     let value = rs1_value ^ rs2_value;
     update_register(machine, rd, value);
 }
@@ -250,8 +250,8 @@ pub fn or<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     rs2: RegisterIndex,
 ) {
-    let rs1_value = machine.registers()[rs1];
-    let rs2_value = machine.registers()[rs2];
+    let rs1_value = machine.registers()[rs1].clone();
+    let rs2_value = machine.registers()[rs2].clone();
     let value = rs1_value | rs2_value;
     update_register(machine, rd, value);
 }
@@ -262,7 +262,7 @@ pub fn andi<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     imm: Immediate,
 ) {
-    let value = machine.registers()[rs1] & R::from_i32(imm);
+    let value = machine.registers()[rs1].clone() & R::from_i32(imm);
     update_register(machine, rd, value);
 }
 
@@ -272,7 +272,7 @@ pub fn xori<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     imm: Immediate,
 ) {
-    let value = machine.registers()[rs1] ^ R::from_i32(imm);
+    let value = machine.registers()[rs1].clone() ^ R::from_i32(imm);
     update_register(machine, rd, value);
 }
 
@@ -282,7 +282,7 @@ pub fn ori<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     imm: Immediate,
 ) {
-    let value = machine.registers()[rs1] | R::from_i32(imm);
+    let value = machine.registers()[rs1].clone() | R::from_i32(imm);
     update_register(machine, rd, value);
 }
 
@@ -292,7 +292,7 @@ pub fn slli<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     shamt: UImmediate,
 ) {
-    let value = machine.registers()[rs1] << R::from_u32(shamt);
+    let value = machine.registers()[rs1].clone() << R::from_u32(shamt);
     update_register(machine, rd, value);
 }
 
@@ -302,7 +302,7 @@ pub fn srli<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     shamt: UImmediate,
 ) {
-    let value = machine.registers()[rs1] >> R::from_u32(shamt);
+    let value = machine.registers()[rs1].clone() >> R::from_u32(shamt);
     update_register(machine, rd, value);
 }
 
@@ -312,7 +312,7 @@ pub fn srai<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     shamt: UImmediate,
 ) {
-    let value = machine.registers()[rs1].signed_shr(R::from_u32(shamt));
+    let value = machine.registers()[rs1].signed_shr(&R::from_u32(shamt));
     update_register(machine, rd, value);
 }
 
@@ -322,8 +322,8 @@ pub fn slliw<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     shamt: UImmediate,
 ) {
-    let value = machine.registers()[rs1] << R::from_u32(shamt);
-    update_register(machine, rd, value.sign_extend(R::from_usize(32)));
+    let value = machine.registers()[rs1].clone() << R::from_u32(shamt);
+    update_register(machine, rd, value.sign_extend(&R::from_usize(32)));
 }
 
 pub fn srliw<Mac: Machine<R, M>, R: Register, M: Memory>(
@@ -332,8 +332,8 @@ pub fn srliw<Mac: Machine<R, M>, R: Register, M: Memory>(
     rs1: RegisterIndex,
     shamt: UImmediate,
 ) {
-    let value = machine.registers()[rs1].zero_extend(R::from_usize(32)) >> R::from_u32(shamt);
-    update_register(machine, rd, value.sign_extend(R::from_usize(32)));
+    let value = machine.registers()[rs1].zero_extend(&R::from_usize(32)) >> R::from_u32(shamt);
+    update_register(machine, rd, value.sign_extend(&R::from_usize(32)));
 }
 
 pub fn sraiw<Mac: Machine<R, M>, R: Register, M: Memory>(
@@ -343,9 +343,9 @@ pub fn sraiw<Mac: Machine<R, M>, R: Register, M: Memory>(
     shamt: UImmediate,
 ) {
     let value = machine.registers()[rs1]
-        .sign_extend(R::from_usize(32))
-        .signed_shr(R::from_u32(shamt));
-    update_register(machine, rd, value.sign_extend(R::from_usize(32)));
+        .sign_extend(&R::from_usize(32))
+        .signed_shr(&R::from_u32(shamt));
+    update_register(machine, rd, value.sign_extend(&R::from_usize(32)));
 }
 
 // =======================
@@ -357,7 +357,7 @@ pub fn jal<Mac: Machine<R, M>, R: Register, M: Memory>(
     imm: Immediate,
     xbytes: usize,
 ) -> Option<R> {
-    let link = machine.pc().overflowing_add(R::from_usize(xbytes));
+    let link = machine.pc().overflowing_add(&R::from_usize(xbytes));
     update_register(machine, rd, link);
-    Some(machine.pc().overflowing_add(R::from_i32(imm)))
+    Some(machine.pc().overflowing_add(&R::from_i32(imm)))
 }

--- a/src/instructions/i.rs
+++ b/src/instructions/i.rs
@@ -151,48 +151,51 @@ impl Execute for Rtype {
             RtypeInstruction::OR => common::or(machine, self.rd, self.rs1, self.rs2),
             RtypeInstruction::AND => common::and(machine, self.rd, self.rs1, self.rs2),
             RtypeInstruction::SLL => {
-                let shift_value = machine.registers()[self.rs2] & R::from_usize(R::SHIFT_MASK);
-                let value = machine.registers()[self.rs1] << shift_value;
+                let shift_value =
+                    machine.registers()[self.rs2].clone() & R::from_usize(R::SHIFT_MASK);
+                let value = machine.registers()[self.rs1].clone() << shift_value;
                 update_register(machine, self.rd, value);
             }
             RtypeInstruction::SLLW => {
-                let shift_value = machine.registers()[self.rs2] & R::from_usize(0x1F);
-                let value = machine.registers()[self.rs1] << shift_value;
-                update_register(machine, self.rd, value.sign_extend(R::from_usize(32)));
+                let shift_value = machine.registers()[self.rs2].clone() & R::from_usize(0x1F);
+                let value = machine.registers()[self.rs1].clone() << shift_value;
+                update_register(machine, self.rd, value.sign_extend(&R::from_usize(32)));
             }
             RtypeInstruction::SRL => {
-                let shift_value = machine.registers()[self.rs2] & R::from_usize(R::SHIFT_MASK);
-                let value = machine.registers()[self.rs1] >> shift_value;
+                let shift_value =
+                    machine.registers()[self.rs2].clone() & R::from_usize(R::SHIFT_MASK);
+                let value = machine.registers()[self.rs1].clone() >> shift_value;
                 update_register(machine, self.rd, value);
             }
             RtypeInstruction::SRLW => {
-                let shift_value = machine.registers()[self.rs2] & R::from_usize(0x1F);
+                let shift_value = machine.registers()[self.rs2].clone() & R::from_usize(0x1F);
                 let value =
-                    machine.registers()[self.rs1].zero_extend(R::from_usize(32)) >> shift_value;
-                update_register(machine, self.rd, value.sign_extend(R::from_usize(32)));
+                    machine.registers()[self.rs1].zero_extend(&R::from_usize(32)) >> shift_value;
+                update_register(machine, self.rd, value.sign_extend(&R::from_usize(32)));
             }
             RtypeInstruction::SRA => {
-                let shift_value = machine.registers()[self.rs2] & R::from_usize(R::SHIFT_MASK);
-                let value = machine.registers()[self.rs1].signed_shr(shift_value);
+                let shift_value =
+                    machine.registers()[self.rs2].clone() & R::from_usize(R::SHIFT_MASK);
+                let value = machine.registers()[self.rs1].signed_shr(&shift_value);
                 update_register(machine, self.rd, value);
             }
             RtypeInstruction::SRAW => {
-                let shift_value = machine.registers()[self.rs2] & R::from_usize(0x1F);
+                let shift_value = machine.registers()[self.rs2].clone() & R::from_usize(0x1F);
                 let value = machine.registers()[self.rs1]
-                    .sign_extend(R::from_usize(32))
-                    .signed_shr(shift_value);
-                update_register(machine, self.rd, value.sign_extend(R::from_usize(32)));
+                    .sign_extend(&R::from_usize(32))
+                    .signed_shr(&shift_value);
+                update_register(machine, self.rd, value.sign_extend(&R::from_usize(32)));
             }
             RtypeInstruction::SLT => {
-                let rs1_value = machine.registers()[self.rs1];
-                let rs2_value = machine.registers()[self.rs2];
-                let value = rs1_value.lt_s(rs2_value);
+                let rs1_value = &machine.registers()[self.rs1];
+                let rs2_value = &machine.registers()[self.rs2];
+                let value = rs1_value.lt_s(&rs2_value);
                 update_register(machine, self.rd, value);
             }
             RtypeInstruction::SLTU => {
-                let rs1_value = machine.registers()[self.rs1];
-                let rs2_value = machine.registers()[self.rs2];
-                let value = rs1_value.lt(rs2_value);
+                let rs1_value = &machine.registers()[self.rs1];
+                let rs2_value = &machine.registers()[self.rs2];
+                let value = rs1_value.lt(&rs2_value);
                 update_register(machine, self.rd, value);
             }
         }
@@ -219,21 +222,21 @@ impl Execute for Itype {
             ItypeInstruction::ORI => common::ori(machine, self.rd, self.rs1, self.imm),
             ItypeInstruction::ANDI => common::andi(machine, self.rd, self.rs1, self.imm),
             ItypeInstruction::SLTI => {
-                let rs1_value = machine.registers()[self.rs1];
+                let rs1_value = &machine.registers()[self.rs1];
                 let imm_value = R::from_i32(self.imm);
-                let value = rs1_value.lt_s(imm_value);
+                let value = rs1_value.lt_s(&imm_value);
                 update_register(machine, self.rd, value);
             }
             ItypeInstruction::SLTIU => {
-                let rs1_value = machine.registers()[self.rs1];
+                let rs1_value = &machine.registers()[self.rs1];
                 let imm_value = R::from_i32(self.imm);
-                let value = rs1_value.lt(imm_value);
+                let value = rs1_value.lt(&imm_value);
                 update_register(machine, self.rd, value);
             }
             ItypeInstruction::JALR => {
-                let link = machine.pc().overflowing_add(R::from_usize(4));
+                let link = machine.pc().overflowing_add(&R::from_usize(4));
                 let mut next_pc =
-                    machine.registers()[self.rs1].overflowing_add(R::from_i32(self.imm));
+                    machine.registers()[self.rs1].overflowing_add(&R::from_i32(self.imm));
                 next_pc = next_pc & (!R::one());
                 update_register(machine, self.rd, link);
                 return Ok(Some(next_pc));
@@ -292,18 +295,18 @@ impl Execute for Btype {
         &self,
         machine: &mut Mac,
     ) -> Result<Option<R>, Error> {
-        let rs1_value = machine.registers()[self.rs1];
-        let rs2_value = machine.registers()[self.rs2];
+        let rs1_value = &machine.registers()[self.rs1];
+        let rs2_value = &machine.registers()[self.rs2];
         let condition = match &self.inst {
-            BtypeInstruction::BEQ => rs1_value.eq(rs2_value),
-            BtypeInstruction::BNE => rs1_value.ne(rs2_value),
-            BtypeInstruction::BLT => rs1_value.lt_s(rs2_value),
-            BtypeInstruction::BGE => rs1_value.ge_s(rs2_value),
-            BtypeInstruction::BLTU => rs1_value.lt(rs2_value),
-            BtypeInstruction::BGEU => rs1_value.ge(rs2_value),
+            BtypeInstruction::BEQ => rs1_value.eq(&rs2_value),
+            BtypeInstruction::BNE => rs1_value.ne(&rs2_value),
+            BtypeInstruction::BLT => rs1_value.lt_s(&rs2_value),
+            BtypeInstruction::BGE => rs1_value.ge_s(&rs2_value),
+            BtypeInstruction::BLTU => rs1_value.lt(&rs2_value),
+            BtypeInstruction::BGEU => rs1_value.ge(&rs2_value),
         };
-        let next_pc_offset = condition.cond(R::from_i32(self.imm), R::from_usize(4));
-        Ok(Some(machine.pc().overflowing_add(next_pc_offset)))
+        let next_pc_offset = condition.cond(&R::from_i32(self.imm), &R::from_usize(4));
+        Ok(Some(machine.pc().overflowing_add(&next_pc_offset)))
     }
 }
 
@@ -317,7 +320,7 @@ impl Execute for Utype {
                 update_register(machine, self.rd, R::from_i32(self.imm));
             }
             UtypeInstruction::AUIPC => {
-                let value = machine.pc().overflowing_add(R::from_i32(self.imm));
+                let value = machine.pc().overflowing_add(&R::from_i32(self.imm));
                 update_register(machine, self.rd, value);
             }
         }
@@ -420,7 +423,7 @@ impl Instruction {
             Instruction::JAL { imm, rd } => common::jal(machine, *rd, *imm, 4),
             Instruction::FENCEI => unimplemented!(),
         };
-        let default_next_pc = machine.pc().overflowing_add(R::from_usize(4));
+        let default_next_pc = machine.pc().overflowing_add(&R::from_usize(4));
         machine.set_pc(next_pc.unwrap_or(default_next_pc));
         Ok(())
     }

--- a/src/instructions/m.rs
+++ b/src/instructions/m.rs
@@ -32,70 +32,70 @@ impl Execute for Rtype {
         &self,
         machine: &mut Mac,
     ) -> Result<Option<R>, Error> {
-        let rs1_value = machine.registers()[self.rs1];
-        let rs2_value = machine.registers()[self.rs2];
+        let rs1_value = &machine.registers()[self.rs1];
+        let rs2_value = &machine.registers()[self.rs2];
         match &self.inst {
             RtypeInstruction::MUL => {
-                let value = rs1_value.overflowing_mul(rs2_value);
+                let value = rs1_value.overflowing_mul(&rs2_value);
                 update_register(machine, self.rd, value);
             }
             RtypeInstruction::MULW => {
                 let value = rs1_value
-                    .zero_extend(R::from_usize(32))
-                    .overflowing_mul(rs2_value.zero_extend(R::from_usize(32)));
-                update_register(machine, self.rd, value.sign_extend(R::from_usize(32)));
+                    .zero_extend(&R::from_usize(32))
+                    .overflowing_mul(&rs2_value.zero_extend(&R::from_usize(32)));
+                update_register(machine, self.rd, value.sign_extend(&R::from_usize(32)));
             }
             RtypeInstruction::MULH => {
-                let value = rs1_value.overflowing_mul_high_signed(rs2_value);
+                let value = rs1_value.overflowing_mul_high_signed(&rs2_value);
                 update_register(machine, self.rd, value);
             }
             RtypeInstruction::MULHSU => {
-                let value = rs1_value.overflowing_mul_high_signed_unsigned(rs2_value);
+                let value = rs1_value.overflowing_mul_high_signed_unsigned(&rs2_value);
                 update_register(machine, self.rd, value);
             }
             RtypeInstruction::MULHU => {
-                let value = rs1_value.overflowing_mul_high_unsigned(rs2_value);
+                let value = rs1_value.overflowing_mul_high_unsigned(&rs2_value);
                 update_register(machine, self.rd, value);
             }
             RtypeInstruction::DIV => {
-                let value = rs1_value.overflowing_div_signed(rs2_value);
+                let value = rs1_value.overflowing_div_signed(&rs2_value);
                 update_register(machine, self.rd, value);
             }
             RtypeInstruction::DIVW => {
-                let rs1_value = rs1_value.sign_extend(R::from_usize(32));
-                let rs2_value = rs2_value.sign_extend(R::from_usize(32));
-                let value = rs1_value.overflowing_div_signed(rs2_value);
-                update_register(machine, self.rd, value.sign_extend(R::from_usize(32)));
+                let rs1_value = rs1_value.sign_extend(&R::from_usize(32));
+                let rs2_value = rs2_value.sign_extend(&R::from_usize(32));
+                let value = rs1_value.overflowing_div_signed(&rs2_value);
+                update_register(machine, self.rd, value.sign_extend(&R::from_usize(32)));
             }
             RtypeInstruction::DIVU => {
-                let value = rs1_value.overflowing_div(rs2_value);
+                let value = rs1_value.overflowing_div(&rs2_value);
                 update_register(machine, self.rd, value);
             }
             RtypeInstruction::DIVUW => {
-                let rs1_value = rs1_value.zero_extend(R::from_usize(32));
-                let rs2_value = rs2_value.zero_extend(R::from_usize(32));
-                let value = rs1_value.overflowing_div(rs2_value);
-                update_register(machine, self.rd, value.sign_extend(R::from_usize(32)));
+                let rs1_value = rs1_value.zero_extend(&R::from_usize(32));
+                let rs2_value = rs2_value.zero_extend(&R::from_usize(32));
+                let value = rs1_value.overflowing_div(&rs2_value);
+                update_register(machine, self.rd, value.sign_extend(&R::from_usize(32)));
             }
             RtypeInstruction::REM => {
-                let value = rs1_value.overflowing_rem_signed(rs2_value);
+                let value = rs1_value.overflowing_rem_signed(&rs2_value);
                 update_register(machine, self.rd, value);
             }
             RtypeInstruction::REMW => {
-                let rs1_value = rs1_value.sign_extend(R::from_usize(32));
-                let rs2_value = rs2_value.sign_extend(R::from_usize(32));
-                let value = rs1_value.overflowing_rem_signed(rs2_value);
-                update_register(machine, self.rd, value.sign_extend(R::from_usize(32)));
+                let rs1_value = rs1_value.sign_extend(&R::from_usize(32));
+                let rs2_value = rs2_value.sign_extend(&R::from_usize(32));
+                let value = rs1_value.overflowing_rem_signed(&rs2_value);
+                update_register(machine, self.rd, value.sign_extend(&R::from_usize(32)));
             }
             RtypeInstruction::REMU => {
-                let value = rs1_value.overflowing_rem(rs2_value);
+                let value = rs1_value.overflowing_rem(&rs2_value);
                 update_register(machine, self.rd, value);
             }
             RtypeInstruction::REMUW => {
-                let rs1_value = rs1_value.zero_extend(R::from_usize(32));
-                let rs2_value = rs2_value.zero_extend(R::from_usize(32));
-                let value = rs1_value.overflowing_rem(rs2_value);
-                update_register(machine, self.rd, value.sign_extend(R::from_usize(32)));
+                let rs1_value = rs1_value.zero_extend(&R::from_usize(32));
+                let rs2_value = rs2_value.zero_extend(&R::from_usize(32));
+                let value = rs1_value.overflowing_rem(&rs2_value);
+                update_register(machine, self.rd, value.sign_extend(&R::from_usize(32)));
             }
         }
         Ok(None)
@@ -108,7 +108,7 @@ impl Instruction {
         machine: &mut Mac,
     ) -> Result<(), Error> {
         let next_pc = self.0.execute(machine)?;
-        let default_next_pc = machine.pc().overflowing_add(R::from_usize(4));
+        let default_next_pc = machine.pc().overflowing_add(&R::from_usize(4));
         machine.set_pc(next_pc.unwrap_or(default_next_pc));
         Ok(())
     }

--- a/src/instructions/rvc.rs
+++ b/src/instructions/rvc.rs
@@ -302,7 +302,7 @@ impl Execute for UtypeU {
     ) -> Result<Option<R>, Error> {
         match &self.inst {
             UtypeUInstruction::ADDI4SPN => {
-                let value = machine.registers()[SP].overflowing_add(R::from_u32(self.imm));
+                let value = machine.registers()[SP].overflowing_add(&R::from_u32(self.imm));
                 update_register(machine, self.rd, value);
             }
             UtypeUInstruction::LWSP => common::lw(machine, self.rd, SP, self.imm as i32)?,
@@ -504,30 +504,30 @@ impl Instruction {
             Instruction::R(inst) => inst.execute(machine)?,
             Instruction::CSS(inst) => inst.execute(machine)?,
             Instruction::BEQZ { rs1, imm } => {
-                let condition = machine.registers()[*rs1].eq(R::zero());
-                let next_pc_offset = condition.cond(R::from_i32(*imm), R::from_usize(2));
-                Some(machine.pc().overflowing_add(next_pc_offset))
+                let condition = machine.registers()[*rs1].eq(&R::zero());
+                let next_pc_offset = condition.cond(&R::from_i32(*imm), &R::from_usize(2));
+                Some(machine.pc().overflowing_add(&next_pc_offset))
             }
             Instruction::BNEZ { rs1, imm } => {
-                let condition = machine.registers()[*rs1].eq(R::zero()).logical_not();
-                let next_pc_offset = condition.cond(R::from_i32(*imm), R::from_usize(2));
-                Some(machine.pc().overflowing_add(next_pc_offset))
+                let condition = machine.registers()[*rs1].eq(&R::zero()).logical_not();
+                let next_pc_offset = condition.cond(&R::from_i32(*imm), &R::from_usize(2));
+                Some(machine.pc().overflowing_add(&next_pc_offset))
             }
             Instruction::MV { rs2, rd } => {
-                let value = machine.registers()[*rs2];
-                update_register(machine, *rd, value);
+                let value = &machine.registers()[*rs2];
+                update_register(machine, *rd, value.clone());
                 None
             }
             Instruction::JAL { imm } => common::jal(machine, 1, *imm, 2),
-            Instruction::J { imm } => Some(machine.pc().overflowing_add(R::from_i32(*imm))),
-            Instruction::JR { rs1 } => Some(machine.registers()[*rs1]),
+            Instruction::J { imm } => Some(machine.pc().overflowing_add(&R::from_i32(*imm))),
+            Instruction::JR { rs1 } => Some(machine.registers()[*rs1].clone()),
             Instruction::JALR { rs1 } => {
-                let link = machine.pc().overflowing_add(R::from_usize(2));
+                let link = machine.pc().overflowing_add(&R::from_usize(2));
                 update_register(machine, 1, link);
-                Some(machine.registers()[*rs1])
+                Some(machine.registers()[*rs1].clone())
             }
             Instruction::ADDI16SP { imm } => {
-                let value = machine.registers()[SP].overflowing_add(R::from_i32(*imm));
+                let value = machine.registers()[SP].overflowing_add(&R::from_i32(*imm));
                 update_register(machine, SP, value);
                 None
             }
@@ -543,7 +543,7 @@ impl Instruction {
                 None
             }
         };
-        let default_next_pc = machine.pc().overflowing_add(R::from_usize(2));
+        let default_next_pc = machine.pc().overflowing_add(&R::from_usize(2));
         machine.set_pc(next_pc.unwrap_or(default_next_pc));
         Ok(())
     }


### PR DESCRIPTION
This is actually one tech debt paid due to my inexperience with Rust :(

Previously, `Register` type implements Copy trait, which means we are really copying the register values everywhere. This is not a problem when we are dealing with primitive types such as `u64` or `u32`, but when we are working on a JIT, the register values are actually AST nodes that look like the following:

```rust
#[derive(Debug, Clone)]
pub enum Value {
    Imm(u64),
    Register(usize),
    PcRegister,
    Add(Rc<Value>, Rc<Value>),
    Sub(Rc<Value>, Rc<Value>),
}
```

Since `Rc` is used here to build recursive enum type, we cannot use copy semantics and have to revert back to move semantics, this PR deals with this change.