### PR TITLE
test: add code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 Cargo.lock
 .deps/
 /examples/is13
+.vscode/

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,36 @@ matrix:
             - git
             - build-essential
       env: SUITE=ci-all-features
+    - name: Code Coverage
+      rust: 1.33.0
+      sudo: true
+      before_install:
+        - sudo apt-get update
+      addons:
+        apt:
+          packages:
+            - git
+            - build-essential
+            - libcurl4-openssl-dev
+            - libelf-dev
+            - libdw-dev
+            - cmake
+            - gcc
+            - binutils-dev
+      script:
+        wget https://github.com/SimonKagstrom/kcov/archive/v36.tar.gz &&
+        tar xzf v36.tar.gz &&
+        cd kcov-36 &&
+        mkdir build &&
+        cd build &&
+        cmake .. &&
+        make &&
+        sudo make install &&
+        cd ../.. &&
+        rm -rf kcov-36 v36.tar.gz &&
+        make cov &&
+        bash <(curl -s https://codecov.io/bash) &&
+        echo "Uploaded code coverage"
 
 script:
 - make "$SUITE"

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ test:
 test-all-features:
 	cargo test --all --features=jit,asm -- --nocapture
 
+cov: test-all-features
+	for file in target/debug/test_*-*[^\.d]; do mkdir -p "target/cov/$$(basename $$file)"; kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$$(basename $$file)" "$$file"; done
+	for file in target/debug/ckb_vm*-*[^\.d]; do mkdir -p "target/cov/$$(basename $$file)"; kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$$(basename $$file)" "$$file"; done
+
 fmt:
 	cargo fmt --all -- --check
 	cd definitions && cargo fmt ${VERBOSE} --all -- --check


### PR DESCRIPTION
https://github.com/nervosnetwork/ckb/pull/943

Using kcov instead of tarpaulin, because it's for compiled programs not only Rust, and we can also compare with tarpaulin for a while.