### PR TITLE
chore: Make JIT into a feature that can be enabled or disabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,13 +28,28 @@ matrix:
             - texinfo
             - libtool
       env: SUITE=ci-quick
-    - rust: 1.32.0
+    - rust: 1.33.0
       addons:
         apt:
           packages:
             - git
             - build-essential
       env: SUITE=ci-asm
+    - rust: 1.33.0
+      addons:
+        apt:
+          packages:
+            - git
+            - build-essential
+      env: SUITE=ci-jit
+    - os: osx
+      rust: 1.33.0
+      addons:
+        apt:
+          packages:
+            - git
+            - build-essential
+      env: SUITE=ci-jit
 
 script:
 - make "$SUITE"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,16 @@ authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 build = "build.rs"
 
+[features]
+default = []
+
+jit = ["memmap", "libc"]
+
 [dependencies]
 byteorder = "1"
 goblin = "0.0.21"
-memmap = "0.7.0"
-libc = "0.2.47"
+memmap = { version = "0.7.0", optional = true }
+libc = { version = "0.2.47", optional = true }
 fnv = "1.0.6"
 
 [build-dependencies]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 test:
 	cargo test --all -- --nocapture
 
+test-jit:
+	cargo test --all --features=jit -- --nocapture
+
 fmt:
 	cargo fmt --all -- --check
 
@@ -11,6 +14,9 @@ ci: fmt clippy test
 	git diff --exit-code Cargo.lock
 
 ci-quick: test
+	git diff --exit-code Cargo.lock
+
+ci-jit: test-jit
 	git diff --exit-code Cargo.lock
 
 ci-asm: src/jit/asm.x64.compiled.c

--- a/build.rs
+++ b/build.rs
@@ -1,13 +1,10 @@
+#[cfg(feature = "jit")]
 use cc::Build;
-use std::env;
 
 fn main() {
-    let target = env::var("TARGET").unwrap();
-    // Right now, JIT only supports linux and Mac OS on x86_64 CPUs
-    if target.contains("x86_64") && (target.contains("linux") || target.contains("darwin")) {
-        Build::new()
-            .file("src/jit/asm.x64.compiled.c")
-            .include("dynasm")
-            .compile("asm");
-    }
+    #[cfg(all(unix, target_pointer_width = "64", feature = "jit"))]
+    Build::new()
+        .file("src/jit/asm.x64.compiled.c")
+        .include("dynasm")
+        .compile("asm");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ pub mod machine;
 pub mod memory;
 pub mod syscalls;
 
-#[cfg(all(unix, target_pointer_width = "64"))]
+#[cfg(feature = "jit")]
 mod jit;
 
 pub use crate::{
@@ -19,7 +19,7 @@ pub use crate::{
 };
 use std::io::{Error as IOError, ErrorKind};
 
-#[cfg(all(unix, target_pointer_width = "64"))]
+#[cfg(feature = "jit")]
 pub use crate::jit::{
     default_jit_machine, BaselineJitMachine, BaselineJitRunData, DefaultTracer, TcgTracer,
 };

--- a/tests/test_jit.rs
+++ b/tests/test_jit.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "jit")]
+
 use ckb_vm::{
     default_jit_machine, BaselineJitMachine, BaselineJitRunData, Error, Instruction, Register,
     SupportMachine, Syscalls, TcgTracer, A0, A1, A2, A3, A4, A5, A7,


### PR DESCRIPTION
This way we can upgrade CKB with latest CKB-VM containing bug fixes, but don't need to worry that JIT related code could bring potential problems for now.