### PR TITLE
refactor: change `Machine` generic type to associated type

### DIFF
--- a/src/instructions/common.rs
+++ b/src/instructions/common.rs
@@ -9,7 +9,7 @@ use super::{Error, Immediate, RegisterIndex, UImmediate};
 // ======================
 // #  ALU instructions  #
 // ======================
-pub fn add<Mac: Machine<R, M>, R: Register, M: Memory>(
+pub fn add<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
@@ -21,7 +21,7 @@ pub fn add<Mac: Machine<R, M>, R: Register, M: Memory>(
     update_register(machine, rd, value);
 }
 
-pub fn addw<Mac: Machine<R, M>, R: Register, M: Memory>(
+pub fn addw<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
@@ -30,10 +30,10 @@ pub fn addw<Mac: Machine<R, M>, R: Register, M: Memory>(
     let rs1_value = &machine.registers()[rs1];
     let rs2_value = &machine.registers()[rs2];
     let value = rs1_value.overflowing_add(&rs2_value);
-    update_register(machine, rd, value.sign_extend(&R::from_usize(32)));
+    update_register(machine, rd, value.sign_extend(&Mac::REG::from_usize(32)));
 }
 
-pub fn sub<Mac: Machine<R, M>, R: Register, M: Memory>(
+pub fn sub<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
@@ -45,7 +45,7 @@ pub fn sub<Mac: Machine<R, M>, R: Register, M: Memory>(
     update_register(machine, rd, value);
 }
 
-pub fn subw<Mac: Machine<R, M>, R: Register, M: Memory>(
+pub fn subw<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
@@ -54,164 +54,164 @@ pub fn subw<Mac: Machine<R, M>, R: Register, M: Memory>(
     let rs1_value = &machine.registers()[rs1];
     let rs2_value = &machine.registers()[rs2];
     let value = rs1_value.overflowing_sub(&rs2_value);
-    update_register(machine, rd, value.sign_extend(&R::from_usize(32)));
+    update_register(machine, rd, value.sign_extend(&Mac::REG::from_usize(32)));
 }
 
-pub fn addi<Mac: Machine<R, M>, R: Register, M: Memory>(
+pub fn addi<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
     imm: Immediate,
 ) {
-    let value = machine.registers()[rs1].overflowing_add(&R::from_i32(imm));
+    let value = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
     update_register(machine, rd, value);
 }
 
-pub fn addiw<Mac: Machine<R, M>, R: Register, M: Memory>(
+pub fn addiw<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
     imm: Immediate,
 ) {
-    let value = machine.registers()[rs1].overflowing_add(&R::from_i32(imm));
-    update_register(machine, rd, value.sign_extend(&R::from_usize(32)));
+    let value = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
+    update_register(machine, rd, value.sign_extend(&Mac::REG::from_usize(32)));
 }
 
 // =======================
 // #  LOAD instructions  #
 // =======================
-pub fn lb<Mac: Machine<R, M>, R: Register, M: Memory>(
+pub fn lb<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(&R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
     let value = machine.memory_mut().load8(address.to_usize())?;
     // sign-extened
-    update_register(machine, rd, R::from_i8(value as i8));
+    update_register(machine, rd, Mac::REG::from_i8(value as i8));
     Ok(())
 }
 
-pub fn lh<Mac: Machine<R, M>, R: Register, M: Memory>(
+pub fn lh<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(&R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
     let value = machine.memory_mut().load16(address.to_usize())?;
     // sign-extened
-    update_register(machine, rd, R::from_i16(value as i16));
+    update_register(machine, rd, Mac::REG::from_i16(value as i16));
     Ok(())
 }
 
-pub fn lw<Mac: Machine<R, M>, R: Register, M: Memory>(
+pub fn lw<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(&R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
     let value = machine.memory_mut().load32(address.to_usize())?;
-    update_register(machine, rd, R::from_i32(value as i32));
+    update_register(machine, rd, Mac::REG::from_i32(value as i32));
     Ok(())
 }
 
-pub fn ld<Mac: Machine<R, M>, R: Register, M: Memory>(
+pub fn ld<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(&R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
     let value = machine.memory_mut().load64(address.to_usize())?;
-    update_register(machine, rd, R::from_i64(value as i64));
+    update_register(machine, rd, Mac::REG::from_i64(value as i64));
     Ok(())
 }
 
-pub fn lbu<Mac: Machine<R, M>, R: Register, M: Memory>(
+pub fn lbu<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(&R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
     let value = machine.memory_mut().load8(address.to_usize())?;
-    update_register(machine, rd, R::from_u8(value));
+    update_register(machine, rd, Mac::REG::from_u8(value));
     Ok(())
 }
 
-pub fn lhu<Mac: Machine<R, M>, R: Register, M: Memory>(
+pub fn lhu<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(&R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
     let value = machine.memory_mut().load16(address.to_usize())?;
-    update_register(machine, rd, R::from_u16(value));
+    update_register(machine, rd, Mac::REG::from_u16(value));
     Ok(())
 }
 
-pub fn lwu<Mac: Machine<R, M>, R: Register, M: Memory>(
+pub fn lwu<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(&R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
     let value = machine.memory_mut().load32(address.to_usize())?;
-    update_register(machine, rd, R::from_u32(value));
+    update_register(machine, rd, Mac::REG::from_u32(value));
     Ok(())
 }
 
 // ========================
 // #  STORE instructions  #
 // ========================
-pub fn sb<Mac: Machine<R, M>, R: Register, M: Memory>(
+pub fn sb<Mac: Machine>(
     machine: &mut Mac,
     rs1: RegisterIndex,
     rs2: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(&R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
     let value = machine.registers()[rs2].to_u8();
     machine.memory_mut().store8(address.to_usize(), value)?;
     Ok(())
 }
 
-pub fn sh<Mac: Machine<R, M>, R: Register, M: Memory>(
+pub fn sh<Mac: Machine>(
     machine: &mut Mac,
     rs1: RegisterIndex,
     rs2: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(&R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
     let value = machine.registers()[rs2].to_u16();
     machine.memory_mut().store16(address.to_usize(), value)?;
     Ok(())
 }
 
-pub fn sw<Mac: Machine<R, M>, R: Register, M: Memory>(
+pub fn sw<Mac: Machine>(
     machine: &mut Mac,
     rs1: RegisterIndex,
     rs2: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(&R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
     let value = machine.registers()[rs2].to_u32();
     machine.memory_mut().store32(address.to_usize(), value)?;
     Ok(())
 }
 
-pub fn sd<Mac: Machine<R, M>, R: Register, M: Memory>(
+pub fn sd<Mac: Machine>(
     machine: &mut Mac,
     rs1: RegisterIndex,
     rs2: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(&R::from_i32(imm));
+    let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
     let value = machine.registers()[rs2].to_u64();
     machine.memory_mut().store64(address.to_usize(), value)?;
     Ok(())
@@ -220,7 +220,7 @@ pub fn sd<Mac: Machine<R, M>, R: Register, M: Memory>(
 // =========================
 // #  BIT-OP instructions  #
 // =========================
-pub fn and<Mac: Machine<R, M>, R: Register, M: Memory>(
+pub fn and<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
@@ -232,7 +232,7 @@ pub fn and<Mac: Machine<R, M>, R: Register, M: Memory>(
     update_register(machine, rd, value);
 }
 
-pub fn xor<Mac: Machine<R, M>, R: Register, M: Memory>(
+pub fn xor<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
@@ -244,7 +244,7 @@ pub fn xor<Mac: Machine<R, M>, R: Register, M: Memory>(
     update_register(machine, rd, value);
 }
 
-pub fn or<Mac: Machine<R, M>, R: Register, M: Memory>(
+pub fn or<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
@@ -256,108 +256,104 @@ pub fn or<Mac: Machine<R, M>, R: Register, M: Memory>(
     update_register(machine, rd, value);
 }
 
-pub fn andi<Mac: Machine<R, M>, R: Register, M: Memory>(
+pub fn andi<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
     imm: Immediate,
 ) {
-    let value = machine.registers()[rs1].clone() & R::from_i32(imm);
+    let value = machine.registers()[rs1].clone() & Mac::REG::from_i32(imm);
     update_register(machine, rd, value);
 }
 
-pub fn xori<Mac: Machine<R, M>, R: Register, M: Memory>(
+pub fn xori<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
     imm: Immediate,
 ) {
-    let value = machine.registers()[rs1].clone() ^ R::from_i32(imm);
+    let value = machine.registers()[rs1].clone() ^ Mac::REG::from_i32(imm);
     update_register(machine, rd, value);
 }
 
-pub fn ori<Mac: Machine<R, M>, R: Register, M: Memory>(
-    machine: &mut Mac,
-    rd: RegisterIndex,
-    rs1: RegisterIndex,
-    imm: Immediate,
-) {
-    let value = machine.registers()[rs1].clone() | R::from_i32(imm);
+pub fn ori<Mac: Machine>(machine: &mut Mac, rd: RegisterIndex, rs1: RegisterIndex, imm: Immediate) {
+    let value = machine.registers()[rs1].clone() | Mac::REG::from_i32(imm);
     update_register(machine, rd, value);
 }
 
-pub fn slli<Mac: Machine<R, M>, R: Register, M: Memory>(
+pub fn slli<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
     shamt: UImmediate,
 ) {
-    let value = machine.registers()[rs1].clone() << R::from_u32(shamt);
+    let value = machine.registers()[rs1].clone() << Mac::REG::from_u32(shamt);
     update_register(machine, rd, value);
 }
 
-pub fn srli<Mac: Machine<R, M>, R: Register, M: Memory>(
+pub fn srli<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
     shamt: UImmediate,
 ) {
-    let value = machine.registers()[rs1].clone() >> R::from_u32(shamt);
+    let value = machine.registers()[rs1].clone() >> Mac::REG::from_u32(shamt);
     update_register(machine, rd, value);
 }
 
-pub fn srai<Mac: Machine<R, M>, R: Register, M: Memory>(
+pub fn srai<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
     shamt: UImmediate,
 ) {
-    let value = machine.registers()[rs1].signed_shr(&R::from_u32(shamt));
+    let value = machine.registers()[rs1].signed_shr(&Mac::REG::from_u32(shamt));
     update_register(machine, rd, value);
 }
 
-pub fn slliw<Mac: Machine<R, M>, R: Register, M: Memory>(
+pub fn slliw<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
     shamt: UImmediate,
 ) {
-    let value = machine.registers()[rs1].clone() << R::from_u32(shamt);
-    update_register(machine, rd, value.sign_extend(&R::from_usize(32)));
+    let value = machine.registers()[rs1].clone() << Mac::REG::from_u32(shamt);
+    update_register(machine, rd, value.sign_extend(&Mac::REG::from_usize(32)));
 }
 
-pub fn srliw<Mac: Machine<R, M>, R: Register, M: Memory>(
+pub fn srliw<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
     shamt: UImmediate,
 ) {
-    let value = machine.registers()[rs1].zero_extend(&R::from_usize(32)) >> R::from_u32(shamt);
-    update_register(machine, rd, value.sign_extend(&R::from_usize(32)));
+    let value = machine.registers()[rs1].zero_extend(&Mac::REG::from_usize(32))
+        >> Mac::REG::from_u32(shamt);
+    update_register(machine, rd, value.sign_extend(&Mac::REG::from_usize(32)));
 }
 
-pub fn sraiw<Mac: Machine<R, M>, R: Register, M: Memory>(
+pub fn sraiw<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
     shamt: UImmediate,
 ) {
     let value = machine.registers()[rs1]
-        .sign_extend(&R::from_usize(32))
-        .signed_shr(&R::from_u32(shamt));
-    update_register(machine, rd, value.sign_extend(&R::from_usize(32)));
+        .sign_extend(&Mac::REG::from_usize(32))
+        .signed_shr(&Mac::REG::from_u32(shamt));
+    update_register(machine, rd, value.sign_extend(&Mac::REG::from_usize(32)));
 }
 
 // =======================
 // #  JUMP instructions  #
 // =======================
-pub fn jal<Mac: Machine<R, M>, R: Register, M: Memory>(
+pub fn jal<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     imm: Immediate,
     xbytes: usize,
-) -> Option<R> {
-    let link = machine.pc().overflowing_add(&R::from_usize(xbytes));
+) -> Option<Mac::REG> {
+    let link = machine.pc().overflowing_add(&Mac::REG::from_usize(xbytes));
     update_register(machine, rd, link);
-    Some(machine.pc().overflowing_add(&R::from_i32(imm)))
+    Some(machine.pc().overflowing_add(&Mac::REG::from_i32(imm)))
 }

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -8,7 +8,6 @@ pub mod rvc;
 
 pub use self::register::Register;
 use super::machine::Machine;
-use super::memory::Memory;
 use super::Error;
 use std::fmt::{self, Display};
 
@@ -20,10 +19,7 @@ pub enum Instruction {
 }
 
 impl Instruction {
-    pub fn execute<Mac: Machine<R, M>, R: Register, M: Memory>(
-        &self,
-        machine: &mut Mac,
-    ) -> Result<(), Error> {
+    pub fn execute<Mac: Machine>(&self, machine: &mut Mac) -> Result<(), Error> {
         match self {
             Instruction::I(instruction) => instruction.execute(machine),
             Instruction::M(instruction) => instruction.execute(machine),
@@ -44,10 +40,7 @@ pub type InstructionFactory = fn(instruction_bits: u32) -> Option<Instruction>;
 
 // Instruction execution trait
 pub trait Execute {
-    fn execute<Mac: Machine<R, M>, R: Register, M: Memory>(
-        &self,
-        machine: &mut Mac,
-    ) -> Result<Option<R>, Error>;
+    fn execute<Mac: Machine>(&self, machine: &mut Mac) -> Result<Option<Mac::REG>, Error>;
 }
 
 type RegisterIndex = usize;

--- a/src/instructions/utils.rs
+++ b/src/instructions/utils.rs
@@ -1,6 +1,4 @@
 use super::super::machine::Machine;
-use super::super::memory::Memory;
-use super::register::Register;
 use crate::RISCV_GENERAL_REGISTER_NUMBER;
 
 // Inspired from https://github.com/riscv/riscv-isa-sim/blob/master/riscv/decode.h#L105-L106
@@ -75,11 +73,7 @@ pub fn utype_immediate(instruction_bits: u32) -> i32 {
     xs(instruction_bits, 12, 20, 12) as i32
 }
 
-pub fn update_register<Mac: Machine<R, M>, R: Register, M: Memory>(
-    machine: &mut Mac,
-    register_index: usize,
-    value: R,
-) {
+pub fn update_register<M: Machine>(machine: &mut M, register_index: usize, value: M::REG) {
     let register_index = register_index % RISCV_GENERAL_REGISTER_NUMBER;
     // In RISC-V, x0 is a special zero register with the following properties:
     //

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -175,27 +175,27 @@ pub struct DefaultCoreMachine<R, M> {
 impl<R: Register, M: Memory> CoreMachine for DefaultCoreMachine<R, M> {
     type REG = R;
     type MEM = M;
-    fn pc(&self) -> &R {
+    fn pc(&self) -> &Self::REG {
         &self.pc
     }
 
-    fn set_pc(&mut self, next_pc: R) {
+    fn set_pc(&mut self, next_pc: Self::REG) {
         self.pc = next_pc;
     }
 
-    fn memory(&self) -> &M {
+    fn memory(&self) -> &Self::MEM {
         &self.memory
     }
 
-    fn memory_mut(&mut self) -> &mut M {
+    fn memory_mut(&mut self) -> &mut Self::MEM {
         &mut self.memory
     }
 
-    fn registers(&self) -> &[R] {
+    fn registers(&self) -> &[Self::REG] {
         &self.registers
     }
 
-    fn set_register(&mut self, idx: usize, value: R) {
+    fn set_register(&mut self, idx: usize, value: Self::REG) {
         self.registers[idx] = value;
     }
 }
@@ -244,8 +244,7 @@ where
 
 impl<R, M> DefaultCoreMachine<R, M>
 where
-    R: Register,
-    M: Default,
+    Self: Default
 {
     pub fn new_with_max_cycles(max_cycles: u64) -> DefaultCoreMachine<R, M> {
         Self {
@@ -257,7 +256,7 @@ where
 
 pub type InstructionCycleFunc = Fn(&Instruction) -> u64;
 
-pub struct DefaultMachine<'a, R: Register, M: Memory> {
+pub struct DefaultMachine<'a, R, M> {
     core: DefaultCoreMachine<R, M>,
 
     // We have run benchmarks on secp256k1 verification, the performance
@@ -270,7 +269,7 @@ pub struct DefaultMachine<'a, R: Register, M: Memory> {
     exit_code: u8,
 }
 
-impl<'a, R: Register, M: Memory> Deref for DefaultMachine<'a, R, M> {
+impl<'a, R, M> Deref for DefaultMachine<'a, R, M> {
     type Target = DefaultCoreMachine<R, M>;
 
     fn deref(&self) -> &Self::Target {
@@ -278,7 +277,7 @@ impl<'a, R: Register, M: Memory> Deref for DefaultMachine<'a, R, M> {
     }
 }
 
-impl<'a, R: Register, M: Memory> DerefMut for DefaultMachine<'a, R, M> {
+impl<'a, R, M> DerefMut for DefaultMachine<'a, R, M> {
     fn deref_mut(&mut self) -> &mut DefaultCoreMachine<R, M> {
         &mut self.core
     }

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -244,7 +244,7 @@ where
 
 impl<R, M> DefaultCoreMachine<R, M>
 where
-    Self: Default
+    Self: Default,
 {
     pub fn new_with_max_cycles(max_cycles: u64) -> DefaultCoreMachine<R, M> {
         Self {

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -1,8 +1,6 @@
-use super::instructions::Register;
 use super::machine::SupportMachine;
-use super::memory::Memory;
 use super::Error;
-pub trait Syscalls<R: Register, M: Memory> {
+pub trait Syscalls<R, M> {
     fn initialize(&mut self, machine: &mut SupportMachine<REG = R, MEM = M>) -> Result<(), Error>;
     // Returned bool means if the syscall has been processed, if
     // a module returns false, Machine would continue to leverage

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -3,9 +3,9 @@ use super::machine::SupportMachine;
 use super::memory::Memory;
 use super::Error;
 pub trait Syscalls<R: Register, M: Memory> {
-    fn initialize(&mut self, machine: &mut SupportMachine<R, M>) -> Result<(), Error>;
+    fn initialize(&mut self, machine: &mut SupportMachine<REG = R, MEM = M>) -> Result<(), Error>;
     // Returned bool means if the syscall has been processed, if
     // a module returns false, Machine would continue to leverage
     // the next syscall module to process.
-    fn ecall(&mut self, machine: &mut SupportMachine<R, M>) -> Result<bool, Error>;
+    fn ecall(&mut self, machine: &mut SupportMachine<REG = R, MEM = M>) -> Result<bool, Error>;
 }

--- a/tests/test_misc.rs
+++ b/tests/test_misc.rs
@@ -34,12 +34,15 @@ pub struct CustomSyscall {}
 impl Syscalls<u64, SparseMemory> for CustomSyscall {
     fn initialize(
         &mut self,
-        _machine: &mut SupportMachine<u64, SparseMemory>,
+        _machine: &mut SupportMachine<REG = u64, MEM = SparseMemory>,
     ) -> Result<(), Error> {
         Ok(())
     }
 
-    fn ecall(&mut self, machine: &mut SupportMachine<u64, SparseMemory>) -> Result<bool, Error> {
+    fn ecall(
+        &mut self,
+        machine: &mut SupportMachine<REG = u64, MEM = SparseMemory>,
+    ) -> Result<bool, Error> {
         let code = machine.registers()[A7];
         if code != 1111 {
             return Ok(false);


### PR DESCRIPTION
This PR changes `Machine` trait's generic type to associated type, any function that wants to take a `Machine` as a parameter now no need to be generic over `Register` and `Memory` type.