### PR TITLE
Dependabot/cargo/criterion 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ memmap = "0.7.0"
 cc = "1.0"
 
 [dev-dependencies]
-criterion = "0.2.10"
+criterion = "0.3.0"
 proptest = "0.9.1"
 
 [[bench]]

--- a/benches/bits_benchmark.rs
+++ b/benches/bits_benchmark.rs
@@ -47,25 +47,25 @@ macro_rules! round_bench {
 }
 
 fn roundup_benchmark(c: &mut Criterion) {
-    c.bench_function("rounup via remainder", |b| {
+    c.bench_function("roundup via remainder", |b| {
         b.iter(|| round_bench!(roundup_via_remainder))
     });
-    c.bench_function("rounup via bit ops", |b| {
+    c.bench_function("roundup via bit ops", |b| {
         b.iter(|| round_bench!(bits::roundup))
     });
-    c.bench_function("rounup via multication", |b| {
+    c.bench_function("roundup via multication", |b| {
         b.iter(|| round_bench!(roundup_via_multiplication))
     });
 }
 
 fn rounddown_benchmark(c: &mut Criterion) {
-    c.bench_function("rounup via remainder", |b| {
+    c.bench_function("roundup via remainder", |b| {
         b.iter(|| round_bench!(rounddown_via_remainder))
     });
-    c.bench_function("rounup via bit ops", |b| {
+    c.bench_function("roundup via bit ops", |b| {
         b.iter(|| round_bench!(bits::rounddown))
     });
-    c.bench_function("rounup via multication", |b| {
+    c.bench_function("roundup via multication", |b| {
         b.iter(|| round_bench!(rounddown_via_multiplication))
     });
 }

--- a/benches/vm_benchmark.rs
+++ b/benches/vm_benchmark.rs
@@ -90,6 +90,10 @@ fn aot_compiling_benchmark(c: &mut Criterion) {
     });
 }
 
+#[cfg(not(has_asm))]
+criterion_group!(benches, interpret_benchmark,);
+
+#[cfg(has_asm)]
 criterion_group!(
     benches,
     interpret_benchmark,


### PR DESCRIPTION
This PR includes three small changes:

- chore(deps): bump criterion from 0.2.11 to 0.3.0
- chore: typo
- chore: cfg criterion_group

