### PR TITLE
perf: Tweak slot calculation algorithm

### DIFF
--- a/definitions/src/asm.rs
+++ b/definitions/src/asm.rs
@@ -17,7 +17,7 @@ pub const RET_INVALID_PERMISSION: u8 = 7;
 
 #[inline(always)]
 pub fn calculate_slot(addr: u64) -> usize {
-    (addr as usize >> 5) & (TRACE_SIZE - 1)
+    (((addr >> 9).wrapping_add(addr) >> 1) & (TRACE_SIZE as u64 - 1)) as usize
 }
 
 #[derive(Default)]

--- a/src/machine/asm/execute.S
+++ b/src/machine/asm/execute.S
@@ -177,7 +177,9 @@ ckb_vm_x64_execute:
 .prepare_trace:
   movq PC_ADDRESS, %rax
   mov %eax, %ecx
-  shr $5, %eax
+  shr $9, %eax
+  addq PC_ADDRESS, %rax
+  shr $1, %eax
   andq $8191, %rax
   imul $CKB_VM_ASM_TRACE_STRUCT_SIZE, %eax
   lea CKB_VM_ASM_ASM_CORE_MACHINE_OFFSET_TRACES(MACHINE, %rax), TRACE

--- a/src/machine/trace.rs
+++ b/src/machine/trace.rs
@@ -18,7 +18,6 @@ const TRACE_MASK: usize = (TRACE_SIZE - 1);
 // The maximum number of instructions to cache in a trace item
 const TRACE_ITEM_LENGTH: usize = 16;
 // Shifts to truncate a value so 2 traces has the minimal chance of sharing code.
-const TRACE_ADDRESS_SHIFTS: usize = 5;
 
 #[derive(Default)]
 struct Trace {
@@ -30,7 +29,7 @@ struct Trace {
 
 #[inline(always)]
 fn calculate_slot(addr: u64) -> usize {
-    (addr as usize >> TRACE_ADDRESS_SHIFTS) & TRACE_MASK
+    (((addr >> 9).wrapping_add(addr) >> 1) & (TRACE_MASK as u64)) as usize
 }
 
 pub struct TraceMachine<'a, Inner> {


### PR DESCRIPTION
The previous slot calculation algorithm we use is optimized for large sequential programs. While this works for simpler cases, it often results in address conflicts in terms of programs with frequent branches. This PR changes the code to a new algorithm that balances between small basic blocks and large code segments. For our most common secp256k1 verification, this reduces ~15% of running time:

```
Benchmarking interpret secp256k1_bench via assembly: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 12.7s or reduce sample count to 40
interpret secp256k1_bench via assembly
                        time:   [2.5024 ms 2.5031 ms 2.5038 ms]
                        change: [-16.289% -16.251% -16.212%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe
```

For more complicated programs, such as [bn256g2](https://github.com/nervosnetwork/ckb-miscellaneous-scripts/blob/zk/c/bn256g2.hpp) where branches are more frequent, we noticed a 4x speedup.