### PR TITLE
fix: fix the broken bench tests

### DIFF
--- a/benches/vm_benchmark.rs
+++ b/benches/vm_benchmark.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate criterion;
 
+use bytes::Bytes;
 use ckb_vm::{run, SparseMemory};
 use criterion::Criterion;
 use std::fs::File;
@@ -12,13 +13,14 @@ fn interpret_benchmark(c: &mut Criterion) {
         let mut buffer = Vec::new();
         file.read_to_end(&mut buffer).unwrap();
 
-        let args: Vec<Vec<u8>> = vec!["secp256k1_bench",
+        let buffer = Bytes::from(buffer);
+        let args: Vec<Bytes> = vec!["secp256k1_bench",
                                       "033f8cf9c4d51a33206a6c1c6b27d2cc5129daa19dbd1fc148d395284f6b26411f",
                                       "304402203679d909f43f073c7c1dcf8468a485090589079ee834e6eed92fea9b09b06a2402201e46f1075afa18f306715e7db87493e7b7e779569aa13c64ab3d09980b3560a3",
                                       "foo",
                                       "bar"].into_iter().map(|a| a.into()).collect();
 
-        b.iter(|| run::<u64, SparseMemory<u64>>(&buffer, &args).unwrap());
+        b.iter(|| run::<u64, SparseMemory<u64>>(&buffer, &args[..]).unwrap());
     });
 }
 


### PR DESCRIPTION
Since the method `run` accepts `Bytes` instead of `Vec<u8>`