### PR TITLE
refactor: Ensure memory trait is also using Register types

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -46,7 +46,7 @@ impl Decoder {
     // Also, due to RISC-V encoding behavior, it's totally okay when we cast a 16-bit
     // RVC instruction into a 32-bit instruction, the meaning of the instruction stays
     // unchanged in the cast conversion.
-    fn decode_bits<R: Register, M: Memory<REG = R>>(
+    fn decode_bits<R: Register, M: Memory<R>>(
         &self,
         memory: &mut M,
         pc: usize,
@@ -58,7 +58,7 @@ impl Decoder {
         Ok(instruction_bits)
     }
 
-    pub fn decode<R: Register, M: Memory<REG = R>>(
+    pub fn decode<R: Register, M: Memory<R>>(
         &self,
         memory: &mut M,
         pc: usize,

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -46,7 +46,11 @@ impl Decoder {
     // Also, due to RISC-V encoding behavior, it's totally okay when we cast a 16-bit
     // RVC instruction into a 32-bit instruction, the meaning of the instruction stays
     // unchanged in the cast conversion.
-    fn decode_bits<M: Memory>(&self, memory: &mut M, pc: usize) -> Result<u32, Error> {
+    fn decode_bits<R: Register, M: Memory<REG = R>>(
+        &self,
+        memory: &mut M,
+        pc: usize,
+    ) -> Result<u32, Error> {
         let mut instruction_bits = u32::from(memory.execute_load16(pc)?);
         if instruction_bits & 0x3 == 0x3 {
             instruction_bits |= u32::from(memory.execute_load16(pc + 2)?) << 16;
@@ -54,7 +58,11 @@ impl Decoder {
         Ok(instruction_bits)
     }
 
-    pub fn decode<M: Memory>(&self, memory: &mut M, pc: usize) -> Result<Instruction, Error> {
+    pub fn decode<R: Register, M: Memory<REG = R>>(
+        &self,
+        memory: &mut M,
+        pc: usize,
+    ) -> Result<Instruction, Error> {
         let instruction_bits = self.decode_bits(memory, pc)?;
         for factory in &self.factories {
             if let Some(instruction) = factory(instruction_bits) {

--- a/src/instructions/common.rs
+++ b/src/instructions/common.rs
@@ -87,9 +87,9 @@ pub fn lb<Mac: Machine>(
     imm: Immediate,
 ) -> Result<(), Error> {
     let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
-    let value = machine.memory_mut().load8(address.to_usize())?;
+    let value = machine.memory_mut().load8(&address)?;
     // sign-extened
-    update_register(machine, rd, Mac::REG::from_i8(value as i8));
+    update_register(machine, rd, value.sign_extend(&Mac::REG::from_usize(8)));
     Ok(())
 }
 
@@ -100,9 +100,9 @@ pub fn lh<Mac: Machine>(
     imm: Immediate,
 ) -> Result<(), Error> {
     let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
-    let value = machine.memory_mut().load16(address.to_usize())?;
+    let value = machine.memory_mut().load16(&address)?;
     // sign-extened
-    update_register(machine, rd, Mac::REG::from_i16(value as i16));
+    update_register(machine, rd, value.sign_extend(&Mac::REG::from_usize(16)));
     Ok(())
 }
 
@@ -113,8 +113,8 @@ pub fn lw<Mac: Machine>(
     imm: Immediate,
 ) -> Result<(), Error> {
     let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
-    let value = machine.memory_mut().load32(address.to_usize())?;
-    update_register(machine, rd, Mac::REG::from_i32(value as i32));
+    let value = machine.memory_mut().load32(&address)?;
+    update_register(machine, rd, value.sign_extend(&Mac::REG::from_usize(32)));
     Ok(())
 }
 
@@ -125,8 +125,8 @@ pub fn ld<Mac: Machine>(
     imm: Immediate,
 ) -> Result<(), Error> {
     let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
-    let value = machine.memory_mut().load64(address.to_usize())?;
-    update_register(machine, rd, Mac::REG::from_i64(value as i64));
+    let value = machine.memory_mut().load64(&address)?;
+    update_register(machine, rd, value.sign_extend(&Mac::REG::from_usize(64)));
     Ok(())
 }
 
@@ -137,8 +137,8 @@ pub fn lbu<Mac: Machine>(
     imm: Immediate,
 ) -> Result<(), Error> {
     let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
-    let value = machine.memory_mut().load8(address.to_usize())?;
-    update_register(machine, rd, Mac::REG::from_u8(value));
+    let value = machine.memory_mut().load8(&address)?;
+    update_register(machine, rd, value);
     Ok(())
 }
 
@@ -149,8 +149,8 @@ pub fn lhu<Mac: Machine>(
     imm: Immediate,
 ) -> Result<(), Error> {
     let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
-    let value = machine.memory_mut().load16(address.to_usize())?;
-    update_register(machine, rd, Mac::REG::from_u16(value));
+    let value = machine.memory_mut().load16(&address)?;
+    update_register(machine, rd, value);
     Ok(())
 }
 
@@ -161,8 +161,8 @@ pub fn lwu<Mac: Machine>(
     imm: Immediate,
 ) -> Result<(), Error> {
     let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
-    let value = machine.memory_mut().load32(address.to_usize())?;
-    update_register(machine, rd, Mac::REG::from_u32(value));
+    let value = machine.memory_mut().load32(&address)?;
+    update_register(machine, rd, value);
     Ok(())
 }
 
@@ -176,8 +176,8 @@ pub fn sb<Mac: Machine>(
     imm: Immediate,
 ) -> Result<(), Error> {
     let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
-    let value = machine.registers()[rs2].to_u8();
-    machine.memory_mut().store8(address.to_usize(), value)?;
+    let value = machine.registers()[rs2].clone();
+    machine.memory_mut().store8(&address, &value)?;
     Ok(())
 }
 
@@ -188,8 +188,8 @@ pub fn sh<Mac: Machine>(
     imm: Immediate,
 ) -> Result<(), Error> {
     let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
-    let value = machine.registers()[rs2].to_u16();
-    machine.memory_mut().store16(address.to_usize(), value)?;
+    let value = machine.registers()[rs2].clone();
+    machine.memory_mut().store16(&address, &value)?;
     Ok(())
 }
 
@@ -200,8 +200,8 @@ pub fn sw<Mac: Machine>(
     imm: Immediate,
 ) -> Result<(), Error> {
     let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
-    let value = machine.registers()[rs2].to_u32();
-    machine.memory_mut().store32(address.to_usize(), value)?;
+    let value = machine.registers()[rs2].clone();
+    machine.memory_mut().store32(&address, &value)?;
     Ok(())
 }
 
@@ -212,8 +212,8 @@ pub fn sd<Mac: Machine>(
     imm: Immediate,
 ) -> Result<(), Error> {
     let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
-    let value = machine.registers()[rs2].to_u64();
-    machine.memory_mut().store64(address.to_usize(), value)?;
+    let value = machine.registers()[rs2].clone();
+    machine.memory_mut().store64(&address, &value)?;
     Ok(())
 }
 

--- a/src/instructions/register.rs
+++ b/src/instructions/register.rs
@@ -1,3 +1,4 @@
+use std::cmp::min;
 use std::fmt::Display;
 use std::ops::{BitAnd, BitOr, BitXor, Not, Shl, Shr};
 
@@ -238,14 +239,14 @@ impl Register for u32 {
     }
 
     fn zero_extend(&self, start_bit: &u32) -> u32 {
-        let start_bit = *start_bit;
-        debug_assert!(start_bit < 32 && start_bit > 0);
+        let start_bit = min(*start_bit, 32);
+        debug_assert!(start_bit > 0);
         (*self << (32 - start_bit)) >> (32 - start_bit)
     }
 
     fn sign_extend(&self, start_bit: &u32) -> u32 {
-        let start_bit = *start_bit;
-        debug_assert!(start_bit < 32 && start_bit > 0);
+        let start_bit = min(*start_bit, 32);
+        debug_assert!(start_bit > 0);
         (((*self << (32 - start_bit)) as i32) >> (32 - start_bit)) as u32
     }
 
@@ -459,14 +460,14 @@ impl Register for u64 {
     }
 
     fn zero_extend(&self, start_bit: &u64) -> u64 {
-        let start_bit = *start_bit;
-        debug_assert!(start_bit < 64 && start_bit > 0);
+        let start_bit = min(*start_bit, 64);
+        debug_assert!(start_bit > 0);
         (*self << (64 - start_bit)) >> (64 - start_bit)
     }
 
     fn sign_extend(&self, start_bit: &u64) -> u64 {
-        let start_bit = *start_bit;
-        debug_assert!(start_bit < 64 && start_bit > 0);
+        let start_bit = min(*start_bit, 64);
+        debug_assert!(start_bit > 0);
         (((*self << (64 - start_bit)) as i64) >> (64 - start_bit)) as u64
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,8 @@ pub const A5: usize = 15;
 pub const A6: usize = 16;
 pub const A7: usize = 17;
 
-#[cfg_attr(rustfmt, rustfmt_skip)]
+// Register ABI names
+#[rustfmt::skip]
 pub const REGISTER_ABI_NAMES: [&str; 32] = [
     "zero", "ra", "sp", "gp",
     "tp", "t0", "t1", "t2",
@@ -89,7 +90,7 @@ impl From<IOError> for Error {
     }
 }
 
-pub fn run<R: Register, M: Memory>(program: &[u8], args: &[Vec<u8>]) -> Result<u8, Error> {
+pub fn run<R: Register, M: Memory<REG = R>>(program: &[u8], args: &[Vec<u8>]) -> Result<u8, Error> {
     let mut machine =
         DefaultMachine::<DefaultCoreMachine<R, M>>::default().load_program(program, args)?;
     interpreter_run(&mut machine)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ impl From<IOError> for Error {
     }
 }
 
-pub fn run<R: Register, M: Memory<REG = R>>(program: &[u8], args: &[Vec<u8>]) -> Result<u8, Error> {
+pub fn run<R: Register, M: Memory<R>>(program: &[u8], args: &[Vec<u8>]) -> Result<u8, Error> {
     let mut machine =
         DefaultMachine::<DefaultCoreMachine<R, M>>::default().load_program(program, args)?;
     interpreter_run(&mut machine)

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -44,7 +44,7 @@ fn convert_flags(p_flags: u32) -> u32 {
 /// syscall support.
 pub trait CoreMachine {
     type REG: Register;
-    type MEM: Memory;
+    type MEM: Memory<REG = Self::REG>;
     fn pc(&self) -> &Self::REG;
     fn set_pc(&mut self, next_pc: Self::REG);
     fn memory(&self) -> &Self::MEM;
@@ -138,7 +138,7 @@ pub trait SupportMachine: CoreMachine {
 
             self.memory_mut().store_bytes(address.to_usize(), bytes)?;
             self.memory_mut()
-                .store8(address.to_usize() + bytes.len(), 0)?;
+                .store_byte(address.to_usize() + bytes.len(), 1, 0)?;
 
             values.push(address.clone());
             self.set_register(SP, address);
@@ -149,8 +149,7 @@ pub trait SupportMachine: CoreMachine {
             let address =
                 self.registers()[SP].overflowing_sub(&Self::REG::from_usize(Self::REG::BITS / 8));
 
-            self.memory_mut()
-                .store32(address.to_usize(), value.to_u32())?;
+            self.memory_mut().store32(&address, value)?;
             self.set_register(SP, address);
         }
         if self.registers()[SP].to_usize() < stack_start {
@@ -172,7 +171,7 @@ pub struct DefaultCoreMachine<R, M> {
     max_cycles: Option<u64>,
 }
 
-impl<R: Register, M: Memory> CoreMachine for DefaultCoreMachine<R, M> {
+impl<R: Register, M: Memory<REG = R>> CoreMachine for DefaultCoreMachine<R, M> {
     type REG = R;
     type MEM = M;
     fn pc(&self) -> &Self::REG {
@@ -200,7 +199,7 @@ impl<R: Register, M: Memory> CoreMachine for DefaultCoreMachine<R, M> {
     }
 }
 
-impl<R: Register, M: Memory> SupportMachine for DefaultCoreMachine<R, M> {
+impl<R: Register, M: Memory<REG = R>> SupportMachine for DefaultCoreMachine<R, M> {
     fn elf_end(&self) -> usize {
         self.elf_end
     }
@@ -222,7 +221,7 @@ impl<R: Register, M: Memory> SupportMachine for DefaultCoreMachine<R, M> {
     }
 }
 
-impl<R: Register, M: Memory> DefaultCoreMachine<R, M> {
+impl<R: Register, M: Memory<REG = R>> DefaultCoreMachine<R, M> {
     pub fn new_with_max_cycles(max_cycles: u64) -> Self {
         Self {
             max_cycles: Some(max_cycles),
@@ -341,7 +340,7 @@ impl<Inner: CoreMachine> Display for DefaultMachine<'_, Inner> {
     }
 }
 
-impl<R: Register, M: Memory> DefaultMachine<'_, DefaultCoreMachine<R, M>> {
+impl<R: Register, M: Memory<REG = R>> DefaultMachine<'_, DefaultCoreMachine<R, M>> {
     pub fn new_with_cost_model(
         instruction_cycle_func: Box<InstructionCycleFunc>,
         max_cycles: u64,

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -44,7 +44,8 @@ fn convert_flags(p_flags: u32) -> u32 {
 /// syscall support.
 pub trait CoreMachine {
     type REG: Register;
-    type MEM: Memory<REG = Self::REG>;
+    type MEM: Memory<Self::REG>;
+
     fn pc(&self) -> &Self::REG;
     fn set_pc(&mut self, next_pc: Self::REG);
     fn memory(&self) -> &Self::MEM;
@@ -171,7 +172,7 @@ pub struct DefaultCoreMachine<R, M> {
     max_cycles: Option<u64>,
 }
 
-impl<R: Register, M: Memory<REG = R>> CoreMachine for DefaultCoreMachine<R, M> {
+impl<R: Register, M: Memory<R>> CoreMachine for DefaultCoreMachine<R, M> {
     type REG = R;
     type MEM = M;
     fn pc(&self) -> &Self::REG {
@@ -199,7 +200,7 @@ impl<R: Register, M: Memory<REG = R>> CoreMachine for DefaultCoreMachine<R, M> {
     }
 }
 
-impl<R: Register, M: Memory<REG = R>> SupportMachine for DefaultCoreMachine<R, M> {
+impl<R: Register, M: Memory<R>> SupportMachine for DefaultCoreMachine<R, M> {
     fn elf_end(&self) -> usize {
         self.elf_end
     }
@@ -221,7 +222,7 @@ impl<R: Register, M: Memory<REG = R>> SupportMachine for DefaultCoreMachine<R, M
     }
 }
 
-impl<R: Register, M: Memory<REG = R>> DefaultCoreMachine<R, M> {
+impl<R: Register, M: Memory<R>> DefaultCoreMachine<R, M> {
     pub fn new_with_max_cycles(max_cycles: u64) -> Self {
         Self {
             max_cycles: Some(max_cycles),
@@ -340,7 +341,7 @@ impl<Inner: CoreMachine> Display for DefaultMachine<'_, Inner> {
     }
 }
 
-impl<R: Register, M: Memory<REG = R>> DefaultMachine<'_, DefaultCoreMachine<R, M>> {
+impl<R: Register, M: Memory<R>> DefaultMachine<'_, DefaultCoreMachine<R, M>> {
     pub fn new_with_cost_model(
         instruction_cycle_func: Box<InstructionCycleFunc>,
         max_cycles: u64,

--- a/src/memory/flat.rs
+++ b/src/memory/flat.rs
@@ -39,9 +39,7 @@ impl<R> DerefMut for FlatMemory<R> {
 
 /// A flat chunk of memory used for RISC-V machine, it lacks all the permission
 /// checking logic.
-impl<R: Register> Memory for FlatMemory<R> {
-    type REG = R;
-
+impl<R: Register> Memory<R> for FlatMemory<R> {
     fn mmap(
         &mut self,
         addr: usize,

--- a/src/memory/flat.rs
+++ b/src/memory/flat.rs
@@ -1,26 +1,29 @@
-use super::super::{Error, RISCV_MAX_MEMORY};
+use super::super::{Error, Register, RISCV_MAX_MEMORY};
 use super::Memory;
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use std::cmp::min;
 use std::io::{Cursor, Seek, SeekFrom};
+use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 use std::ptr;
 use std::rc::Rc;
 
-pub struct FlatMemory {
+pub struct FlatMemory<R> {
     data: Vec<u8>,
+    _inner: PhantomData<R>,
 }
 
-impl Default for FlatMemory {
+impl<R> Default for FlatMemory<R> {
     fn default() -> Self {
         Self {
             data: vec![0; RISCV_MAX_MEMORY],
+            _inner: PhantomData,
         }
     }
 }
 
-impl Deref for FlatMemory {
+impl<R> Deref for FlatMemory<R> {
     type Target = Vec<u8>;
 
     fn deref(&self) -> &Self::Target {
@@ -28,7 +31,7 @@ impl Deref for FlatMemory {
     }
 }
 
-impl DerefMut for FlatMemory {
+impl<R> DerefMut for FlatMemory<R> {
     fn deref_mut(&mut self) -> &mut Vec<u8> {
         &mut self.data
     }
@@ -36,7 +39,9 @@ impl DerefMut for FlatMemory {
 
 /// A flat chunk of memory used for RISC-V machine, it lacks all the permission
 /// checking logic.
-impl Memory for FlatMemory {
+impl<R: Register> Memory for FlatMemory<R> {
+    type REG = R;
+
     fn mmap(
         &mut self,
         addr: usize,
@@ -69,85 +74,97 @@ impl Memory for FlatMemory {
     }
 
     fn execute_load16(&mut self, addr: usize) -> Result<u16, Error> {
-        self.load16(addr)
+        self.load16(&R::from_usize(addr)).map(|v| v.to_u16())
     }
 
-    fn load8(&mut self, addr: usize) -> Result<u8, Error> {
+    fn load8(&mut self, addr: &R) -> Result<R, Error> {
+        let addr = addr.to_usize();
         if addr + 1 > self.len() {
             return Err(Error::OutOfBound);
         }
         let mut reader = Cursor::new(&self.data);
         reader.seek(SeekFrom::Start(addr as u64))?;
-        Ok(reader.read_u8()?)
+        let v = reader.read_u8()?;
+        Ok(R::from_u8(v))
     }
 
-    fn load16(&mut self, addr: usize) -> Result<u16, Error> {
+    fn load16(&mut self, addr: &R) -> Result<R, Error> {
+        let addr = addr.to_usize();
         if addr + 2 > self.len() {
             return Err(Error::OutOfBound);
         }
         let mut reader = Cursor::new(&self.data);
         reader.seek(SeekFrom::Start(addr as u64))?;
         // NOTE: Base RISC-V ISA is defined as a little-endian memory system.
-        Ok(reader.read_u16::<LittleEndian>()?)
+        let v = reader.read_u16::<LittleEndian>()?;
+        Ok(R::from_u16(v))
     }
 
-    fn load32(&mut self, addr: usize) -> Result<u32, Error> {
+    fn load32(&mut self, addr: &R) -> Result<R, Error> {
+        let addr = addr.to_usize();
         if addr + 4 > self.len() {
             return Err(Error::OutOfBound);
         }
         let mut reader = Cursor::new(&self.data);
         reader.seek(SeekFrom::Start(addr as u64))?;
         // NOTE: Base RISC-V ISA is defined as a little-endian memory system.
-        Ok(reader.read_u32::<LittleEndian>()?)
+        let v = reader.read_u32::<LittleEndian>()?;
+        Ok(R::from_u32(v))
     }
 
-    fn load64(&mut self, addr: usize) -> Result<u64, Error> {
+    fn load64(&mut self, addr: &R) -> Result<R, Error> {
+        let addr = addr.to_usize();
         if addr + 8 > self.len() {
             return Err(Error::OutOfBound);
         }
         let mut reader = Cursor::new(&self.data);
         reader.seek(SeekFrom::Start(addr as u64))?;
         // NOTE: Base RISC-V ISA is defined as a little-endian memory system.
-        Ok(reader.read_u64::<LittleEndian>()?)
+        let v = reader.read_u64::<LittleEndian>()?;
+        Ok(R::from_u64(v))
     }
 
-    fn store8(&mut self, addr: usize, value: u8) -> Result<(), Error> {
+    fn store8(&mut self, addr: &R, value: &R) -> Result<(), Error> {
+        let addr = addr.to_usize();
         if addr + 1 > self.len() {
             return Err(Error::OutOfBound);
         }
         let mut writer = Cursor::new(&mut self.data);
         writer.seek(SeekFrom::Start(addr as u64))?;
-        writer.write_u8(value)?;
+        writer.write_u8(value.to_u8())?;
         Ok(())
     }
 
-    fn store16(&mut self, addr: usize, value: u16) -> Result<(), Error> {
+    fn store16(&mut self, addr: &R, value: &R) -> Result<(), Error> {
+        let addr = addr.to_usize();
         if addr + 2 > self.len() {
             return Err(Error::OutOfBound);
         }
         let mut writer = Cursor::new(&mut self.data);
         writer.seek(SeekFrom::Start(addr as u64))?;
-        writer.write_u16::<LittleEndian>(value)?;
+        writer.write_u16::<LittleEndian>(value.to_u16())?;
         Ok(())
     }
 
-    fn store32(&mut self, addr: usize, value: u32) -> Result<(), Error> {
+    fn store32(&mut self, addr: &R, value: &R) -> Result<(), Error> {
+        let addr = addr.to_usize();
         if addr + 4 > self.len() {
             return Err(Error::OutOfBound);
         }
         let mut writer = Cursor::new(&mut self.data);
         writer.seek(SeekFrom::Start(addr as u64))?;
-        writer.write_u32::<LittleEndian>(value)?;
+        writer.write_u32::<LittleEndian>(value.to_u32())?;
         Ok(())
     }
 
-    fn store64(&mut self, addr: usize, value: u64) -> Result<(), Error> {
+    fn store64(&mut self, addr: &R, value: &R) -> Result<(), Error> {
+        let addr = addr.to_usize();
         if addr + 8 > self.len() {
             return Err(Error::OutOfBound);
         }
         let mut writer = Cursor::new(&mut self.data);
         writer.seek(SeekFrom::Start(addr as u64))?;
-        writer.write_u64::<LittleEndian>(value)?;
+        writer.write_u64::<LittleEndian>(value.to_u64())?;
         Ok(())
     }
 

--- a/src/memory/mmu.rs
+++ b/src/memory/mmu.rs
@@ -1,7 +1,8 @@
-use super::super::{Error, RISCV_MAX_MEMORY, RISCV_PAGESIZE};
+use super::super::{Error, Register, RISCV_MAX_MEMORY, RISCV_PAGESIZE};
 use super::{round_page, Memory, Page, PROT_EXEC, PROT_READ, PROT_WRITE};
 
 use std::cmp::min;
+use std::marker::PhantomData;
 use std::ptr;
 use std::rc::Rc;
 
@@ -50,7 +51,7 @@ pub struct TlbEntry {
 /// An MMU implementation with proper protection schemes. Notice this is a correct
 /// soft MMU, not necessarily a fast MMU. For the best performance, we should
 /// leverage native mmap() calls instead to avoid overheads.
-pub struct Mmu {
+pub struct Mmu<R> {
     vms: Vec<Option<VirtualMemoryEntry>>,
     // Page table that stores indices of VirtualMemoryEntry for each page. We are
     // using u8 here to save some memory since we have a hard upper bound of 64
@@ -69,6 +70,7 @@ pub struct Mmu {
     page_data: Vec<Page>,
     // Translation lookaside buffer
     tlb: [Option<TlbEntry>; MAX_TLB_ENTRIES],
+    _inner: PhantomData<R>,
 }
 
 // Generates a new page based on VM mapping, also copy mapped data to the page
@@ -87,14 +89,15 @@ fn handle_page_fault(vm: &VirtualMemoryEntry, addr: usize) -> Result<Page, Error
     Ok(page)
 }
 
-impl Mmu {
-    pub fn new() -> Mmu {
+impl<R> Mmu<R> {
+    pub fn new() -> Mmu<R> {
         Mmu {
             vms: vec![None; MAX_VIRTUAL_MEMORY_ENTRIES],
             page_table: [INVALID_PAGE_INDEX; MAX_PAGES],
             page_addresses: Vec::new(),
             page_data: Vec::new(),
             tlb: [None; MAX_TLB_ENTRIES],
+            _inner: PhantomData,
         }
     }
 
@@ -209,7 +212,9 @@ impl Mmu {
     }
 }
 
-impl Memory for Mmu {
+impl<R: Register> Memory for Mmu<R> {
+    type REG = R;
+
     fn mmap(
         &mut self,
         addr: usize,
@@ -258,20 +263,24 @@ impl Memory for Mmu {
         self.munmap_aligned(addr, size)
     }
 
-    fn load8(&mut self, addr: usize) -> Result<u8, Error> {
-        self.load(addr, 1, PROT_READ).map(|v| v as u8)
+    fn load8(&mut self, addr: &R) -> Result<R, Error> {
+        let v = self.load(addr.to_usize(), 1, PROT_READ).map(|v| v as u8)?;
+        Ok(R::from_u8(v))
     }
 
-    fn load16(&mut self, addr: usize) -> Result<u16, Error> {
-        self.load(addr, 2, PROT_READ).map(|v| v as u16)
+    fn load16(&mut self, addr: &R) -> Result<R, Error> {
+        let v = self.load(addr.to_usize(), 2, PROT_READ).map(|v| v as u16)?;
+        Ok(R::from_u16(v))
     }
 
-    fn load32(&mut self, addr: usize) -> Result<u32, Error> {
-        self.load(addr, 4, PROT_READ).map(|v| v as u32)
+    fn load32(&mut self, addr: &R) -> Result<R, Error> {
+        let v = self.load(addr.to_usize(), 4, PROT_READ).map(|v| v as u32)?;
+        Ok(R::from_u32(v))
     }
 
-    fn load64(&mut self, addr: usize) -> Result<u64, Error> {
-        self.load(addr, 8, PROT_READ)
+    fn load64(&mut self, addr: &R) -> Result<R, Error> {
+        let v = self.load(addr.to_usize(), 8, PROT_READ)?;
+        Ok(R::from_u64(v))
     }
 
     fn execute_load16(&mut self, addr: usize) -> Result<u16, Error> {
@@ -313,19 +322,21 @@ impl Memory for Mmu {
         Ok(())
     }
 
-    fn store8(&mut self, addr: usize, value: u8) -> Result<(), Error> {
-        self.store_bytes(addr, &[value])
+    fn store8(&mut self, addr: &R, value: &R) -> Result<(), Error> {
+        self.store_bytes(addr.to_usize(), &[value.to_u8()])
     }
 
-    fn store16(&mut self, addr: usize, value: u16) -> Result<(), Error> {
+    fn store16(&mut self, addr: &R, value: &R) -> Result<(), Error> {
+        let value = value.to_u16();
         // RISC-V is little-endian by specification
-        self.store_bytes(addr, &[(value & 0xFF) as u8, (value >> 8) as u8])
+        self.store_bytes(addr.to_usize(), &[(value & 0xFF) as u8, (value >> 8) as u8])
     }
 
-    fn store32(&mut self, addr: usize, value: u32) -> Result<(), Error> {
+    fn store32(&mut self, addr: &R, value: &R) -> Result<(), Error> {
+        let value = value.to_u32();
         // RISC-V is little-endian by specification
         self.store_bytes(
-            addr,
+            addr.to_usize(),
             &[
                 (value & 0xFF) as u8,
                 ((value >> 8) & 0xFF) as u8,
@@ -335,10 +346,11 @@ impl Memory for Mmu {
         )
     }
 
-    fn store64(&mut self, addr: usize, value: u64) -> Result<(), Error> {
+    fn store64(&mut self, addr: &R, value: &R) -> Result<(), Error> {
+        let value = value.to_u64();
         // RISC-V is little-endian by specification
         self.store_bytes(
-            addr,
+            addr.to_usize(),
             &[
                 (value & 0xFF) as u8,
                 ((value >> 8) & 0xFF) as u8,
@@ -353,7 +365,7 @@ impl Memory for Mmu {
     }
 }
 
-impl Default for Mmu {
+impl<R> Default for Mmu<R> {
     fn default() -> Self {
         Self::new()
     }

--- a/src/memory/mmu.rs
+++ b/src/memory/mmu.rs
@@ -212,9 +212,7 @@ impl<R> Mmu<R> {
     }
 }
 
-impl<R: Register> Memory for Mmu<R> {
-    type REG = R;
-
+impl<R: Register> Memory<R> for Mmu<R> {
     fn mmap(
         &mut self,
         addr: usize,

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1,4 +1,4 @@
-use super::{Error, RISCV_PAGESIZE};
+use super::{Error, Register, RISCV_PAGESIZE};
 use std::rc::Rc;
 
 pub mod flat;
@@ -17,6 +17,8 @@ pub fn round_page(x: usize) -> usize {
 pub type Page = [u8; RISCV_PAGESIZE];
 
 pub trait Memory: Default {
+    type REG: Register;
+
     // Note this mmap only handles the very low level memory mapping logic.
     // It only takes an aligned address and size, then maps either existing
     // bytes or empty bytes to this range. It doesn't allocate addresses when
@@ -37,19 +39,21 @@ pub trait Memory: Default {
         offset: usize,
     ) -> Result<(), Error>;
     fn munmap(&mut self, addr: usize, size: usize) -> Result<(), Error>;
-
-    // TODO: maybe parameterize those?
-    fn load8(&mut self, addr: usize) -> Result<u8, Error>;
-    fn load16(&mut self, addr: usize) -> Result<u16, Error>;
-    fn load32(&mut self, addr: usize) -> Result<u32, Error>;
-    fn load64(&mut self, addr: usize) -> Result<u64, Error>;
-
-    fn execute_load16(&mut self, addr: usize) -> Result<u16, Error>;
-
-    fn store8(&mut self, addr: usize, value: u8) -> Result<(), Error>;
-    fn store16(&mut self, addr: usize, value: u16) -> Result<(), Error>;
-    fn store32(&mut self, addr: usize, value: u32) -> Result<(), Error>;
-    fn store64(&mut self, addr: usize, value: u64) -> Result<(), Error>;
+    // This is in fact just memset
     fn store_byte(&mut self, addr: usize, size: usize, value: u8) -> Result<(), Error>;
     fn store_bytes(&mut self, addr: usize, value: &[u8]) -> Result<(), Error>;
+    fn execute_load16(&mut self, addr: usize) -> Result<u16, Error>;
+
+    // Methods below are used to implement RISC-V instructions, to make JIT
+    // possible, we need to use register type here so as to pass enough
+    // information around.
+    fn load8(&mut self, addr: &Self::REG) -> Result<Self::REG, Error>;
+    fn load16(&mut self, addr: &Self::REG) -> Result<Self::REG, Error>;
+    fn load32(&mut self, addr: &Self::REG) -> Result<Self::REG, Error>;
+    fn load64(&mut self, addr: &Self::REG) -> Result<Self::REG, Error>;
+
+    fn store8(&mut self, addr: &Self::REG, value: &Self::REG) -> Result<(), Error>;
+    fn store16(&mut self, addr: &Self::REG, value: &Self::REG) -> Result<(), Error>;
+    fn store32(&mut self, addr: &Self::REG, value: &Self::REG) -> Result<(), Error>;
+    fn store64(&mut self, addr: &Self::REG, value: &Self::REG) -> Result<(), Error>;
 }

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -16,9 +16,7 @@ pub fn round_page(x: usize) -> usize {
 
 pub type Page = [u8; RISCV_PAGESIZE];
 
-pub trait Memory: Default {
-    type REG: Register;
-
+pub trait Memory<R: Register>: Default {
     // Note this mmap only handles the very low level memory mapping logic.
     // It only takes an aligned address and size, then maps either existing
     // bytes or empty bytes to this range. It doesn't allocate addresses when
@@ -47,13 +45,13 @@ pub trait Memory: Default {
     // Methods below are used to implement RISC-V instructions, to make JIT
     // possible, we need to use register type here so as to pass enough
     // information around.
-    fn load8(&mut self, addr: &Self::REG) -> Result<Self::REG, Error>;
-    fn load16(&mut self, addr: &Self::REG) -> Result<Self::REG, Error>;
-    fn load32(&mut self, addr: &Self::REG) -> Result<Self::REG, Error>;
-    fn load64(&mut self, addr: &Self::REG) -> Result<Self::REG, Error>;
+    fn load8(&mut self, addr: &R) -> Result<R, Error>;
+    fn load16(&mut self, addr: &R) -> Result<R, Error>;
+    fn load32(&mut self, addr: &R) -> Result<R, Error>;
+    fn load64(&mut self, addr: &R) -> Result<R, Error>;
 
-    fn store8(&mut self, addr: &Self::REG, value: &Self::REG) -> Result<(), Error>;
-    fn store16(&mut self, addr: &Self::REG, value: &Self::REG) -> Result<(), Error>;
-    fn store32(&mut self, addr: &Self::REG, value: &Self::REG) -> Result<(), Error>;
-    fn store64(&mut self, addr: &Self::REG, value: &Self::REG) -> Result<(), Error>;
+    fn store8(&mut self, addr: &R, value: &R) -> Result<(), Error>;
+    fn store16(&mut self, addr: &R, value: &R) -> Result<(), Error>;
+    fn store32(&mut self, addr: &R, value: &R) -> Result<(), Error>;
+    fn store64(&mut self, addr: &R, value: &R) -> Result<(), Error>;
 }

--- a/src/memory/sparse.rs
+++ b/src/memory/sparse.rs
@@ -67,9 +67,7 @@ impl<R> SparseMemory<R> {
     }
 }
 
-impl<R: Register> Memory for SparseMemory<R> {
-    type REG = R;
-
+impl<R: Register> Memory<R> for SparseMemory<R> {
     fn mmap(
         &mut self,
         addr: usize,

--- a/tests/test_minimal.rs
+++ b/tests/test_minimal.rs
@@ -10,7 +10,7 @@ pub fn test_minimal_with_no_args() {
     let mut buffer = Vec::new();
     file.read_to_end(&mut buffer).unwrap();
 
-    let result = run::<u32, SparseMemory>(&buffer, &vec![b"minimal".to_vec()]);
+    let result = run::<u32, SparseMemory<u32>>(&buffer, &vec![b"minimal".to_vec()]);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 1);
 }
@@ -21,7 +21,7 @@ pub fn test_minimal_with_a() {
     let mut buffer = Vec::new();
     file.read_to_end(&mut buffer).unwrap();
 
-    let result = run::<u32, SparseMemory>(&buffer, &vec![b"minimal".to_vec(), b"a".to_vec()]);
+    let result = run::<u32, SparseMemory<u32>>(&buffer, &vec![b"minimal".to_vec(), b"a".to_vec()]);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 2);
 }
@@ -32,7 +32,7 @@ pub fn test_minimal_with_b() {
     let mut buffer = Vec::new();
     file.read_to_end(&mut buffer).unwrap();
 
-    let result = run::<u32, SparseMemory>(&buffer, &vec![b"minimal".to_vec(), b"b".to_vec()]);
+    let result = run::<u32, SparseMemory<u32>>(&buffer, &vec![b"minimal".to_vec(), b"b".to_vec()]);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);
 }

--- a/tests/test_misc.rs
+++ b/tests/test_misc.rs
@@ -13,7 +13,7 @@ pub fn test_andi() {
     let mut buffer = Vec::new();
     file.read_to_end(&mut buffer).unwrap();
 
-    let result = run::<u32, SparseMemory>(&buffer, &vec![b"andi".to_vec()]);
+    let result = run::<u32, SparseMemory<u32>>(&buffer, &vec![b"andi".to_vec()]);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);
 }
@@ -24,16 +24,14 @@ pub fn test_nop() {
     let mut buffer = Vec::new();
     file.read_to_end(&mut buffer).unwrap();
 
-    let result = run::<u32, SparseMemory>(&buffer, &vec![b"nop".to_vec()]);
+    let result = run::<u32, SparseMemory<u32>>(&buffer, &vec![b"nop".to_vec()]);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);
 }
 
-pub struct CustomSyscall<'a> {
-    data: &'a [u8],
-}
+pub struct CustomSyscall {}
 
-impl<Mac: SupportMachine> Syscalls<Mac> for CustomSyscall<'_> {
+impl<Mac: SupportMachine> Syscalls<Mac> for CustomSyscall {
     fn initialize(&mut self, _machine: &mut Mac) -> Result<(), Error> {
         Ok(())
     }
@@ -60,9 +58,8 @@ pub fn test_custom_syscall() {
     let mut buffer = Vec::new();
     file.read_to_end(&mut buffer).unwrap();
 
-    let v = vec![1, 2, 3];
-    let mut machine = DefaultMachine::<DefaultCoreMachine<u64, SparseMemory>>::default();
-    machine.add_syscall_module(Box::new(CustomSyscall { data: &v }));
+    let mut machine = DefaultMachine::<DefaultCoreMachine<u64, SparseMemory<u64>>>::default();
+    machine.add_syscall_module(Box::new(CustomSyscall {}));
     machine = machine
         .load_program(&buffer, &vec![b"syscall".to_vec()])
         .unwrap();

--- a/tests/test_mmu.rs
+++ b/tests/test_mmu.rs
@@ -10,7 +10,7 @@ pub fn test_invalid_write() {
     let mut buffer = Vec::new();
     file.read_to_end(&mut buffer).unwrap();
 
-    let result = run::<u32, Mmu>(&buffer, &[b"invalidwrite".to_vec()]);
+    let result = run::<u32, Mmu<u32>>(&buffer, &[b"invalidwrite".to_vec()]);
     assert!(result.is_err());
 }
 
@@ -20,6 +20,6 @@ pub fn test_invalid_exec() {
     let mut buffer = Vec::new();
     file.read_to_end(&mut buffer).unwrap();
 
-    let result = run::<u32, Mmu>(&buffer, &[b"invalidexec".to_vec()]);
+    let result = run::<u32, Mmu<u32>>(&buffer, &[b"invalidexec".to_vec()]);
     assert!(result.is_err());
 }

--- a/tests/test_simple.rs
+++ b/tests/test_simple.rs
@@ -13,7 +13,7 @@ pub fn test_simple_instructions() {
     let mut buffer = Vec::new();
     file.read_to_end(&mut buffer).unwrap();
 
-    let result = run::<u32, SparseMemory>(&buffer, &vec![b"simple".to_vec()]);
+    let result = run::<u32, SparseMemory<u32>>(&buffer, &vec![b"simple".to_vec()]);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);
 }
@@ -24,7 +24,7 @@ pub fn test_simple_instructions_64() {
     let mut buffer = Vec::new();
     file.read_to_end(&mut buffer).unwrap();
 
-    let result = run::<u64, SparseMemory>(&buffer, &vec![b"simple".to_vec()]);
+    let result = run::<u64, SparseMemory<u64>>(&buffer, &vec![b"simple".to_vec()]);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);
 }
@@ -35,7 +35,7 @@ pub fn test_simple_instructions_flatmemory() {
     let mut buffer = Vec::new();
     file.read_to_end(&mut buffer).unwrap();
 
-    let result = run::<u32, FlatMemory>(&buffer, &vec![b"simple".to_vec()]);
+    let result = run::<u32, FlatMemory<u32>>(&buffer, &vec![b"simple".to_vec()]);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);
 }
@@ -50,10 +50,11 @@ pub fn test_simple_cycles() {
     let mut buffer = Vec::new();
     file.read_to_end(&mut buffer).unwrap();
 
-    let mut machine = DefaultMachine::<DefaultCoreMachine<u64, SparseMemory>>::new_with_cost_model(
-        Box::new(dummy_cycle_func),
-        517,
-    );
+    let mut machine =
+        DefaultMachine::<DefaultCoreMachine<u64, SparseMemory<u64>>>::new_with_cost_model(
+            Box::new(dummy_cycle_func),
+            517,
+        );
     machine = machine
         .load_program(&buffer, &vec![b"simple".to_vec()])
         .unwrap();
@@ -71,10 +72,11 @@ pub fn test_simple_max_cycles_reached() {
     file.read_to_end(&mut buffer).unwrap();
 
     // Running simple64 should consume 517 cycles using dummy cycle func
-    let mut machine = DefaultMachine::<DefaultCoreMachine<u64, SparseMemory>>::new_with_cost_model(
-        Box::new(dummy_cycle_func),
-        500,
-    );
+    let mut machine =
+        DefaultMachine::<DefaultCoreMachine<u64, SparseMemory<u64>>>::new_with_cost_model(
+            Box::new(dummy_cycle_func),
+            500,
+        );
     machine = machine
         .load_program(&buffer, &vec![b"simple".to_vec()])
         .unwrap();
@@ -89,7 +91,7 @@ pub fn test_simple_invalid_bits() {
     let mut buffer = Vec::new();
     file.read_to_end(&mut buffer).unwrap();
 
-    let result = run::<u64, SparseMemory>(&buffer, &vec![b"simple".to_vec()]);
+    let result = run::<u64, SparseMemory<u64>>(&buffer, &vec![b"simple".to_vec()]);
     assert!(result.is_err());
     assert_eq!(result.unwrap_err(), Error::InvalidElfBits);
 }


### PR DESCRIPTION
While #21 ensures most of the logic happens within register type, memory trait is left out, and we did have logic that [happens outside register type](https://github.com/nervosnetwork/ckb-vm/blob/42e0e13e801fd90409b6532f53d899fe7876d30b/src/instructions/common.rs#L178-L180), this is fixed here to make sure JIT can have all the needed information.