### PR TITLE
feat: Return loaded program consumed bytes

### DIFF
--- a/src/machine/asm/mod.rs
+++ b/src/machine/asm/mod.rs
@@ -239,9 +239,8 @@ impl<'a> AsmMachine<'a> {
         }
     }
 
-    pub fn load_program(&mut self, program: &Bytes, args: &[Bytes]) -> Result<(), Error> {
-        self.machine.load_program(program, args)?;
-        Ok(())
+    pub fn load_program(&mut self, program: &Bytes, args: &[Bytes]) -> Result<u64, Error> {
+        self.machine.load_program(program, args)
     }
 
     pub fn run(&mut self) -> Result<i8, Error> {

--- a/src/machine/trace.rs
+++ b/src/machine/trace.rs
@@ -92,9 +92,8 @@ impl<'a, R: Register, M: Memory<R>, Inner: SupportMachine<REG = R, MEM = WXorXMe
         }
     }
 
-    pub fn load_program(&mut self, program: &Bytes, args: &[Bytes]) -> Result<(), Error> {
-        self.machine.load_program(program, args)?;
-        Ok(())
+    pub fn load_program(&mut self, program: &Bytes, args: &[Bytes]) -> Result<u64, Error> {
+        self.machine.load_program(program, args)
     }
 
     pub fn run(&mut self) -> Result<i8, Error> {

--- a/tests/test_simple.rs
+++ b/tests/test_simple.rs
@@ -2,8 +2,8 @@ extern crate ckb_vm;
 
 use bytes::Bytes;
 use ckb_vm::{
-    run, DefaultCoreMachine, DefaultMachineBuilder, Error, FlatMemory, Instruction, SparseMemory,
-    SupportMachine,
+    run, DefaultCoreMachine, DefaultMachine, DefaultMachineBuilder, Error, FlatMemory, Instruction,
+    SparseMemory, SupportMachine,
 };
 use std::fs::File;
 use std::io::Read;
@@ -101,4 +101,18 @@ pub fn test_simple_invalid_bits() {
     let result = run::<u64, SparseMemory<u64>>(&buffer, &vec!["simple".into()]);
     assert!(result.is_err());
     assert_eq!(result.unwrap_err(), Error::InvalidElfBits);
+}
+
+#[test]
+pub fn test_simple_loaded_bytes() {
+    let mut file = File::open("tests/programs/simple64").unwrap();
+    let mut buffer = Vec::new();
+    file.read_to_end(&mut buffer).unwrap();
+    let buffer: Bytes = buffer.into();
+
+    let mut machine = DefaultMachine::<DefaultCoreMachine<u64, SparseMemory<u64>>>::default();
+    let bytes = machine
+        .load_program(&buffer, &vec!["simple".into()])
+        .unwrap();
+    assert_eq!(bytes, 4055);
 }


### PR DESCRIPTION
This allows us to charge proper cycles for bytes loaded via the program at CKB side.