### PR TITLE
Use traces to optimize interpreter performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,12 @@ build = "build.rs"
 [features]
 default = []
 
-jit = ["memmap", "libc"]
+jit = ["fnv", "memmap", "libc"]
 
 [dependencies]
 byteorder = "1"
 goblin = "0.0.21"
+fnv = { version = "1.0.6", optional = true }
 memmap = { version = "0.7.0", optional = true }
 libc = { version = "0.2.47", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ byteorder = "1"
 goblin = "0.0.21"
 memmap = { version = "0.7.0", optional = true }
 libc = { version = "0.2.47", optional = true }
-fnv = "1.0.6"
 
 [build-dependencies]
 cc = "1.0"

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -1,6 +1,6 @@
 // Source: https://en.wikipedia.org/wiki/Bit_manipulation#Example_of_bit_manipulation
 #[inline(always)]
-fn power_of_2(x: usize) -> bool {
+pub fn power_of_2(x: usize) -> bool {
     x > 0 && ((x & (x - 1)) == 0)
 }
 

--- a/src/instructions/common.rs
+++ b/src/instructions/common.rs
@@ -15,8 +15,8 @@ pub fn add<Mac: Machine>(
     rs1: RegisterIndex,
     rs2: RegisterIndex,
 ) {
-    let rs1_value = &machine.registers()[rs1];
-    let rs2_value = &machine.registers()[rs2];
+    let rs1_value = &machine.registers()[rs1 as usize];
+    let rs2_value = &machine.registers()[rs2 as usize];
     let value = rs1_value.overflowing_add(&rs2_value);
     update_register(machine, rd, value);
 }
@@ -27,8 +27,8 @@ pub fn addw<Mac: Machine>(
     rs1: RegisterIndex,
     rs2: RegisterIndex,
 ) {
-    let rs1_value = &machine.registers()[rs1];
-    let rs2_value = &machine.registers()[rs2];
+    let rs1_value = &machine.registers()[rs1 as usize];
+    let rs2_value = &machine.registers()[rs2 as usize];
     let value = rs1_value.overflowing_add(&rs2_value);
     update_register(machine, rd, value.sign_extend(&Mac::REG::from_usize(32)));
 }
@@ -39,8 +39,8 @@ pub fn sub<Mac: Machine>(
     rs1: RegisterIndex,
     rs2: RegisterIndex,
 ) {
-    let rs1_value = &machine.registers()[rs1];
-    let rs2_value = &machine.registers()[rs2];
+    let rs1_value = &machine.registers()[rs1 as usize];
+    let rs2_value = &machine.registers()[rs2 as usize];
     let value = rs1_value.overflowing_sub(&rs2_value);
     update_register(machine, rd, value);
 }
@@ -51,8 +51,8 @@ pub fn subw<Mac: Machine>(
     rs1: RegisterIndex,
     rs2: RegisterIndex,
 ) {
-    let rs1_value = &machine.registers()[rs1];
-    let rs2_value = &machine.registers()[rs2];
+    let rs1_value = &machine.registers()[rs1 as usize];
+    let rs2_value = &machine.registers()[rs2 as usize];
     let value = rs1_value.overflowing_sub(&rs2_value);
     update_register(machine, rd, value.sign_extend(&Mac::REG::from_usize(32)));
 }
@@ -63,7 +63,7 @@ pub fn addi<Mac: Machine>(
     rs1: RegisterIndex,
     imm: Immediate,
 ) {
-    let value = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
+    let value = machine.registers()[rs1 as usize].overflowing_add(&Mac::REG::from_i32(imm));
     update_register(machine, rd, value);
 }
 
@@ -73,7 +73,7 @@ pub fn addiw<Mac: Machine>(
     rs1: RegisterIndex,
     imm: Immediate,
 ) {
-    let value = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
+    let value = machine.registers()[rs1 as usize].overflowing_add(&Mac::REG::from_i32(imm));
     update_register(machine, rd, value.sign_extend(&Mac::REG::from_usize(32)));
 }
 
@@ -86,7 +86,7 @@ pub fn lb<Mac: Machine>(
     rs1: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
+    let address = machine.registers()[rs1 as usize].overflowing_add(&Mac::REG::from_i32(imm));
     let value = machine.memory_mut().load8(&address)?;
     // sign-extened
     update_register(machine, rd, value.sign_extend(&Mac::REG::from_usize(8)));
@@ -99,7 +99,7 @@ pub fn lh<Mac: Machine>(
     rs1: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
+    let address = machine.registers()[rs1 as usize].overflowing_add(&Mac::REG::from_i32(imm));
     let value = machine.memory_mut().load16(&address)?;
     // sign-extened
     update_register(machine, rd, value.sign_extend(&Mac::REG::from_usize(16)));
@@ -112,7 +112,7 @@ pub fn lw<Mac: Machine>(
     rs1: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
+    let address = machine.registers()[rs1 as usize].overflowing_add(&Mac::REG::from_i32(imm));
     let value = machine.memory_mut().load32(&address)?;
     update_register(machine, rd, value.sign_extend(&Mac::REG::from_usize(32)));
     Ok(())
@@ -124,7 +124,7 @@ pub fn ld<Mac: Machine>(
     rs1: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
+    let address = machine.registers()[rs1 as usize].overflowing_add(&Mac::REG::from_i32(imm));
     let value = machine.memory_mut().load64(&address)?;
     update_register(machine, rd, value.sign_extend(&Mac::REG::from_usize(64)));
     Ok(())
@@ -136,7 +136,7 @@ pub fn lbu<Mac: Machine>(
     rs1: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
+    let address = machine.registers()[rs1 as usize].overflowing_add(&Mac::REG::from_i32(imm));
     let value = machine.memory_mut().load8(&address)?;
     update_register(machine, rd, value);
     Ok(())
@@ -148,7 +148,7 @@ pub fn lhu<Mac: Machine>(
     rs1: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
+    let address = machine.registers()[rs1 as usize].overflowing_add(&Mac::REG::from_i32(imm));
     let value = machine.memory_mut().load16(&address)?;
     update_register(machine, rd, value);
     Ok(())
@@ -160,7 +160,7 @@ pub fn lwu<Mac: Machine>(
     rs1: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
+    let address = machine.registers()[rs1 as usize].overflowing_add(&Mac::REG::from_i32(imm));
     let value = machine.memory_mut().load32(&address)?;
     update_register(machine, rd, value);
     Ok(())
@@ -175,8 +175,8 @@ pub fn sb<Mac: Machine>(
     rs2: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
-    let value = machine.registers()[rs2].clone();
+    let address = machine.registers()[rs1 as usize].overflowing_add(&Mac::REG::from_i32(imm));
+    let value = machine.registers()[rs2 as usize].clone();
     machine.memory_mut().store8(&address, &value)?;
     Ok(())
 }
@@ -187,8 +187,8 @@ pub fn sh<Mac: Machine>(
     rs2: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
-    let value = machine.registers()[rs2].clone();
+    let address = machine.registers()[rs1 as usize].overflowing_add(&Mac::REG::from_i32(imm));
+    let value = machine.registers()[rs2 as usize].clone();
     machine.memory_mut().store16(&address, &value)?;
     Ok(())
 }
@@ -199,8 +199,8 @@ pub fn sw<Mac: Machine>(
     rs2: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
-    let value = machine.registers()[rs2].clone();
+    let address = machine.registers()[rs1 as usize].overflowing_add(&Mac::REG::from_i32(imm));
+    let value = machine.registers()[rs2 as usize].clone();
     machine.memory_mut().store32(&address, &value)?;
     Ok(())
 }
@@ -211,8 +211,8 @@ pub fn sd<Mac: Machine>(
     rs2: RegisterIndex,
     imm: Immediate,
 ) -> Result<(), Error> {
-    let address = machine.registers()[rs1].overflowing_add(&Mac::REG::from_i32(imm));
-    let value = machine.registers()[rs2].clone();
+    let address = machine.registers()[rs1 as usize].overflowing_add(&Mac::REG::from_i32(imm));
+    let value = machine.registers()[rs2 as usize].clone();
     machine.memory_mut().store64(&address, &value)?;
     Ok(())
 }
@@ -226,8 +226,8 @@ pub fn and<Mac: Machine>(
     rs1: RegisterIndex,
     rs2: RegisterIndex,
 ) {
-    let rs1_value = machine.registers()[rs1].clone();
-    let rs2_value = machine.registers()[rs2].clone();
+    let rs1_value = machine.registers()[rs1 as usize].clone();
+    let rs2_value = machine.registers()[rs2 as usize].clone();
     let value = rs1_value & rs2_value;
     update_register(machine, rd, value);
 }
@@ -238,8 +238,8 @@ pub fn xor<Mac: Machine>(
     rs1: RegisterIndex,
     rs2: RegisterIndex,
 ) {
-    let rs1_value = machine.registers()[rs1].clone();
-    let rs2_value = machine.registers()[rs2].clone();
+    let rs1_value = machine.registers()[rs1 as usize].clone();
+    let rs2_value = machine.registers()[rs2 as usize].clone();
     let value = rs1_value ^ rs2_value;
     update_register(machine, rd, value);
 }
@@ -250,8 +250,8 @@ pub fn or<Mac: Machine>(
     rs1: RegisterIndex,
     rs2: RegisterIndex,
 ) {
-    let rs1_value = machine.registers()[rs1].clone();
-    let rs2_value = machine.registers()[rs2].clone();
+    let rs1_value = machine.registers()[rs1 as usize].clone();
+    let rs2_value = machine.registers()[rs2 as usize].clone();
     let value = rs1_value | rs2_value;
     update_register(machine, rd, value);
 }
@@ -262,7 +262,7 @@ pub fn andi<Mac: Machine>(
     rs1: RegisterIndex,
     imm: Immediate,
 ) {
-    let value = machine.registers()[rs1].clone() & Mac::REG::from_i32(imm);
+    let value = machine.registers()[rs1 as usize].clone() & Mac::REG::from_i32(imm);
     update_register(machine, rd, value);
 }
 
@@ -272,12 +272,12 @@ pub fn xori<Mac: Machine>(
     rs1: RegisterIndex,
     imm: Immediate,
 ) {
-    let value = machine.registers()[rs1].clone() ^ Mac::REG::from_i32(imm);
+    let value = machine.registers()[rs1 as usize].clone() ^ Mac::REG::from_i32(imm);
     update_register(machine, rd, value);
 }
 
 pub fn ori<Mac: Machine>(machine: &mut Mac, rd: RegisterIndex, rs1: RegisterIndex, imm: Immediate) {
-    let value = machine.registers()[rs1].clone() | Mac::REG::from_i32(imm);
+    let value = machine.registers()[rs1 as usize].clone() | Mac::REG::from_i32(imm);
     update_register(machine, rd, value);
 }
 
@@ -287,7 +287,7 @@ pub fn slli<Mac: Machine>(
     rs1: RegisterIndex,
     shamt: UImmediate,
 ) {
-    let value = machine.registers()[rs1].clone() << Mac::REG::from_u32(shamt);
+    let value = machine.registers()[rs1 as usize].clone() << Mac::REG::from_u32(shamt);
     update_register(machine, rd, value);
 }
 
@@ -297,7 +297,7 @@ pub fn srli<Mac: Machine>(
     rs1: RegisterIndex,
     shamt: UImmediate,
 ) {
-    let value = machine.registers()[rs1].clone() >> Mac::REG::from_u32(shamt);
+    let value = machine.registers()[rs1 as usize].clone() >> Mac::REG::from_u32(shamt);
     update_register(machine, rd, value);
 }
 
@@ -307,7 +307,7 @@ pub fn srai<Mac: Machine>(
     rs1: RegisterIndex,
     shamt: UImmediate,
 ) {
-    let value = machine.registers()[rs1].signed_shr(&Mac::REG::from_u32(shamt));
+    let value = machine.registers()[rs1 as usize].signed_shr(&Mac::REG::from_u32(shamt));
     update_register(machine, rd, value);
 }
 
@@ -317,7 +317,7 @@ pub fn slliw<Mac: Machine>(
     rs1: RegisterIndex,
     shamt: UImmediate,
 ) {
-    let value = machine.registers()[rs1].clone() << Mac::REG::from_u32(shamt);
+    let value = machine.registers()[rs1 as usize].clone() << Mac::REG::from_u32(shamt);
     update_register(machine, rd, value.sign_extend(&Mac::REG::from_usize(32)));
 }
 
@@ -327,7 +327,7 @@ pub fn srliw<Mac: Machine>(
     rs1: RegisterIndex,
     shamt: UImmediate,
 ) {
-    let value = machine.registers()[rs1].zero_extend(&Mac::REG::from_usize(32))
+    let value = machine.registers()[rs1 as usize].zero_extend(&Mac::REG::from_usize(32))
         >> Mac::REG::from_u32(shamt);
     update_register(machine, rd, value.sign_extend(&Mac::REG::from_usize(32)));
 }
@@ -338,7 +338,7 @@ pub fn sraiw<Mac: Machine>(
     rs1: RegisterIndex,
     shamt: UImmediate,
 ) {
-    let value = machine.registers()[rs1]
+    let value = machine.registers()[rs1 as usize]
         .sign_extend(&Mac::REG::from_usize(32))
         .signed_shr(&Mac::REG::from_u32(shamt));
     update_register(machine, rd, value.sign_extend(&Mac::REG::from_usize(32)));

--- a/src/instructions/i.rs
+++ b/src/instructions/i.rs
@@ -686,3 +686,12 @@ pub fn factory<R: Register>(instruction_bits: u32) -> Option<GenericInstruction>
     };
     instruction_opt.map(I)
 }
+
+pub fn nop() -> GenericInstruction {
+    I(Instruction::I(Itype {
+        rs1: 0,
+        rd: 0,
+        imm: 0,
+        inst: ItypeInstruction::ADDI,
+    }))
+}

--- a/src/instructions/i.rs
+++ b/src/instructions/i.rs
@@ -147,15 +147,15 @@ impl Execute for Rtype {
             RtypeInstruction::OR => common::or(machine, self.rd, self.rs1, self.rs2),
             RtypeInstruction::AND => common::and(machine, self.rd, self.rs1, self.rs2),
             RtypeInstruction::SLL => {
-                let shift_value = machine.registers()[self.rs2].clone()
+                let shift_value = machine.registers()[self.rs2 as usize].clone()
                     & Mac::REG::from_usize(Mac::REG::SHIFT_MASK);
-                let value = machine.registers()[self.rs1].clone() << shift_value;
+                let value = machine.registers()[self.rs1 as usize].clone() << shift_value;
                 update_register(machine, self.rd, value);
             }
             RtypeInstruction::SLLW => {
                 let shift_value =
-                    machine.registers()[self.rs2].clone() & Mac::REG::from_usize(0x1F);
-                let value = machine.registers()[self.rs1].clone() << shift_value;
+                    machine.registers()[self.rs2 as usize].clone() & Mac::REG::from_usize(0x1F);
+                let value = machine.registers()[self.rs1 as usize].clone() << shift_value;
                 update_register(
                     machine,
                     self.rd,
@@ -163,15 +163,16 @@ impl Execute for Rtype {
                 );
             }
             RtypeInstruction::SRL => {
-                let shift_value = machine.registers()[self.rs2].clone()
+                let shift_value = machine.registers()[self.rs2 as usize].clone()
                     & Mac::REG::from_usize(Mac::REG::SHIFT_MASK);
-                let value = machine.registers()[self.rs1].clone() >> shift_value;
+                let value = machine.registers()[self.rs1 as usize].clone() >> shift_value;
                 update_register(machine, self.rd, value);
             }
             RtypeInstruction::SRLW => {
                 let shift_value =
-                    machine.registers()[self.rs2].clone() & Mac::REG::from_usize(0x1F);
-                let value = machine.registers()[self.rs1].zero_extend(&Mac::REG::from_usize(32))
+                    machine.registers()[self.rs2 as usize].clone() & Mac::REG::from_usize(0x1F);
+                let value = machine.registers()[self.rs1 as usize]
+                    .zero_extend(&Mac::REG::from_usize(32))
                     >> shift_value;
                 update_register(
                     machine,
@@ -180,15 +181,15 @@ impl Execute for Rtype {
                 );
             }
             RtypeInstruction::SRA => {
-                let shift_value = machine.registers()[self.rs2].clone()
+                let shift_value = machine.registers()[self.rs2 as usize].clone()
                     & Mac::REG::from_usize(Mac::REG::SHIFT_MASK);
-                let value = machine.registers()[self.rs1].signed_shr(&shift_value);
+                let value = machine.registers()[self.rs1 as usize].signed_shr(&shift_value);
                 update_register(machine, self.rd, value);
             }
             RtypeInstruction::SRAW => {
                 let shift_value =
-                    machine.registers()[self.rs2].clone() & Mac::REG::from_usize(0x1F);
-                let value = machine.registers()[self.rs1]
+                    machine.registers()[self.rs2 as usize].clone() & Mac::REG::from_usize(0x1F);
+                let value = machine.registers()[self.rs1 as usize]
                     .sign_extend(&Mac::REG::from_usize(32))
                     .signed_shr(&shift_value);
                 update_register(
@@ -198,14 +199,14 @@ impl Execute for Rtype {
                 );
             }
             RtypeInstruction::SLT => {
-                let rs1_value = &machine.registers()[self.rs1];
-                let rs2_value = &machine.registers()[self.rs2];
+                let rs1_value = &machine.registers()[self.rs1 as usize];
+                let rs2_value = &machine.registers()[self.rs2 as usize];
                 let value = rs1_value.lt_s(&rs2_value);
                 update_register(machine, self.rd, value);
             }
             RtypeInstruction::SLTU => {
-                let rs1_value = &machine.registers()[self.rs1];
-                let rs2_value = &machine.registers()[self.rs2];
+                let rs1_value = &machine.registers()[self.rs1 as usize];
+                let rs2_value = &machine.registers()[self.rs2 as usize];
                 let value = rs1_value.lt(&rs2_value);
                 update_register(machine, self.rd, value);
             }
@@ -230,21 +231,21 @@ impl Execute for Itype {
             ItypeInstruction::ORI => common::ori(machine, self.rd, self.rs1, self.imm),
             ItypeInstruction::ANDI => common::andi(machine, self.rd, self.rs1, self.imm),
             ItypeInstruction::SLTI => {
-                let rs1_value = &machine.registers()[self.rs1];
+                let rs1_value = &machine.registers()[self.rs1 as usize];
                 let imm_value = Mac::REG::from_i32(self.imm);
                 let value = rs1_value.lt_s(&imm_value);
                 update_register(machine, self.rd, value);
             }
             ItypeInstruction::SLTIU => {
-                let rs1_value = &machine.registers()[self.rs1];
+                let rs1_value = &machine.registers()[self.rs1 as usize];
                 let imm_value = Mac::REG::from_i32(self.imm);
                 let value = rs1_value.lt(&imm_value);
                 update_register(machine, self.rd, value);
             }
             ItypeInstruction::JALR => {
                 let link = machine.pc().overflowing_add(&Mac::REG::from_usize(4));
-                let mut next_pc =
-                    machine.registers()[self.rs1].overflowing_add(&Mac::REG::from_i32(self.imm));
+                let mut next_pc = machine.registers()[self.rs1 as usize]
+                    .overflowing_add(&Mac::REG::from_i32(self.imm));
                 next_pc = next_pc & (!Mac::REG::one());
                 update_register(machine, self.rd, link);
                 return Ok(Some(next_pc));
@@ -294,8 +295,8 @@ impl Execute for Stype {
 
 impl Execute for Btype {
     fn execute<Mac: Machine>(&self, machine: &mut Mac) -> Result<Option<Mac::REG>, Error> {
-        let rs1_value = &machine.registers()[self.rs1];
-        let rs2_value = &machine.registers()[self.rs2];
+        let rs1_value = &machine.registers()[self.rs1 as usize];
+        let rs2_value = &machine.registers()[self.rs2 as usize];
         let condition = match &self.inst {
             BtypeInstruction::BEQ => rs1_value.eq(&rs2_value),
             BtypeInstruction::BNE => rs1_value.ne(&rs2_value),
@@ -615,19 +616,19 @@ pub fn factory<R: Register>(instruction_bits: u32) -> Option<GenericInstruction>
                     0b_101 => Some(Instruction::CsrI(CsrIType {
                         csr,
                         rd,
-                        zimm: rs1_zimm as u32,
+                        zimm: u32::from(rs1_zimm),
                         inst: CsrIInstruction::CSRRWI,
                     })),
                     0b_110 => Some(Instruction::CsrI(CsrIType {
                         csr,
                         rd,
-                        zimm: rs1_zimm as u32,
+                        zimm: u32::from(rs1_zimm),
                         inst: CsrIInstruction::CSRRSI,
                     })),
                     0b_111 => Some(Instruction::CsrI(CsrIType {
                         csr,
                         rd,
-                        zimm: rs1_zimm as u32,
+                        zimm: u32::from(rs1_zimm),
                         inst: CsrIInstruction::CSRRCI,
                     })),
                     _ => None,

--- a/src/instructions/i.rs
+++ b/src/instructions/i.rs
@@ -7,7 +7,7 @@ use super::utils::{
 use super::Register;
 use super::{
     common, Execute, Immediate, Instruction as GenericInstruction, Instruction::I, RegisterIndex,
-    UImmediate,
+    UImmediate, UShortImmediate,
 };
 
 #[derive(Debug)]
@@ -113,11 +113,11 @@ type ItypeShift = super::ItypeShift<Immediate, ItypeShiftInstruction>;
 // as viewed by other RISC- V harts and external devices or coprocessors.
 #[derive(Debug)]
 pub struct FenceType {
-    fm: u32,
+    fm: u8,
     // predecessor
-    pred: u32,
+    pred: u8,
     // successor
-    succ: u32,
+    succ: u8,
 }
 
 #[derive(Debug)]
@@ -130,8 +130,8 @@ pub struct CsrType {
 
 #[derive(Debug)]
 pub struct CsrIType {
-    csr: UImmediate,
-    zimm: UImmediate,
+    csr: UShortImmediate,
+    zimm: UShortImmediate,
     rd: RegisterIndex,
     inst: CsrIInstruction,
 }
@@ -575,9 +575,9 @@ pub fn factory<R: Register>(instruction_bits: u32) -> Option<GenericInstruction>
                 Some(Instruction::FENCEI)
             } else if instruction_bits & 0x000_FFFFF == FENCE_LOW_BITS {
                 Some(Instruction::Fence(FenceType {
-                    fm: (instruction_bits & 0xF00_00000) >> 28,
-                    pred: (instruction_bits & 0x0F0_00000) >> 24,
-                    succ: (instruction_bits & 0x00F_00000) >> 20,
+                    fm: ((instruction_bits & 0xF00_00000) >> 28) as u8,
+                    pred: ((instruction_bits & 0x0F0_00000) >> 24) as u8,
+                    succ: ((instruction_bits & 0x00F_00000) >> 20) as u8,
                 }))
             } else {
                 None
@@ -614,21 +614,21 @@ pub fn factory<R: Register>(instruction_bits: u32) -> Option<GenericInstruction>
                         inst: CsrInstruction::CSRRC,
                     })),
                     0b_101 => Some(Instruction::CsrI(CsrIType {
-                        csr,
+                        csr: csr as u16,
                         rd,
-                        zimm: u32::from(rs1_zimm),
+                        zimm: u16::from(rs1_zimm),
                         inst: CsrIInstruction::CSRRWI,
                     })),
                     0b_110 => Some(Instruction::CsrI(CsrIType {
-                        csr,
+                        csr: csr as u16,
                         rd,
-                        zimm: u32::from(rs1_zimm),
+                        zimm: u16::from(rs1_zimm),
                         inst: CsrIInstruction::CSRRSI,
                     })),
                     0b_111 => Some(Instruction::CsrI(CsrIType {
-                        csr,
+                        csr: csr as u16,
                         rd,
-                        zimm: u32::from(rs1_zimm),
+                        zimm: u16::from(rs1_zimm),
                         inst: CsrIInstruction::CSRRCI,
                     })),
                     _ => None,

--- a/src/instructions/m.rs
+++ b/src/instructions/m.rs
@@ -28,8 +28,8 @@ pub struct Instruction(pub Rtype);
 
 impl Execute for Rtype {
     fn execute<Mac: Machine>(&self, machine: &mut Mac) -> Result<Option<Mac::REG>, Error> {
-        let rs1_value = &machine.registers()[self.rs1];
-        let rs2_value = &machine.registers()[self.rs2];
+        let rs1_value = &machine.registers()[self.rs1 as usize];
+        let rs2_value = &machine.registers()[self.rs2 as usize];
         match &self.inst {
             RtypeInstruction::MUL => {
                 let value = rs1_value.overflowing_mul(&rs2_value);

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -61,7 +61,7 @@ pub trait Execute {
     fn execute<Mac: Machine>(&self, machine: &mut Mac) -> Result<Option<Mac::REG>, Error>;
 }
 
-type RegisterIndex = usize;
+type RegisterIndex = u8;
 type Immediate = i32;
 type UImmediate = u32;
 

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -64,6 +64,7 @@ pub trait Execute {
 type RegisterIndex = u8;
 type Immediate = i32;
 type UImmediate = u32;
+type UShortImmediate = u16;
 
 //
 //  31       27 26 25 24     20 19    15 14    12 11          7 6      0

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -13,13 +13,17 @@ use std::fmt::{self, Display};
 
 #[derive(Debug)]
 pub enum Instruction {
-    // Empty instruction serves as a marker to denote no instruction is here.
-    // Although nop serves the same purpose, this allows us to skip many method
-    // calls and return directly.
-    Empty,
     RVC(rvc::Instruction),
     I(i::Instruction),
     M(m::Instruction),
+}
+
+impl Default for Instruction {
+    fn default() -> Self {
+        // Default instruction is NOP, note that we don't use NOP from RVC,
+        // since it's more likely every chip will implement I than RVC.
+        i::nop()
+    }
 }
 
 impl Instruction {
@@ -28,21 +32,7 @@ impl Instruction {
             Instruction::I(instruction) => instruction.execute(machine),
             Instruction::M(instruction) => instruction.execute(machine),
             Instruction::RVC(instruction) => instruction.execute(machine),
-            Instruction::Empty => Ok(()),
         }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        match self {
-            Instruction::Empty => true,
-            _ => false,
-        }
-    }
-}
-
-impl Default for Instruction {
-    fn default() -> Self {
-        Instruction::Empty
     }
 }
 
@@ -189,7 +179,6 @@ pub fn is_basic_block_end_instruction(i: &Instruction) -> bool {
             _ => false,
         },
         Instruction::M(_) => false,
-        Instruction::Empty => false,
     }
 }
 

--- a/src/instructions/utils.rs
+++ b/src/instructions/utils.rs
@@ -28,18 +28,18 @@ pub fn funct7(instruction_bits: u32) -> u32 {
 }
 
 #[inline(always)]
-pub fn rd(instruction_bits: u32) -> usize {
-    x(instruction_bits, 7, 5, 0) as usize
+pub fn rd(instruction_bits: u32) -> u8 {
+    x(instruction_bits, 7, 5, 0) as u8
 }
 
 #[inline(always)]
-pub fn rs1(instruction_bits: u32) -> usize {
-    x(instruction_bits, 15, 5, 0) as usize
+pub fn rs1(instruction_bits: u32) -> u8 {
+    x(instruction_bits, 15, 5, 0) as u8
 }
 
 #[inline(always)]
-pub fn rs2(instruction_bits: u32) -> usize {
-    x(instruction_bits, 20, 5, 0) as usize
+pub fn rs2(instruction_bits: u32) -> u8 {
+    x(instruction_bits, 20, 5, 0) as u8
 }
 
 #[inline(always)]
@@ -73,8 +73,8 @@ pub fn utype_immediate(instruction_bits: u32) -> i32 {
     xs(instruction_bits, 12, 20, 12) as i32
 }
 
-pub fn update_register<M: Machine>(machine: &mut M, register_index: usize, value: M::REG) {
-    let register_index = register_index % RISCV_GENERAL_REGISTER_NUMBER;
+pub fn update_register<M: Machine>(machine: &mut M, register_index: u8, value: M::REG) {
+    let register_index = register_index as usize % RISCV_GENERAL_REGISTER_NUMBER;
     // In RISC-V, x0 is a special zero register with the following properties:
     //
     // * All writes to this register are silently ignored

--- a/src/jit/instructions.rs
+++ b/src/jit/instructions.rs
@@ -11,6 +11,5 @@ pub fn is_jitable_instruction(i: &Instruction) -> bool {
             _ => true,
         },
         Instruction::M(_) => true,
-        Instruction::Empty => false,
     }
 }

--- a/src/jit/instructions.rs
+++ b/src/jit/instructions.rs
@@ -11,38 +11,6 @@ pub fn is_jitable_instruction(i: &Instruction) -> bool {
             _ => true,
         },
         Instruction::M(_) => true,
-    }
-}
-
-pub fn is_basic_block_end_instruction(i: &Instruction) -> bool {
-    match i {
-        Instruction::I(i) => match i {
-            i::Instruction::I(i) => match i.inst() {
-                i::ItypeInstruction::JALR => true,
-                _ => false,
-            },
-            i::Instruction::B(_) => true,
-            i::Instruction::Env(_) => true,
-            i::Instruction::JAL { .. } => true,
-            _ => false,
-        },
-        Instruction::RVC(i) => match i {
-            rvc::Instruction::BEQZ { .. } => true,
-            rvc::Instruction::BNEZ { .. } => true,
-            rvc::Instruction::JAL { .. } => true,
-            rvc::Instruction::J { .. } => true,
-            rvc::Instruction::JR { .. } => true,
-            rvc::Instruction::JALR { .. } => true,
-            rvc::Instruction::EBREAK => true,
-            _ => false,
-        },
-        Instruction::M(_) => false,
-    }
-}
-
-pub fn instruction_length(i: &Instruction) -> usize {
-    match i {
-        Instruction::RVC(_) => 2,
-        _ => 4,
+        Instruction::Empty => false,
     }
 }

--- a/src/jit/machine.rs
+++ b/src/jit/machine.rs
@@ -1,13 +1,9 @@
-use super::{
-    emitter::Emitter,
-    instructions::{instruction_length, is_basic_block_end_instruction, is_jitable_instruction},
-    tracer::Tracer,
-    value::Value,
-};
+use super::{emitter::Emitter, instructions::is_jitable_instruction, tracer::Tracer, value::Value};
 use crate::{
-    decoder::build_imac_decoder, CoreMachine, DefaultMachineBuilder, Error, InstructionCycleFunc,
-    Machine, Memory, Register, SparseMemory, SupportMachine, Syscalls,
-    RISCV_GENERAL_REGISTER_NUMBER,
+    decoder::build_imac_decoder,
+    instructions::{instruction_length, is_basic_block_end_instruction},
+    CoreMachine, DefaultMachineBuilder, Error, InstructionCycleFunc, Machine, Memory, Register,
+    SparseMemory, SupportMachine, Syscalls, RISCV_GENERAL_REGISTER_NUMBER,
 };
 use fnv::FnvHashMap;
 use libc::{c_int, uint64_t};

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -428,6 +428,9 @@ impl<'a, Inner: SupportMachine> DefaultMachine<'a, Inner> {
                 traces[slot].address = pc;
             }
             for i in &traces[slot].instructions {
+                if let Instruction::Empty = i {
+                    break;
+                }
                 i.execute(self)?;
                 let cycles = self
                     .instruction_cycle_func

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -485,3 +485,17 @@ impl<'a, Inner> DefaultMachineBuilder<'a, Inner> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::bits::power_of_2;
+
+    #[test]
+    fn test_trace_constant_rules() {
+        assert!(power_of_2(TRACE_SIZE));
+        assert_eq!(TRACE_MASK, TRACE_SIZE - 1);
+        assert!(power_of_2(TRACE_ITEM_LENGTH));
+        assert_eq!(TRACE_ITEM_LENGTH, 1 << TRACE_ADDRESS_SHIFTS);
+    }
+}

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -488,8 +488,8 @@ impl<'a, Inner> DefaultMachineBuilder<'a, Inner> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::bits::power_of_2;
+    use super::*;
 
     #[test]
     fn test_trace_constant_rules() {

--- a/tests/test_simple.rs
+++ b/tests/test_simple.rs
@@ -40,11 +40,8 @@ pub fn test_simple_instructions_flatmemory() {
     assert_eq!(result.unwrap(), 0);
 }
 
-fn dummy_cycle_func(i: &Instruction) -> u64 {
-    match i {
-        Instruction::Empty => 0,
-        _ => 1,
-    }
+fn dummy_cycle_func(_i: &Instruction) -> u64 {
+    1
 }
 
 #[test]

--- a/tests/test_simple.rs
+++ b/tests/test_simple.rs
@@ -40,8 +40,11 @@ pub fn test_simple_instructions_flatmemory() {
     assert_eq!(result.unwrap(), 0);
 }
 
-fn dummy_cycle_func(_i: &Instruction) -> u64 {
-    1
+fn dummy_cycle_func(i: &Instruction) -> u64 {
+    match i {
+        Instruction::Empty => 0,
+        _ => 1,
+    }
 }
 
 #[test]


### PR DESCRIPTION
Note this is actually at the same level of performance comparing to our currently deployed [version](https://github.com/nervosnetwork/ckb-vm/tree/simple-decoder-cache-64-2) using decoder cache. But the advantage of this solution here, is that we are using fixed length vector instead of a dynamically grown HashMap, hence we will have a fixed upper bound on the memory usage when running any arbitrary scripts.