### PR TITLE
feat: Set codecov coverage target

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 75
+        threshold: 10
+    patch:
+      default:
+        target: 75
+        threshold: 10


### PR DESCRIPTION
Right now any percentage of coverage drop will trigger a codecov failure. This PR adds reasonable codecov target for now. We can bump the standard here later when we have a more comprehensive test suite.