### PR TITLE
Revert "perf: Tweak slot calculation algorithm"

### DIFF
--- a/definitions/src/asm.rs
+++ b/definitions/src/asm.rs
@@ -17,7 +17,7 @@ pub const RET_INVALID_PERMISSION: u8 = 7;
 
 #[inline(always)]
 pub fn calculate_slot(addr: u64) -> usize {
-    (((addr >> 9).wrapping_add(addr) >> 1) & (TRACE_SIZE as u64 - 1)) as usize
+    (addr as usize >> 5) & (TRACE_SIZE - 1)
 }
 
 #[derive(Default)]

--- a/src/machine/asm/execute.S
+++ b/src/machine/asm/execute.S
@@ -177,9 +177,7 @@ ckb_vm_x64_execute:
 .prepare_trace:
   movq PC_ADDRESS, %rax
   mov %eax, %ecx
-  shr $9, %eax
-  addq PC_ADDRESS, %rax
-  shr $1, %eax
+  shr $5, %eax
   andq $8191, %rax
   imul $CKB_VM_ASM_TRACE_STRUCT_SIZE, %eax
   lea CKB_VM_ASM_ASM_CORE_MACHINE_OFFSET_TRACES(MACHINE, %rax), TRACE

--- a/src/machine/trace.rs
+++ b/src/machine/trace.rs
@@ -18,6 +18,7 @@ const TRACE_MASK: usize = (TRACE_SIZE - 1);
 // The maximum number of instructions to cache in a trace item
 const TRACE_ITEM_LENGTH: usize = 16;
 // Shifts to truncate a value so 2 traces has the minimal chance of sharing code.
+const TRACE_ADDRESS_SHIFTS: usize = 5;
 
 #[derive(Default)]
 struct Trace {
@@ -29,7 +30,7 @@ struct Trace {
 
 #[inline(always)]
 fn calculate_slot(addr: u64) -> usize {
-    (((addr >> 9).wrapping_add(addr) >> 1) & (TRACE_MASK as u64)) as usize
+    (addr as usize >> TRACE_ADDRESS_SHIFTS) & TRACE_MASK
 }
 
 pub struct TraceMachine<'a, Inner> {


### PR DESCRIPTION
This reverts commit ae48232307535a1b6a3d4b8973b0592c7d433b5e.

While micro-benchmark shows the VM is indeed faster, when using on a large scale deployment in CKB, this causes CKB to have worse performance.