### PR TITLE
Add coverage CI job containing full CKB VM test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,7 @@ matrix:
         ln -snf .. ckb-vm-test-suite/ckb-vm &&
         sudo docker run --rm -v `pwd`:/code xxuejie/riscv-gnu-toolchain-rv64imac:xenial-20190606 cp -r /riscv /code/riscv &&
         RISCV=`pwd`/riscv ./ckb-vm-test-suite/test.sh --coverage &&
+        make cov &&
         bash <(curl -s https://codecov.io/bash) &&
         echo "Uploaded code coverage"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,30 @@ matrix:
             - git
             - build-essential
       env: SUITE=ci-all-features
+    - name: Test Suite
+      rust: 1.35.0
+      dist: xenial
+      addons:
+        apt:
+          packages:
+            - git
+            - build-essential
+            - autoconf
+            - automake
+            - autotools-dev
+            - libmpc-dev
+            - libmpfr-dev
+            - libgmp-dev
+            - gawk
+            - libtool
+            - patchutils
+            - libexpat-dev
+            - zlib1g-dev
+      script:
+        git clone --recursive https://github.com/nervosnetwork/ckb-vm-test-suite &&
+        ln -snf .. ckb-vm-test-suite/ckb-vm &&
+        sudo docker run --rm -v `pwd`:/code xxuejie/riscv-gnu-toolchain-rv64imac:xenial-20190606 cp -r /riscv /code/riscv &&
+        RISCV=`pwd`/riscv ./ckb-vm-test-suite/test.sh
     - name: Code Coverage
       rust: 1.35.0
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,46 @@ matrix:
             - git
             - build-essential
       env: SUITE=ci-all-features
-
+    - name: Code Coverage
+      rust: 1.35.0
+      dist: xenial
+      addons:
+        apt:
+          packages:
+            - git
+            - build-essential
+            - autoconf
+            - automake
+            - autotools-dev
+            - libmpc-dev
+            - libmpfr-dev
+            - libgmp-dev
+            - gawk
+            - libtool
+            - patchutils
+            - libexpat-dev
+            - binutils-dev
+            - libcurl4-openssl-dev
+            - zlib1g-dev
+            - libdw-dev
+            - libiberty-dev
+      script:
+        wget https://github.com/SimonKagstrom/kcov/archive/v36.tar.gz &&
+        tar xzf v36.tar.gz &&
+        cd kcov-36 &&
+        mkdir build &&
+        cd build &&
+        cmake .. &&
+        make &&
+        sudo make install &&
+        cd ../.. &&
+        rm -rf kcov-36 v36.tar.gz &&
+        git clone --recursive https://github.com/nervosnetwork/ckb-vm-test-suite &&
+        ln -snf .. ckb-vm-test-suite/ckb-vm &&
+        sudo docker run --rm -v `pwd`:/code xxuejie/riscv-gnu-toolchain-rv64imac:xenial-20190606 cp -r /riscv /code/riscv &&
+        RISCV=`pwd`/riscv ./ckb-vm-test-suite/test.sh --coverage &&
+        bash <(curl -s https://codecov.io/bash) &&
+        echo "Uploaded code coverage"
 script:
 - make "$SUITE"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ matrix:
       script:
         git clone --recursive https://github.com/nervosnetwork/ckb-vm-test-suite &&
         ln -snf .. ckb-vm-test-suite/ckb-vm &&
-        sudo docker run --rm -v `pwd`:/code xxuejie/riscv-gnu-toolchain-rv64imac:xenial-20190606 cp -r /riscv /code/riscv &&
+        docker run --rm -v `pwd`:/code xxuejie/riscv-gnu-toolchain-rv64imac:xenial-20190606 cp -r /riscv /code/riscv &&
         RISCV=`pwd`/riscv ./ckb-vm-test-suite/test.sh
     - name: Code Coverage
       rust: 1.35.0
@@ -110,7 +110,7 @@ matrix:
         rm -rf kcov-36 v36.tar.gz &&
         git clone --recursive https://github.com/nervosnetwork/ckb-vm-test-suite &&
         ln -snf .. ckb-vm-test-suite/ckb-vm &&
-        sudo docker run --rm -v `pwd`:/code xxuejie/riscv-gnu-toolchain-rv64imac:xenial-20190606 cp -r /riscv /code/riscv &&
+        docker run --rm -v `pwd`:/code xxuejie/riscv-gnu-toolchain-rv64imac:xenial-20190606 cp -r /riscv /code/riscv &&
         RISCV=`pwd`/riscv ./ckb-vm-test-suite/test.sh --coverage &&
         make cov &&
         bash <(curl -s https://codecov.io/bash) &&

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,13 @@ test:
 test-all-features:
 	cargo test --all --features=jit,asm -- --nocapture
 
+# JIT code is considered experimental right now, hence coverage
+# would skip it.
+cov:
+	cargo clean
+	cargo test --all --features=asm -- --nocapture
+	for file in `find target/debug/ -maxdepth 1 -executable -type f`; do mkdir -p "target/cov/$$(basename $$file)"; kcov --exclude-pattern=/.cargo,/usr/lib "target/cov/$$(basename $$file)" "$$file"; done
+
 fmt:
 	cargo fmt --all -- --check
 	cd definitions && cargo fmt ${VERBOSE} --all -- --check

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test-all-features:
 cov:
 	cargo clean
 	cargo test --all --features=asm -- --nocapture
-	for file in `find target/debug/ -maxdepth 1 -executable -type f`; do mkdir -p "target/cov/$$(basename $$file)"; kcov --exclude-pattern=/.cargo,/usr/lib "target/cov/$$(basename $$file)" "$$file"; done
+	for file in `find target/debug/ -maxdepth 1 -executable -type f`; do mkdir -p "target/cov/$$(basename $$file)"; kcov --exclude-pattern=/.cargo,/usr/lib,tests "target/cov/$$(basename $$file)" "$$file"; done
 
 fmt:
 	cargo fmt --all -- --check


### PR DESCRIPTION
This is adapted from #66 thanks to @u2's help!

I originally rejected the idea of adding coverage job in #66 but upon further consideration, that's a mistake, we should add coverage job in this repo since:

* Cross-posting coverage report from another repository is very tricky to get right
* While test suite repo contains a lot of useful and complete tests, the tests included in this repo is a good supplement for invalid cases
* With CI job here, bugs in PRs can be detected earlier