### PR TITLE
Implement StdError for Error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ byteorder = "1"
 bytes = "0.4.12"
 goblin = "0.0.24"
 ckb-vm-definitions = { path = "definitions", version = "0.17.0" }
+derive_more = "0.15.0"
 
 # Feature detection won't work here
 [target.'cfg(any(windows, unix))'.dependencies]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,44 @@
+use std::error::Error as StdError;
+use std::io::{Error as IOError, ErrorKind};
+
+#[derive(Debug, PartialEq, Clone, Copy, Eq, Display)]
+pub enum Error {
+    #[display(fmt = "parse error")]
+    ParseError,
+    #[display(fmt = "unaligned page access")]
+    Unaligned,
+    #[display(fmt = "out of bound access")]
+    OutOfBound,
+    #[display(fmt = "max cycles exceeded")]
+    InvalidCycles,
+    #[display(fmt = "invalid instruction {}", "_0")]
+    InvalidInstruction(u32),
+    #[display(fmt = "invalid syscall {}", "_0")]
+    InvalidEcall(u64),
+    #[display(fmt = "invalid elf")]
+    InvalidElfBits,
+    #[display(fmt = "invalid operand {}", "_0")]
+    InvalidOp(u8),
+    #[display(fmt = "I/O error: {:?}", "_0")]
+    IO(ErrorKind),
+    #[display(fmt = "dynasm error {}", "_0")]
+    Dynasm(i32),
+    #[display(fmt = "assembly error {}", "_0")]
+    Asm(u8),
+    #[display(fmt = "limit reached")] // FIXME: Distinguish which limit
+    LimitReached,
+    #[display(fmt = "invalid permission")] // FIXME: Distinguish which permission
+    InvalidPermission,
+    #[display(fmt = "unexpected error")]
+    Unexpected,
+    #[display(fmt = "unimplemented")]
+    Unimplemented,
+}
+
+impl StdError for Error { }
+
+impl From<IOError> for Error {
+    fn from(error: IOError) -> Self {
+        Error::IO(error.kind())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,10 @@
+#[macro_use]
+extern crate derive_more;
+
 pub mod bits;
 pub mod debugger;
 pub mod decoder;
+pub mod error;
 pub mod instructions;
 pub mod machine;
 pub mod memory;
@@ -17,37 +21,13 @@ pub use crate::{
     syscalls::Syscalls,
 };
 use bytes::Bytes;
-use std::io::{Error as IOError, ErrorKind};
 
 pub use ckb_vm_definitions::{
     registers, DEFAULT_STACK_SIZE, RISCV_GENERAL_REGISTER_NUMBER, RISCV_MAX_MEMORY, RISCV_PAGES,
     RISCV_PAGESIZE,
 };
 
-#[derive(Debug, PartialEq, Clone, Copy, Eq)]
-pub enum Error {
-    ParseError,
-    Unaligned,
-    OutOfBound,
-    InvalidCycles,
-    InvalidInstruction(u32),
-    InvalidEcall(u64),
-    InvalidElfBits,
-    InvalidOp(u8),
-    IO(ErrorKind),
-    Dynasm(i32),
-    Asm(u8),
-    LimitReached,
-    InvalidPermission,
-    Unexpected,
-    Unimplemented,
-}
-
-impl From<IOError> for Error {
-    fn from(error: IOError) -> Self {
-        Error::IO(error.kind())
-    }
-}
+pub use error::Error;
 
 pub fn run<R: Register, M: Memory<R> + Default>(
     program: &Bytes,


### PR DESCRIPTION
This is pretty important for interop with other libraries.

I used derive_more for this, which is a fairly hefty proc macro. It could also be open-coded.