### PR TITLE
fix: flat memory implementation stores byte in wrong locations

### DIFF
--- a/src/memory/flat.rs
+++ b/src/memory/flat.rs
@@ -65,7 +65,7 @@ impl<R: Register> Memory<R> for FlatMemory<R> {
         }
         // This is essentially memset call
         unsafe {
-            let slice_ptr = self[..size].as_mut_ptr();
+            let slice_ptr = self[addr..addr + size].as_mut_ptr();
             ptr::write_bytes(slice_ptr, b'0', size);
         }
         Ok(())
@@ -182,7 +182,7 @@ impl<R: Register> Memory<R> for FlatMemory<R> {
         }
         // This is essentially memset call
         unsafe {
-            let slice_ptr = self[..size].as_mut_ptr();
+            let slice_ptr = self[addr..addr + size].as_mut_ptr();
             ptr::write_bytes(slice_ptr, value, size);
         }
         Ok(())


### PR DESCRIPTION
As far as I can know, `slice_ptr` should start from `addr`.