### PR TITLE
refactor: use bits operations to round up/down

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,12 @@ env:
 matrix:
   include:
     - os: osx
-      rust: 1.31.0
+      rust: 1.32.0
       install:
         - cargo fmt --version || rustup component add rustfmt-preview
         - cargo clippy --version || rustup component add clippy-preview
       env: SUITE=ci
-    - rust: 1.31.0
+    - rust: 1.32.0
       addons:
         apt:
           packages:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,11 @@ edition = "2018"
 [dependencies]
 byteorder = "1"
 goblin = "0.0.20"
+
+[dev-dependencies]
+criterion = "0.2.10"
+proptest = "0.9.1"
+
+[[bench]]
+name = "bits_benchmark"
+harness = false

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ The contribution workflow is described in [CONTRIBUTING.md](CONTRIBUTING.md), an
 
 ## How to build
 
+CKB VM is currently tested mainly with `stable-1.32.0` on Linux and Mac OSX.
+
 ```bash
 # download CKB VM
 $ git clone https://github.com/nervosnetwork/ckb-vm

--- a/benches/bits_benchmark.rs
+++ b/benches/bits_benchmark.rs
@@ -1,0 +1,71 @@
+use ckb_vm::bits;
+use criterion::Criterion;
+
+#[inline(always)]
+pub fn roundup_via_remainder(x: usize, round: usize) -> usize {
+    let remainder = x % round;
+    if remainder > 0 {
+        x - remainder + round
+    } else {
+        x - remainder
+    }
+}
+
+#[inline(always)]
+pub fn rounddown_via_remainder(x: usize, round: usize) -> usize {
+    let remainder = x % round;
+    x - remainder
+}
+
+#[inline(always)]
+pub fn roundup_via_multiplication(x: usize, round: usize) -> usize {
+    if x == 0 {
+        0
+    } else {
+        ((x - 1) / round + 1) * round
+    }
+}
+
+#[inline(always)]
+pub fn rounddown_via_multiplication(x: usize, round: usize) -> usize {
+    x / round * round
+}
+
+const ROUNDS: &[usize] = &[1, 2, 4, 8, 16, 32];
+
+macro_rules! round_bench {
+    ($f:expr) => {
+        (0..9999).for_each(|x| {
+            (&ROUNDS).iter().for_each(|round| {
+                $f(x, *round);
+            })
+        })
+    };
+}
+
+fn roundup_benchmark(c: &mut Criterion) {
+    c.bench_function("rounup via remainder", |b| {
+        b.iter(|| round_bench!(roundup_via_remainder))
+    });
+    c.bench_function("rounup via bit ops", |b| {
+        b.iter(|| round_bench!(bits::roundup))
+    });
+    c.bench_function("rounup via multication", |b| {
+        b.iter(|| round_bench!(roundup_via_multiplication))
+    });
+}
+
+fn rounddown_benchmark(c: &mut Criterion) {
+    c.bench_function("rounup via remainder", |b| {
+        b.iter(|| round_bench!(rounddown_via_remainder))
+    });
+    c.bench_function("rounup via bit ops", |b| {
+        b.iter(|| round_bench!(bits::rounddown))
+    });
+    c.bench_function("rounup via multication", |b| {
+        b.iter(|| round_bench!(rounddown_via_multiplication))
+    });
+}
+
+criterion_group!(benches, roundup_benchmark, rounddown_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
```
rounup via remainder    time:   [2.2321 us 2.2439 us 2.2577 us]
                        change: [-5.5708% -3.8512% -2.2337%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe

rounup via bit ops      time:   [0.0000 ps 0.0000 ps 0.0000 ps]
                        change: [-53.351% -6.3284% +86.775%] (p = 0.87 > 0.05)
                        No change in performance detected.
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe

rounup via multication  time:   [2.4807 us 2.5208 us 2.5662 us]
                        change: [+4.8590% +7.3068% +9.9176%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 11 outliers among 100 measurements (11.00%)
  8 (8.00%) high mild
  3 (3.00%) high severe

rounup via remainder    time:   [2.3393 us 2.3603 us 2.3835 us]
                        change: [+5.4361% +7.3216% +9.4704%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

rounup via bit ops      time:   [0.0000 ps 0.0000 ps 0.0000 ps]
                        change: [-46.005% +9.5582% +124.75%] (p = 0.82 > 0.05)
                        No change in performance detected.
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe

rounup via multication  time:   [2.3288 us 2.3491 us 2.3713 us]
                        change: [-10.144% -8.3477% -6.5150%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
```