### PR TITLE
chore: fix a bad way to using machine

### DIFF
--- a/src/instructions/execute.rs
+++ b/src/instructions/execute.rs
@@ -639,8 +639,8 @@ pub fn execute<Mac: Machine>(inst: Instruction, machine: &mut Mac) -> Result<(),
         }
         insts::OP_RVC_MV => {
             let i = Rtype(inst);
-            let value = &machine.registers()[i.rs2()];
-            update_register(machine, i.rd(), value.clone());
+            let value = machine.registers()[i.rs2()].clone();
+            update_register(machine, i.rd(), value);
             None
         }
         insts::OP_RVC_JAL => {


### PR DESCRIPTION
The old codes:

```rs
let value = &machine.registers()[i.rs2()]; // immutable borrow machine
update_register(machine, i.rd(), value.clone()); // mutable borrow machine in first argument, and immutable borrow in third argument "value"
```