### PR TITLE
Replace custom power_of_2 function with std

### DIFF
--- a/src/bits.rs
+++ b/src/bits.rs
@@ -1,19 +1,13 @@
-// Source: https://en.wikipedia.org/wiki/Bit_manipulation#Example_of_bit_manipulation
-#[inline(always)]
-pub fn power_of_2(x: usize) -> bool {
-    x > 0 && ((x & (x - 1)) == 0)
-}
-
 #[inline(always)]
 pub fn roundup(x: usize, round: usize) -> usize {
-    debug_assert!(power_of_2(round));
+    debug_assert!(round.is_power_of_two());
     // x + (((!x) + 1) & (round - 1))
     x + ((!x).wrapping_add(1) & (round.wrapping_sub(1)))
 }
 
 #[inline(always)]
 pub fn rounddown(x: usize, round: usize) -> usize {
-    debug_assert!(power_of_2(round));
+    debug_assert!(round.is_power_of_two());
     // x & !(round - 1)
     x & !(round.wrapping_sub(1))
 }
@@ -22,21 +16,6 @@ pub fn rounddown(x: usize, round: usize) -> usize {
 mod tests {
     use super::*;
     use proptest::prelude::*;
-
-    #[test]
-    fn test_power_of_2() {
-        let test_cases = [
-            (0, false),
-            (1, true),
-            (2, true),
-            (3, false),
-            (4, true),
-            (5, false),
-        ];
-        for test_case in test_cases.iter() {
-            assert_eq!(test_case.1, power_of_2(test_case.0))
-        }
-    }
 
     #[test]
     fn test_roundup() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,6 @@ pub fn run<R: Register, M: Memory<R> + Default>(
 
 #[cfg(test)]
 mod tests {
-    use super::bits::power_of_2;
     use super::*;
 
     #[test]
@@ -76,6 +75,6 @@ mod tests {
 
     #[test]
     fn test_page_size_be_power_of_2() {
-        assert!(power_of_2(RISCV_PAGESIZE));
+        assert!(RISCV_PAGESIZE.is_power_of_two());
     }
 }

--- a/src/machine/trace.rs
+++ b/src/machine/trace.rs
@@ -143,14 +143,13 @@ impl<'a, R: Register, M: Memory<R>, Inner: SupportMachine<REG = R, MEM = WXorXMe
 
 #[cfg(test)]
 mod tests {
-    use super::super::super::bits::power_of_2;
     use super::*;
 
     #[test]
     fn test_trace_constant_rules() {
-        assert!(power_of_2(TRACE_SIZE));
+        assert!(TRACE_SIZE.is_power_of_two());
         assert_eq!(TRACE_MASK, TRACE_SIZE - 1);
-        assert!(power_of_2(TRACE_ITEM_LENGTH));
+        assert!(TRACE_ITEM_LENGTH.is_power_of_two());
         assert!(TRACE_ITEM_LENGTH <= 255);
     }
 }


### PR DESCRIPTION
Implementation is only different in ways that are inconsequential for how they
are used here.

Custom:

```
#[inline(always)]
pub fn power_of_2(x: usize) -> bool {
    x > 0 && ((x & (x - 1)) == 0)
}
```

std:

```
#[inline]
pub fn is_power_of_two(self) -> bool {
    (self.wrapping_sub(1)) & self == 0 && !(self == 0)
}
```