### PR TITLE
Replace uses of rounddown / roundup with round_page_down / round_page_up

### DIFF
--- a/src/machine/asm/mod.rs
+++ b/src/machine/asm/mod.rs
@@ -1,11 +1,11 @@
 use crate::{
-    bits::{rounddown, roundup},
     decoder::build_imac_decoder,
     instructions::{
         blank_instruction, extract_opcode, instruction_length, is_basic_block_end_instruction,
     },
     memory::{
-        check_permission, fill_page_data, memset, FLAG_EXECUTABLE, FLAG_FREEZED, FLAG_WRITABLE,
+        check_permission, fill_page_data, memset, round_page_down, round_page_up, FLAG_EXECUTABLE,
+        FLAG_FREEZED, FLAG_WRITABLE,
     },
     CoreMachine, DefaultMachine, Error, Machine, Memory, SupportMachine, RISCV_MAX_MEMORY,
     RISCV_PAGES, RISCV_PAGESIZE,
@@ -61,9 +61,7 @@ impl Memory<u64> for Box<AsmCoreMachine> {
         source: Option<Bytes>,
         offset_from_addr: u64,
     ) -> Result<(), Error> {
-        if rounddown(addr, RISCV_PAGESIZE as u64) != addr
-            || roundup(size, RISCV_PAGESIZE as u64) != size
-        {
+        if round_page_down(addr) != addr || round_page_up(size) != size {
             return Err(Error::Unaligned);
         }
         if addr > RISCV_MAX_MEMORY as u64

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1,4 +1,7 @@
-use super::{bits::rounddown, Error, Register, RISCV_PAGESIZE};
+use super::{
+    bits::{rounddown, roundup},
+    Error, Register, RISCV_PAGESIZE,
+};
 use bytes::Bytes;
 use std::cmp::min;
 use std::ptr;
@@ -12,8 +15,13 @@ pub use ckb_vm_definitions::memory::{
 };
 
 #[inline(always)]
-pub fn round_page(x: u64) -> u64 {
-    x & (!(RISCV_PAGESIZE as u64 - 1))
+pub fn round_page_down(x: u64) -> u64 {
+    rounddown(x, RISCV_PAGESIZE as u64)
+}
+
+#[inline(always)]
+pub fn round_page_up(x: u64) -> u64 {
+    roundup(x, RISCV_PAGESIZE as u64)
 }
 
 pub type Page = [u8; RISCV_PAGESIZE];
@@ -81,7 +89,7 @@ pub fn check_permission<R: Register>(
     flag: u8,
 ) -> Result<(), Error> {
     let e = addr + size;
-    let mut current_addr = rounddown(addr, RISCV_PAGESIZE as u64);
+    let mut current_addr = round_page_down(addr);
     while current_addr < e {
         let page = current_addr / RISCV_PAGESIZE as u64;
         let page_flag = memory.fetch_flag(page)?;

--- a/src/memory/sparse.rs
+++ b/src/memory/sparse.rs
@@ -1,5 +1,5 @@
 use super::super::{Error, Register, RISCV_PAGES, RISCV_PAGESIZE};
-use super::{fill_page_data, memset, round_page, Memory, Page};
+use super::{fill_page_data, memset, round_page_down, Memory, Page};
 
 use bytes::Bytes;
 use std::cmp::min;
@@ -45,7 +45,7 @@ impl<R> SparseMemory<R> {
 
     fn load(&mut self, addr: u64, bytes: u64) -> Result<u64, Error> {
         debug_assert!(bytes == 1 || bytes == 2 || bytes == 4 || bytes == 8);
-        let page_addr = round_page(addr);
+        let page_addr = round_page_down(addr);
         let first_page_bytes = min(bytes, RISCV_PAGESIZE as u64 - (addr - page_addr));
         let mut shift = 0;
         let mut value: u64 = 0;
@@ -118,7 +118,7 @@ impl<R: Register> Memory<R> for SparseMemory<R> {
 
     fn store_bytes(&mut self, addr: u64, value: &[u8]) -> Result<(), Error> {
         let mut remaining_data = value;
-        let mut current_page_addr = round_page(addr);
+        let mut current_page_addr = round_page_down(addr);
         let mut current_page_offset = addr - current_page_addr;
         while !remaining_data.is_empty() {
             let page = self.fetch_page(current_page_addr)?;
@@ -138,7 +138,7 @@ impl<R: Register> Memory<R> for SparseMemory<R> {
     }
 
     fn store_byte(&mut self, addr: u64, size: u64, value: u8) -> Result<(), Error> {
-        let mut current_page_addr = round_page(addr);
+        let mut current_page_addr = round_page_down(addr);
         let mut current_page_offset = addr - current_page_addr;
         let mut remaining_size = size;
         while remaining_size > 0 {

--- a/src/memory/wxorx.rs
+++ b/src/memory/wxorx.rs
@@ -1,8 +1,8 @@
-use super::super::{
-    bits::{rounddown, roundup},
-    Error, Register, RISCV_MAX_MEMORY, RISCV_PAGES, RISCV_PAGESIZE,
+use super::super::{Error, Register, RISCV_MAX_MEMORY, RISCV_PAGES, RISCV_PAGESIZE};
+use super::{
+    check_permission, round_page_down, round_page_up, Memory, FLAG_EXECUTABLE, FLAG_FREEZED,
+    FLAG_WRITABLE,
 };
-use super::{check_permission, Memory, FLAG_EXECUTABLE, FLAG_FREEZED, FLAG_WRITABLE};
 
 use bytes::Bytes;
 use std::marker::PhantomData;
@@ -32,9 +32,7 @@ impl<R: Register, M: Memory<R>> Memory<R> for WXorXMemory<R, M> {
         source: Option<Bytes>,
         offset_from_addr: u64,
     ) -> Result<(), Error> {
-        if rounddown(addr, RISCV_PAGESIZE as u64) != addr
-            || roundup(size, RISCV_PAGESIZE as u64) != size
-        {
+        if round_page_down(addr) != addr || round_page_up(size) != size {
             return Err(Error::Unaligned);
         }
         if addr > RISCV_MAX_MEMORY as u64


### PR DESCRIPTION
There was already an implementation of round_page_down that duplicated rounddown. This cleanup patch adds round_page_up and makes all rounddown / roundup uses call the round_page versions.