### PR TITLE
Eliminate as much usize as making sense from CKB VM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,7 @@ matrix:
         docker run --rm -v `pwd`:/code xxuejie/riscv-gnu-toolchain-rv64imac:xenial-20190606 cp -r /riscv /code/riscv &&
         RISCV=`pwd`/riscv ./ckb-vm-test-suite/test.sh
     - name: Code Coverage
+      if: 'tag IS NOT present AND (branch = develop OR branch = master)'
       rust: 1.35.0
       dist: xenial
       addons:

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -1,12 +1,12 @@
 #[inline(always)]
-pub fn roundup(x: usize, round: usize) -> usize {
+pub fn roundup(x: u64, round: u64) -> u64 {
     debug_assert!(round.is_power_of_two());
     // x + (((!x) + 1) & (round - 1))
     x + ((!x).wrapping_add(1) & (round.wrapping_sub(1)))
 }
 
 #[inline(always)]
-pub fn rounddown(x: usize, round: usize) -> usize {
+pub fn rounddown(x: u64, round: u64) -> u64 {
     debug_assert!(round.is_power_of_two());
     // x & !(round - 1)
     x & !(round.wrapping_sub(1))
@@ -24,10 +24,7 @@ mod tests {
         assert_eq!(16, roundup(15, 16));
         assert_eq!(16, roundup(16, 16));
         assert_eq!(32, roundup(17, 16));
-        assert_eq!(
-            usize::max_value() - 15,
-            roundup(usize::max_value() - 15, 16)
-        );
+        assert_eq!(u64::max_value() - 15, roundup(u64::max_value() - 15, 16));
     }
 
     #[test]
@@ -37,12 +34,12 @@ mod tests {
         assert_eq!(0, rounddown(15, 16));
         assert_eq!(16, rounddown(16, 16));
         assert_eq!(16, rounddown(17, 16));
-        assert_eq!(usize::max_value() - 15, rounddown(usize::max_value(), 16));
+        assert_eq!(u64::max_value() - 15, rounddown(u64::max_value(), 16));
     }
 
     proptest! {
         #[test]
-        fn roundup_proptest(x: usize, round in (0u32..16).prop_map(|d| 2usize.pow(d))) {
+        fn roundup_proptest(x: u64, round in (0u32..16).prop_map(|d| 2u64.pow(d))) {
             prop_assume!(x.checked_add(round).is_some(), "avoid integer overflow");
             let result = roundup(x, round);
 
@@ -57,7 +54,7 @@ mod tests {
         }
 
         #[test]
-        fn rounddown_proptest(x: usize, round in (0u32..16).prop_map(|d| 2usize.pow(d))) {
+        fn rounddown_proptest(x: u64, round in (0u32..16).prop_map(|d| 2u64.pow(d))) {
             let result = rounddown(x, round);
 
             // multiple of round

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -49,7 +49,7 @@ impl Decoder {
     fn decode_bits<R: Register, M: Memory<R>>(
         &self,
         memory: &mut M,
-        pc: usize,
+        pc: u64,
     ) -> Result<u32, Error> {
         let mut instruction_bits = u32::from(memory.execute_load16(pc)?);
         if instruction_bits & 0x3 == 0x3 {
@@ -61,7 +61,7 @@ impl Decoder {
     pub fn decode<R: Register, M: Memory<R>>(
         &self,
         memory: &mut M,
-        pc: usize,
+        pc: u64,
     ) -> Result<Instruction, Error> {
         let instruction_bits = self.decode_bits(memory, pc)?;
         for factory in &self.factories {

--- a/src/instructions/common.rs
+++ b/src/instructions/common.rs
@@ -30,7 +30,7 @@ pub fn addw<Mac: Machine>(
     let rs1_value = &machine.registers()[rs1 as usize];
     let rs2_value = &machine.registers()[rs2 as usize];
     let value = rs1_value.overflowing_add(&rs2_value);
-    update_register(machine, rd, value.sign_extend(&Mac::REG::from_usize(32)));
+    update_register(machine, rd, value.sign_extend(&Mac::REG::from_u8(32)));
 }
 
 pub fn sub<Mac: Machine>(
@@ -54,7 +54,7 @@ pub fn subw<Mac: Machine>(
     let rs1_value = &machine.registers()[rs1 as usize];
     let rs2_value = &machine.registers()[rs2 as usize];
     let value = rs1_value.overflowing_sub(&rs2_value);
-    update_register(machine, rd, value.sign_extend(&Mac::REG::from_usize(32)));
+    update_register(machine, rd, value.sign_extend(&Mac::REG::from_u8(32)));
 }
 
 pub fn addi<Mac: Machine>(
@@ -74,7 +74,7 @@ pub fn addiw<Mac: Machine>(
     imm: Immediate,
 ) {
     let value = machine.registers()[rs1 as usize].overflowing_add(&Mac::REG::from_i32(imm));
-    update_register(machine, rd, value.sign_extend(&Mac::REG::from_usize(32)));
+    update_register(machine, rd, value.sign_extend(&Mac::REG::from_u8(32)));
 }
 
 // =======================
@@ -89,7 +89,7 @@ pub fn lb<Mac: Machine>(
     let address = machine.registers()[rs1 as usize].overflowing_add(&Mac::REG::from_i32(imm));
     let value = machine.memory_mut().load8(&address)?;
     // sign-extened
-    update_register(machine, rd, value.sign_extend(&Mac::REG::from_usize(8)));
+    update_register(machine, rd, value.sign_extend(&Mac::REG::from_u8(8)));
     Ok(())
 }
 
@@ -102,7 +102,7 @@ pub fn lh<Mac: Machine>(
     let address = machine.registers()[rs1 as usize].overflowing_add(&Mac::REG::from_i32(imm));
     let value = machine.memory_mut().load16(&address)?;
     // sign-extened
-    update_register(machine, rd, value.sign_extend(&Mac::REG::from_usize(16)));
+    update_register(machine, rd, value.sign_extend(&Mac::REG::from_u8(16)));
     Ok(())
 }
 
@@ -114,7 +114,7 @@ pub fn lw<Mac: Machine>(
 ) -> Result<(), Error> {
     let address = machine.registers()[rs1 as usize].overflowing_add(&Mac::REG::from_i32(imm));
     let value = machine.memory_mut().load32(&address)?;
-    update_register(machine, rd, value.sign_extend(&Mac::REG::from_usize(32)));
+    update_register(machine, rd, value.sign_extend(&Mac::REG::from_u8(32)));
     Ok(())
 }
 
@@ -126,7 +126,7 @@ pub fn ld<Mac: Machine>(
 ) -> Result<(), Error> {
     let address = machine.registers()[rs1 as usize].overflowing_add(&Mac::REG::from_i32(imm));
     let value = machine.memory_mut().load64(&address)?;
-    update_register(machine, rd, value.sign_extend(&Mac::REG::from_usize(64)));
+    update_register(machine, rd, value.sign_extend(&Mac::REG::from_u8(64)));
     Ok(())
 }
 
@@ -318,7 +318,7 @@ pub fn slliw<Mac: Machine>(
     shamt: UImmediate,
 ) {
     let value = machine.registers()[rs1 as usize].clone() << Mac::REG::from_u32(shamt);
-    update_register(machine, rd, value.sign_extend(&Mac::REG::from_usize(32)));
+    update_register(machine, rd, value.sign_extend(&Mac::REG::from_u8(32)));
 }
 
 pub fn srliw<Mac: Machine>(
@@ -327,9 +327,9 @@ pub fn srliw<Mac: Machine>(
     rs1: RegisterIndex,
     shamt: UImmediate,
 ) {
-    let value = machine.registers()[rs1 as usize].zero_extend(&Mac::REG::from_usize(32))
+    let value = machine.registers()[rs1 as usize].zero_extend(&Mac::REG::from_u8(32))
         >> Mac::REG::from_u32(shamt);
-    update_register(machine, rd, value.sign_extend(&Mac::REG::from_usize(32)));
+    update_register(machine, rd, value.sign_extend(&Mac::REG::from_u8(32)));
 }
 
 pub fn sraiw<Mac: Machine>(
@@ -339,9 +339,9 @@ pub fn sraiw<Mac: Machine>(
     shamt: UImmediate,
 ) {
     let value = machine.registers()[rs1 as usize]
-        .sign_extend(&Mac::REG::from_usize(32))
+        .sign_extend(&Mac::REG::from_u8(32))
         .signed_shr(&Mac::REG::from_u32(shamt));
-    update_register(machine, rd, value.sign_extend(&Mac::REG::from_usize(32)));
+    update_register(machine, rd, value.sign_extend(&Mac::REG::from_u8(32)));
 }
 
 // =======================
@@ -351,9 +351,9 @@ pub fn jal<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     imm: Immediate,
-    xbytes: usize,
+    xbytes: u8,
 ) -> Option<Mac::REG> {
-    let link = machine.pc().overflowing_add(&Mac::REG::from_usize(xbytes));
+    let link = machine.pc().overflowing_add(&Mac::REG::from_u8(xbytes));
     update_register(machine, rd, link);
     Some(machine.pc().overflowing_add(&Mac::REG::from_i32(imm)))
 }

--- a/src/instructions/execute.rs
+++ b/src/instructions/execute.rs
@@ -47,61 +47,49 @@ pub fn execute<Mac: Machine>(inst: Instruction, machine: &mut Mac) -> Result<(),
         insts::OP_SLL => {
             let i = Rtype(inst);
             let shift_value =
-                machine.registers()[i.rs2()].clone() & Mac::REG::from_usize(Mac::REG::SHIFT_MASK);
+                machine.registers()[i.rs2()].clone() & Mac::REG::from_u8(Mac::REG::SHIFT_MASK);
             let value = machine.registers()[i.rs1()].clone() << shift_value;
             update_register(machine, i.rd(), value);
             None
         }
         insts::OP_SLLW => {
             let i = Rtype(inst);
-            let shift_value = machine.registers()[i.rs2()].clone() & Mac::REG::from_usize(0x1F);
+            let shift_value = machine.registers()[i.rs2()].clone() & Mac::REG::from_u8(0x1F);
             let value = machine.registers()[i.rs1()].clone() << shift_value;
-            update_register(
-                machine,
-                i.rd(),
-                value.sign_extend(&Mac::REG::from_usize(32)),
-            );
+            update_register(machine, i.rd(), value.sign_extend(&Mac::REG::from_u8(32)));
             None
         }
         insts::OP_SRL => {
             let i = Rtype(inst);
             let shift_value =
-                machine.registers()[i.rs2()].clone() & Mac::REG::from_usize(Mac::REG::SHIFT_MASK);
+                machine.registers()[i.rs2()].clone() & Mac::REG::from_u8(Mac::REG::SHIFT_MASK);
             let value = machine.registers()[i.rs1()].clone() >> shift_value;
             update_register(machine, i.rd(), value);
             None
         }
         insts::OP_SRLW => {
             let i = Rtype(inst);
-            let shift_value = machine.registers()[i.rs2()].clone() & Mac::REG::from_usize(0x1F);
+            let shift_value = machine.registers()[i.rs2()].clone() & Mac::REG::from_u8(0x1F);
             let value =
-                machine.registers()[i.rs1()].zero_extend(&Mac::REG::from_usize(32)) >> shift_value;
-            update_register(
-                machine,
-                i.rd(),
-                value.sign_extend(&Mac::REG::from_usize(32)),
-            );
+                machine.registers()[i.rs1()].zero_extend(&Mac::REG::from_u8(32)) >> shift_value;
+            update_register(machine, i.rd(), value.sign_extend(&Mac::REG::from_u8(32)));
             None
         }
         insts::OP_SRA => {
             let i = Rtype(inst);
             let shift_value =
-                machine.registers()[i.rs2()].clone() & Mac::REG::from_usize(Mac::REG::SHIFT_MASK);
+                machine.registers()[i.rs2()].clone() & Mac::REG::from_u8(Mac::REG::SHIFT_MASK);
             let value = machine.registers()[i.rs1()].signed_shr(&shift_value);
             update_register(machine, i.rd(), value);
             None
         }
         insts::OP_SRAW => {
             let i = Rtype(inst);
-            let shift_value = machine.registers()[i.rs2()].clone() & Mac::REG::from_usize(0x1F);
+            let shift_value = machine.registers()[i.rs2()].clone() & Mac::REG::from_u8(0x1F);
             let value = machine.registers()[i.rs1()]
-                .sign_extend(&Mac::REG::from_usize(32))
+                .sign_extend(&Mac::REG::from_u8(32))
                 .signed_shr(&shift_value);
-            update_register(
-                machine,
-                i.rd(),
-                value.sign_extend(&Mac::REG::from_usize(32)),
-            );
+            update_register(machine, i.rd(), value.sign_extend(&Mac::REG::from_u8(32)));
             None
         }
         insts::OP_SLT => {
@@ -198,7 +186,7 @@ pub fn execute<Mac: Machine>(inst: Instruction, machine: &mut Mac) -> Result<(),
         }
         insts::OP_JALR => {
             let i = Itype(inst);
-            let link = machine.pc().overflowing_add(&Mac::REG::from_usize(4));
+            let link = machine.pc().overflowing_add(&Mac::REG::from_u8(4));
             let mut next_pc =
                 machine.registers()[i.rs1()].overflowing_add(&Mac::REG::from_i32(i.immediate_s()));
             next_pc = next_pc & (!Mac::REG::one());
@@ -263,7 +251,7 @@ pub fn execute<Mac: Machine>(inst: Instruction, machine: &mut Mac) -> Result<(),
             let condition = rs1_value.eq(&rs2_value);
             let new_pc = condition.cond(
                 &Mac::REG::from_i32(i.immediate_s()).overflowing_add(&pc),
-                &Mac::REG::from_usize(4).overflowing_add(&pc),
+                &Mac::REG::from_u8(4).overflowing_add(&pc),
             );
             Some(new_pc)
         }
@@ -275,7 +263,7 @@ pub fn execute<Mac: Machine>(inst: Instruction, machine: &mut Mac) -> Result<(),
             let condition = rs1_value.ne(&rs2_value);
             let new_pc = condition.cond(
                 &Mac::REG::from_i32(i.immediate_s()).overflowing_add(&pc),
-                &Mac::REG::from_usize(4).overflowing_add(&pc),
+                &Mac::REG::from_u8(4).overflowing_add(&pc),
             );
             Some(new_pc)
         }
@@ -287,7 +275,7 @@ pub fn execute<Mac: Machine>(inst: Instruction, machine: &mut Mac) -> Result<(),
             let condition = rs1_value.lt_s(&rs2_value);
             let new_pc = condition.cond(
                 &Mac::REG::from_i32(i.immediate_s()).overflowing_add(&pc),
-                &Mac::REG::from_usize(4).overflowing_add(&pc),
+                &Mac::REG::from_u8(4).overflowing_add(&pc),
             );
             Some(new_pc)
         }
@@ -299,7 +287,7 @@ pub fn execute<Mac: Machine>(inst: Instruction, machine: &mut Mac) -> Result<(),
             let condition = rs1_value.ge_s(&rs2_value);
             let new_pc = condition.cond(
                 &Mac::REG::from_i32(i.immediate_s()).overflowing_add(&pc),
-                &Mac::REG::from_usize(4).overflowing_add(&pc),
+                &Mac::REG::from_u8(4).overflowing_add(&pc),
             );
             Some(new_pc)
         }
@@ -311,7 +299,7 @@ pub fn execute<Mac: Machine>(inst: Instruction, machine: &mut Mac) -> Result<(),
             let condition = rs1_value.lt(&rs2_value);
             let new_pc = condition.cond(
                 &Mac::REG::from_i32(i.immediate_s()).overflowing_add(&pc),
-                &Mac::REG::from_usize(4).overflowing_add(&pc),
+                &Mac::REG::from_u8(4).overflowing_add(&pc),
             );
             Some(new_pc)
         }
@@ -323,7 +311,7 @@ pub fn execute<Mac: Machine>(inst: Instruction, machine: &mut Mac) -> Result<(),
             let condition = rs1_value.ge(&rs2_value);
             let new_pc = condition.cond(
                 &Mac::REG::from_i32(i.immediate_s()).overflowing_add(&pc),
-                &Mac::REG::from_usize(4).overflowing_add(&pc),
+                &Mac::REG::from_u8(4).overflowing_add(&pc),
             );
             Some(new_pc)
         }
@@ -371,13 +359,9 @@ pub fn execute<Mac: Machine>(inst: Instruction, machine: &mut Mac) -> Result<(),
             let rs1_value = &machine.registers()[i.rs1()];
             let rs2_value = &machine.registers()[i.rs2()];
             let value = rs1_value
-                .zero_extend(&Mac::REG::from_usize(32))
-                .overflowing_mul(&rs2_value.zero_extend(&Mac::REG::from_usize(32)));
-            update_register(
-                machine,
-                i.rd(),
-                value.sign_extend(&Mac::REG::from_usize(32)),
-            );
+                .zero_extend(&Mac::REG::from_u8(32))
+                .overflowing_mul(&rs2_value.zero_extend(&Mac::REG::from_u8(32)));
+            update_register(machine, i.rd(), value.sign_extend(&Mac::REG::from_u8(32)));
             None
         }
         insts::OP_MULH => {
@@ -416,14 +400,10 @@ pub fn execute<Mac: Machine>(inst: Instruction, machine: &mut Mac) -> Result<(),
             let i = Rtype(inst);
             let rs1_value = &machine.registers()[i.rs1()];
             let rs2_value = &machine.registers()[i.rs2()];
-            let rs1_value = rs1_value.sign_extend(&Mac::REG::from_usize(32));
-            let rs2_value = rs2_value.sign_extend(&Mac::REG::from_usize(32));
+            let rs1_value = rs1_value.sign_extend(&Mac::REG::from_u8(32));
+            let rs2_value = rs2_value.sign_extend(&Mac::REG::from_u8(32));
             let value = rs1_value.overflowing_div_signed(&rs2_value);
-            update_register(
-                machine,
-                i.rd(),
-                value.sign_extend(&Mac::REG::from_usize(32)),
-            );
+            update_register(machine, i.rd(), value.sign_extend(&Mac::REG::from_u8(32)));
             None
         }
         insts::OP_DIVU => {
@@ -438,14 +418,10 @@ pub fn execute<Mac: Machine>(inst: Instruction, machine: &mut Mac) -> Result<(),
             let i = Rtype(inst);
             let rs1_value = &machine.registers()[i.rs1()];
             let rs2_value = &machine.registers()[i.rs2()];
-            let rs1_value = rs1_value.zero_extend(&Mac::REG::from_usize(32));
-            let rs2_value = rs2_value.zero_extend(&Mac::REG::from_usize(32));
+            let rs1_value = rs1_value.zero_extend(&Mac::REG::from_u8(32));
+            let rs2_value = rs2_value.zero_extend(&Mac::REG::from_u8(32));
             let value = rs1_value.overflowing_div(&rs2_value);
-            update_register(
-                machine,
-                i.rd(),
-                value.sign_extend(&Mac::REG::from_usize(32)),
-            );
+            update_register(machine, i.rd(), value.sign_extend(&Mac::REG::from_u8(32)));
             None
         }
         insts::OP_REM => {
@@ -460,14 +436,10 @@ pub fn execute<Mac: Machine>(inst: Instruction, machine: &mut Mac) -> Result<(),
             let i = Rtype(inst);
             let rs1_value = &machine.registers()[i.rs1()];
             let rs2_value = &machine.registers()[i.rs2()];
-            let rs1_value = rs1_value.sign_extend(&Mac::REG::from_usize(32));
-            let rs2_value = rs2_value.sign_extend(&Mac::REG::from_usize(32));
+            let rs1_value = rs1_value.sign_extend(&Mac::REG::from_u8(32));
+            let rs2_value = rs2_value.sign_extend(&Mac::REG::from_u8(32));
             let value = rs1_value.overflowing_rem_signed(&rs2_value);
-            update_register(
-                machine,
-                i.rd(),
-                value.sign_extend(&Mac::REG::from_usize(32)),
-            );
+            update_register(machine, i.rd(), value.sign_extend(&Mac::REG::from_u8(32)));
             None
         }
         insts::OP_REMU => {
@@ -482,14 +454,10 @@ pub fn execute<Mac: Machine>(inst: Instruction, machine: &mut Mac) -> Result<(),
             let i = Rtype(inst);
             let rs1_value = &machine.registers()[i.rs1()];
             let rs2_value = &machine.registers()[i.rs2()];
-            let rs1_value = rs1_value.zero_extend(&Mac::REG::from_usize(32));
-            let rs2_value = rs2_value.zero_extend(&Mac::REG::from_usize(32));
+            let rs1_value = rs1_value.zero_extend(&Mac::REG::from_u8(32));
+            let rs2_value = rs2_value.zero_extend(&Mac::REG::from_u8(32));
             let value = rs1_value.overflowing_rem(&rs2_value);
-            update_register(
-                machine,
-                i.rd(),
-                value.sign_extend(&Mac::REG::from_usize(32)),
-            );
+            update_register(machine, i.rd(), value.sign_extend(&Mac::REG::from_u8(32)));
             None
         }
         insts::OP_RVC_SUB => {
@@ -621,7 +589,7 @@ pub fn execute<Mac: Machine>(inst: Instruction, machine: &mut Mac) -> Result<(),
             let condition = machine.registers()[i.rs1()].eq(&Mac::REG::zero());
             let new_pc = condition.cond(
                 &Mac::REG::from_i32(i.immediate_s()).overflowing_add(&pc),
-                &Mac::REG::from_usize(2).overflowing_add(&pc),
+                &Mac::REG::from_u8(2).overflowing_add(&pc),
             );
             Some(new_pc)
         }
@@ -633,7 +601,7 @@ pub fn execute<Mac: Machine>(inst: Instruction, machine: &mut Mac) -> Result<(),
                 .logical_not();
             let new_pc = condition.cond(
                 &Mac::REG::from_i32(i.immediate_s()).overflowing_add(&pc),
-                &Mac::REG::from_usize(2).overflowing_add(&pc),
+                &Mac::REG::from_u8(2).overflowing_add(&pc),
             );
             Some(new_pc)
         }
@@ -663,7 +631,7 @@ pub fn execute<Mac: Machine>(inst: Instruction, machine: &mut Mac) -> Result<(),
         }
         insts::OP_RVC_JALR => {
             let i = Stype(inst);
-            let link = machine.pc().overflowing_add(&Mac::REG::from_usize(2));
+            let link = machine.pc().overflowing_add(&Mac::REG::from_u8(2));
             let mut next_pc = machine.registers()[i.rs1()].clone();
             next_pc = next_pc & (!Mac::REG::one());
             update_register(machine, 1, link);
@@ -695,7 +663,7 @@ pub fn execute<Mac: Machine>(inst: Instruction, machine: &mut Mac) -> Result<(),
     let default_instruction_size = instruction_length(inst);
     let default_next_pc = machine
         .pc()
-        .overflowing_add(&Mac::REG::from_usize(default_instruction_size));
+        .overflowing_add(&Mac::REG::from_u8(default_instruction_size));
     machine.set_pc(next_pc.unwrap_or(default_next_pc));
     Ok(())
 }

--- a/src/instructions/i.rs
+++ b/src/instructions/i.rs
@@ -122,7 +122,7 @@ pub fn factory<R: Register>(instruction_bits: u32) -> Option<Instruction> {
                             inst,
                             rd(instruction_bits),
                             rs1(instruction_bits),
-                            itype_immediate(instruction_bits) & R::SHIFT_MASK as i32,
+                            itype_immediate(instruction_bits) & i32::from(R::SHIFT_MASK),
                         )
                         .0
                     });

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -220,7 +220,7 @@ pub fn is_basic_block_end_instruction(i: Instruction) -> bool {
 }
 
 #[inline(always)]
-pub fn instruction_length(i: Instruction) -> usize {
+pub fn instruction_length(i: Instruction) -> u8 {
     let o = extract_opcode(i);
     if o >= MINIMAL_RVC_OPCODE && o <= MAXIMUM_RVC_OPCODE {
         2

--- a/src/instructions/register.rs
+++ b/src/instructions/register.rs
@@ -14,8 +14,8 @@ pub trait Register:
     + Shl<Self, Output = Self>
     + Shr<Self, Output = Self>
 {
-    const BITS: usize;
-    const SHIFT_MASK: usize;
+    const BITS: u8;
+    const SHIFT_MASK: u8;
 
     fn zero() -> Self;
     fn one() -> Self;
@@ -79,23 +79,19 @@ pub trait Register:
     fn to_i16(&self) -> i16;
     fn to_i32(&self) -> i32;
     fn to_i64(&self) -> i64;
-    fn to_isize(&self) -> isize;
     fn to_u8(&self) -> u8;
     fn to_u16(&self) -> u16;
     fn to_u32(&self) -> u32;
     fn to_u64(&self) -> u64;
-    fn to_usize(&self) -> usize;
 
     fn from_i8(v: i8) -> Self;
     fn from_i16(v: i16) -> Self;
     fn from_i32(v: i32) -> Self;
     fn from_i64(v: i64) -> Self;
-    fn from_isize(v: isize) -> Self;
     fn from_u8(v: u8) -> Self;
     fn from_u16(v: u16) -> Self;
     fn from_u32(v: u32) -> Self;
     fn from_u64(v: u64) -> Self;
-    fn from_usize(v: usize) -> Self;
 
     fn ne(&self, rhs: &Self) -> Self {
         self.eq(rhs).logical_not()
@@ -111,8 +107,8 @@ pub trait Register:
 }
 
 impl Register for u32 {
-    const BITS: usize = 32;
-    const SHIFT_MASK: usize = 0x1F;
+    const BITS: u8 = 32;
+    const SHIFT_MASK: u8 = 0x1F;
 
     fn zero() -> u32 {
         0
@@ -266,10 +262,6 @@ impl Register for u32 {
         i64::from(*self as i32)
     }
 
-    fn to_isize(&self) -> isize {
-        i64::from(*self as i32) as isize
-    }
-
     fn to_u8(&self) -> u8 {
         *self as u8
     }
@@ -284,10 +276,6 @@ impl Register for u32 {
 
     fn to_u64(&self) -> u64 {
         u64::from(*self)
-    }
-
-    fn to_usize(&self) -> usize {
-        *self as usize
     }
 
     fn from_i8(v: i8) -> u32 {
@@ -306,10 +294,6 @@ impl Register for u32 {
         (v as i32) as u32
     }
 
-    fn from_isize(v: isize) -> u32 {
-        (v as i32) as u32
-    }
-
     fn from_u8(v: u8) -> u32 {
         u32::from(v)
     }
@@ -325,15 +309,11 @@ impl Register for u32 {
     fn from_u64(v: u64) -> u32 {
         v as u32
     }
-
-    fn from_usize(v: usize) -> u32 {
-        v as u32
-    }
 }
 
 impl Register for u64 {
-    const BITS: usize = 64;
-    const SHIFT_MASK: usize = 0x3F;
+    const BITS: u8 = 64;
+    const SHIFT_MASK: u8 = 0x3F;
 
     fn zero() -> u64 {
         0
@@ -487,10 +467,6 @@ impl Register for u64 {
         *self as i64
     }
 
-    fn to_isize(&self) -> isize {
-        (*self as i64) as isize
-    }
-
     fn to_u8(&self) -> u8 {
         *self as u8
     }
@@ -505,10 +481,6 @@ impl Register for u64 {
 
     fn to_u64(&self) -> u64 {
         *self
-    }
-
-    fn to_usize(&self) -> usize {
-        *self as usize
     }
 
     fn from_i8(v: i8) -> u64 {
@@ -527,10 +499,6 @@ impl Register for u64 {
         v as u64
     }
 
-    fn from_isize(v: isize) -> u64 {
-        (v as i64) as u64
-    }
-
     fn from_u8(v: u8) -> u64 {
         u64::from(v)
     }
@@ -545,9 +513,5 @@ impl Register for u64 {
 
     fn from_u64(v: u64) -> u64 {
         v
-    }
-
-    fn from_usize(v: usize) -> u64 {
-        v as u64
     }
 }

--- a/src/jit/machine.rs
+++ b/src/jit/machine.rs
@@ -239,7 +239,7 @@ impl BaselineJitMachine {
                 let end_instruction = (!jitable) || is_basic_block_end_instruction(instruction);
                 // Unjitable instruction will be its own basic block
                 if instructions.is_empty() || jitable {
-                    let length = instruction_length(instruction) as u64;
+                    let length = u64::from(instruction_length(instruction));
                     current_pc += length;
                     block_length += length;
                     block_cycles += machine

--- a/src/jit/value.rs
+++ b/src/jit/value.rs
@@ -106,8 +106,8 @@ impl Shr<Value> for Value {
 
 impl Register for Value {
     // For now we only support JIT on 64 bit RISC-V machine
-    const BITS: usize = 64;
-    const SHIFT_MASK: usize = 0x3F;
+    const BITS: u8 = 64;
+    const SHIFT_MASK: u8 = 0x3F;
 
     fn zero() -> Value {
         Value::Imm(0)
@@ -291,10 +291,6 @@ impl Register for Value {
         0
     }
 
-    fn to_isize(&self) -> isize {
-        0
-    }
-
     fn to_u8(&self) -> u8 {
         0
     }
@@ -308,10 +304,6 @@ impl Register for Value {
     }
 
     fn to_u64(&self) -> u64 {
-        0
-    }
-
-    fn to_usize(&self) -> usize {
         0
     }
 
@@ -331,10 +323,6 @@ impl Register for Value {
         Value::Imm(v as u64)
     }
 
-    fn from_isize(v: isize) -> Value {
-        Value::Imm((v as i64) as u64)
-    }
-
     fn from_u8(v: u8) -> Value {
         Value::Imm(u64::from(v))
     }
@@ -349,9 +337,5 @@ impl Register for Value {
 
     fn from_u64(v: u64) -> Value {
         Value::Imm(v)
-    }
-
-    fn from_usize(v: usize) -> Value {
-        Value::Imm(v as u64)
     }
 }

--- a/src/machine/asm/mod.rs
+++ b/src/machine/asm/mod.rs
@@ -121,11 +121,11 @@ impl Memory<u64> for Box<AsmCoreMachine> {
 
     fn execute_load16(&mut self, addr: u64) -> Result<u16, Error> {
         check_permission(self, addr, 2, FLAG_EXECUTABLE)?;
-        self.load16(&(addr as u64)).map(|v| v as u16)
+        self.load16(&(addr)).map(|v| v as u16)
     }
 
     fn load8(&mut self, addr: &u64) -> Result<u64, Error> {
-        let addr = *addr as u64;
+        let addr = *addr;
         if addr + 1 > self.memory.len() as u64 {
             return Err(Error::OutOfBound);
         }
@@ -133,7 +133,7 @@ impl Memory<u64> for Box<AsmCoreMachine> {
     }
 
     fn load16(&mut self, addr: &u64) -> Result<u64, Error> {
-        let addr = *addr as u64;
+        let addr = *addr;
         if addr + 2 > self.memory.len() as u64 {
             return Err(Error::OutOfBound);
         }
@@ -143,7 +143,7 @@ impl Memory<u64> for Box<AsmCoreMachine> {
     }
 
     fn load32(&mut self, addr: &u64) -> Result<u64, Error> {
-        let addr = *addr as u64;
+        let addr = *addr;
         if addr + 4 > self.memory.len() as u64 {
             return Err(Error::OutOfBound);
         }
@@ -153,7 +153,7 @@ impl Memory<u64> for Box<AsmCoreMachine> {
     }
 
     fn load64(&mut self, addr: &u64) -> Result<u64, Error> {
-        let addr = *addr as u64;
+        let addr = *addr;
         if addr + 8 > self.memory.len() as u64 {
             return Err(Error::OutOfBound);
         }
@@ -163,14 +163,14 @@ impl Memory<u64> for Box<AsmCoreMachine> {
     }
 
     fn store8(&mut self, addr: &u64, value: &u64) -> Result<(), Error> {
-        let addr = *addr as u64;
+        let addr = *addr;
         check_permission(self, addr, 1, FLAG_WRITABLE)?;
         self.memory[addr as usize] = (*value) as u8;
         Ok(())
     }
 
     fn store16(&mut self, addr: &u64, value: &u64) -> Result<(), Error> {
-        let addr = *addr as u64;
+        let addr = *addr;
         check_permission(self, addr, 2, FLAG_WRITABLE)?;
         LittleEndian::write_u16(
             &mut self.memory[addr as usize..(addr + 2) as usize],
@@ -180,7 +180,7 @@ impl Memory<u64> for Box<AsmCoreMachine> {
     }
 
     fn store32(&mut self, addr: &u64, value: &u64) -> Result<(), Error> {
-        let addr = *addr as u64;
+        let addr = *addr;
         check_permission(self, addr, 4, FLAG_WRITABLE)?;
         LittleEndian::write_u32(
             &mut self.memory[addr as usize..(addr + 4) as usize],
@@ -190,7 +190,7 @@ impl Memory<u64> for Box<AsmCoreMachine> {
     }
 
     fn store64(&mut self, addr: &u64, value: &u64) -> Result<(), Error> {
-        let addr = *addr as u64;
+        let addr = *addr;
         check_permission(self, addr, 8, FLAG_WRITABLE)?;
         LittleEndian::write_u64(&mut self.memory[addr as usize..(addr + 8) as usize], *value);
         Ok(())
@@ -279,7 +279,7 @@ impl<'a> AsmMachine<'a> {
                             *(ckb_vm_asm_labels as *const u32).offset(OP_CUSTOM_TRACE_END as isize),
                         ) + (ckb_vm_asm_labels as *const u32 as u64)
                     };
-                    trace.address = pc as u64;
+                    trace.address = pc;
                     trace.length = (current_pc - pc) as u8;
                     self.machine.inner_mut().traces[slot] = trace;
                 }

--- a/src/machine/asm/mod.rs
+++ b/src/machine/asm/mod.rs
@@ -249,7 +249,7 @@ impl<'a> AsmMachine<'a> {
                         let mut instruction =
                             decoder.decode(self.machine.memory_mut(), current_pc)?;
                         let end_instruction = is_basic_block_end_instruction(instruction);
-                        current_pc += instruction_length(instruction) as u64;
+                        current_pc += u64::from(instruction_length(instruction));
                         // We are storing the offset after current instruction in unused
                         // space of the instruction, so as to allow easy access of this data
                         // within assembly loops.

--- a/src/machine/trace.rs
+++ b/src/machine/trace.rs
@@ -22,15 +22,15 @@ const TRACE_ADDRESS_SHIFTS: usize = 5;
 
 #[derive(Default)]
 struct Trace {
-    address: usize,
+    address: u64,
     length: usize,
     instruction_count: u8,
     instructions: [Instruction; TRACE_ITEM_LENGTH],
 }
 
 #[inline(always)]
-fn calculate_slot(addr: usize) -> usize {
-    (addr >> TRACE_ADDRESS_SHIFTS) & TRACE_MASK
+fn calculate_slot(addr: u64) -> usize {
+    (addr as usize >> TRACE_ADDRESS_SHIFTS) & TRACE_MASK
 }
 
 pub struct TraceMachine<'a, Inner> {
@@ -105,7 +105,7 @@ impl<'a, R: Register, M: Memory<R>, Inner: SupportMachine<REG = R, MEM = WXorXMe
         // larger trace item length.
         self.traces.resize_with(TRACE_SIZE, Trace::default);
         while self.machine.running() {
-            let pc = self.machine.pc().to_usize();
+            let pc = self.machine.pc().to_u64();
             let slot = calculate_slot(pc);
             if pc != self.traces[slot].address || self.traces[slot].instruction_count == 0 {
                 self.traces[slot] = Trace::default();
@@ -114,7 +114,7 @@ impl<'a, R: Register, M: Memory<R>, Inner: SupportMachine<REG = R, MEM = WXorXMe
                 while i < TRACE_ITEM_LENGTH {
                     let instruction = decoder.decode(self.machine.memory_mut(), current_pc)?;
                     let end_instruction = is_basic_block_end_instruction(instruction);
-                    current_pc += instruction_length(instruction);
+                    current_pc += instruction_length(instruction) as u64;
                     self.traces[slot].instructions[i] = instruction;
                     i += 1;
                     if end_instruction {
@@ -122,7 +122,7 @@ impl<'a, R: Register, M: Memory<R>, Inner: SupportMachine<REG = R, MEM = WXorXMe
                     }
                 }
                 self.traces[slot].address = pc;
-                self.traces[slot].length = current_pc - pc;
+                self.traces[slot].length = (current_pc - pc) as usize;
                 self.traces[slot].instruction_count = i as u8;
             }
             for i in 0..self.traces[slot].instruction_count {

--- a/src/machine/trace.rs
+++ b/src/machine/trace.rs
@@ -114,7 +114,7 @@ impl<'a, R: Register, M: Memory<R>, Inner: SupportMachine<REG = R, MEM = WXorXMe
                 while i < TRACE_ITEM_LENGTH {
                     let instruction = decoder.decode(self.machine.memory_mut(), current_pc)?;
                     let end_instruction = is_basic_block_end_instruction(instruction);
-                    current_pc += instruction_length(instruction) as u64;
+                    current_pc += u64::from(instruction_length(instruction));
                     self.traces[slot].instructions[i] = instruction;
                     i += 1;
                     if end_instruction {

--- a/src/memory/flat.rs
+++ b/src/memory/flat.rs
@@ -40,30 +40,30 @@ impl<R> DerefMut for FlatMemory<R> {
 impl<R: Register> Memory<R> for FlatMemory<R> {
     fn init_pages(
         &mut self,
-        addr: usize,
-        size: usize,
+        addr: u64,
+        size: u64,
         _flags: u8,
         source: Option<Bytes>,
-        offset_from_addr: usize,
+        offset_from_addr: u64,
     ) -> Result<(), Error> {
         fill_page_data(self, addr, size, source, offset_from_addr)
     }
 
-    fn fetch_flag(&mut self, page: usize) -> Result<u8, Error> {
-        if page < RISCV_PAGES {
+    fn fetch_flag(&mut self, page: u64) -> Result<u8, Error> {
+        if page < RISCV_PAGES as u64 {
             Ok(0)
         } else {
             Err(Error::OutOfBound)
         }
     }
 
-    fn execute_load16(&mut self, addr: usize) -> Result<u16, Error> {
-        self.load16(&R::from_usize(addr)).map(|v| v.to_u16())
+    fn execute_load16(&mut self, addr: u64) -> Result<u16, Error> {
+        self.load16(&R::from_u64(addr)).map(|v| v.to_u16())
     }
 
     fn load8(&mut self, addr: &R) -> Result<R, Error> {
-        let addr = addr.to_usize();
-        if addr + 1 > self.len() {
+        let addr = addr.to_u64();
+        if addr + 1 > self.len() as u64 {
             return Err(Error::OutOfBound);
         }
         let mut reader = Cursor::new(&self.data);
@@ -73,8 +73,8 @@ impl<R: Register> Memory<R> for FlatMemory<R> {
     }
 
     fn load16(&mut self, addr: &R) -> Result<R, Error> {
-        let addr = addr.to_usize();
-        if addr + 2 > self.len() {
+        let addr = addr.to_u64();
+        if addr + 2 > self.len() as u64 {
             return Err(Error::OutOfBound);
         }
         let mut reader = Cursor::new(&self.data);
@@ -85,8 +85,8 @@ impl<R: Register> Memory<R> for FlatMemory<R> {
     }
 
     fn load32(&mut self, addr: &R) -> Result<R, Error> {
-        let addr = addr.to_usize();
-        if addr + 4 > self.len() {
+        let addr = addr.to_u64();
+        if addr + 4 > self.len() as u64 {
             return Err(Error::OutOfBound);
         }
         let mut reader = Cursor::new(&self.data);
@@ -97,8 +97,8 @@ impl<R: Register> Memory<R> for FlatMemory<R> {
     }
 
     fn load64(&mut self, addr: &R) -> Result<R, Error> {
-        let addr = addr.to_usize();
-        if addr + 8 > self.len() {
+        let addr = addr.to_u64();
+        if addr + 8 > self.len() as u64 {
             return Err(Error::OutOfBound);
         }
         let mut reader = Cursor::new(&self.data);
@@ -109,8 +109,8 @@ impl<R: Register> Memory<R> for FlatMemory<R> {
     }
 
     fn store8(&mut self, addr: &R, value: &R) -> Result<(), Error> {
-        let addr = addr.to_usize();
-        if addr + 1 > self.len() {
+        let addr = addr.to_u64();
+        if addr + 1 > self.len() as u64 {
             return Err(Error::OutOfBound);
         }
         let mut writer = Cursor::new(&mut self.data);
@@ -120,8 +120,8 @@ impl<R: Register> Memory<R> for FlatMemory<R> {
     }
 
     fn store16(&mut self, addr: &R, value: &R) -> Result<(), Error> {
-        let addr = addr.to_usize();
-        if addr + 2 > self.len() {
+        let addr = addr.to_u64();
+        if addr + 2 > self.len() as u64 {
             return Err(Error::OutOfBound);
         }
         let mut writer = Cursor::new(&mut self.data);
@@ -131,8 +131,8 @@ impl<R: Register> Memory<R> for FlatMemory<R> {
     }
 
     fn store32(&mut self, addr: &R, value: &R) -> Result<(), Error> {
-        let addr = addr.to_usize();
-        if addr + 4 > self.len() {
+        let addr = addr.to_u64();
+        if addr + 4 > self.len() as u64 {
             return Err(Error::OutOfBound);
         }
         let mut writer = Cursor::new(&mut self.data);
@@ -142,8 +142,8 @@ impl<R: Register> Memory<R> for FlatMemory<R> {
     }
 
     fn store64(&mut self, addr: &R, value: &R) -> Result<(), Error> {
-        let addr = addr.to_usize();
-        if addr + 8 > self.len() {
+        let addr = addr.to_u64();
+        if addr + 8 > self.len() as u64 {
             return Err(Error::OutOfBound);
         }
         let mut writer = Cursor::new(&mut self.data);
@@ -152,21 +152,21 @@ impl<R: Register> Memory<R> for FlatMemory<R> {
         Ok(())
     }
 
-    fn store_bytes(&mut self, addr: usize, value: &[u8]) -> Result<(), Error> {
-        let size = value.len();
-        if addr + size > self.len() {
+    fn store_bytes(&mut self, addr: u64, value: &[u8]) -> Result<(), Error> {
+        let size = value.len() as u64;
+        if addr + size > self.len() as u64 {
             return Err(Error::OutOfBound);
         }
-        let slice = &mut self[addr..addr + size];
+        let slice = &mut self[addr as usize..(addr + size) as usize];
         slice.copy_from_slice(value);
         Ok(())
     }
 
-    fn store_byte(&mut self, addr: usize, size: usize, value: u8) -> Result<(), Error> {
-        if addr + size > self.len() {
+    fn store_byte(&mut self, addr: u64, size: u64, value: u8) -> Result<(), Error> {
+        if addr + size > self.len() as u64 {
             return Err(Error::OutOfBound);
         }
-        memset(&mut self[addr..addr + size], value);
+        memset(&mut self[addr as usize..(addr + size) as usize], value);
         Ok(())
     }
 }


### PR DESCRIPTION
`usize` is a tricky part since it has different widths across 32-bit vs 64-bit architectures. This PR tries to remove the use of usize from the parts that are making sense. After this PR, we should only be using usize where we have to(such as indexing arrays), and constants where we know no overflows would occur.