### PR TITLE
feat: Do not trigger coverage jobs in PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ matrix:
         docker run --rm -v `pwd`:/code xxuejie/riscv-gnu-toolchain-rv64imac:xenial-20190606 cp -r /riscv /code/riscv &&
         RISCV=`pwd`/riscv ./ckb-vm-test-suite/test.sh
     - name: Code Coverage
-      if: 'tag IS NOT present AND (branch = develop OR branch = master)'
+      if: 'tag IS NOT present AND type != pull_request AND (branch = develop OR branch = master)'
       rust: 1.35.0
       dist: xenial
       addons:


### PR DESCRIPTION
By default codecov would generate a codecov report and if the coverage is less than original, rejects the CI check. This PR changes the code so we are skipping codecov check in PR, but still do the coverage check when merged to develop