### PR TITLE
chore: Lock test suite commit version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
 env:
   global:
     - RUST_BACKTRACE=full
+    - TEST_SUITE_COMMIT=5d65d4b410c1f4dd74988d620e84f49eaea4c1a1
 
 matrix:
   include:
@@ -80,7 +81,8 @@ matrix:
         git clone --recursive https://github.com/nervosnetwork/ckb-vm-test-suite &&
         ln -snf .. ckb-vm-test-suite/ckb-vm &&
         docker run --rm -v `pwd`:/code xxuejie/riscv-gnu-toolchain-rv64imac:xenial-20190606 cp -r /riscv /code/riscv &&
-        RISCV=`pwd`/riscv ./ckb-vm-test-suite/test.sh
+        cd ckb-vm-test-suite && git checkout $TEST_SUITE_COMMIT &&
+        RISCV=`pwd`/../riscv ./test.sh
     - name: Code Coverage
       if: 'tag IS NOT present AND type != pull_request AND (branch = develop OR branch = master)'
       rust: 1.41.0
@@ -119,7 +121,8 @@ matrix:
         git clone --recursive https://github.com/nervosnetwork/ckb-vm-test-suite &&
         ln -snf .. ckb-vm-test-suite/ckb-vm &&
         docker run --rm -v `pwd`:/code xxuejie/riscv-gnu-toolchain-rv64imac:xenial-20190606 cp -r /riscv /code/riscv &&
-        RISCV=`pwd`/riscv ./ckb-vm-test-suite/test.sh --coverage &&
+        cd ckb-vm-test-suite && git checkout $TEST_SUITE_COMMIT &&
+        RISCV=`pwd`/../riscv ./test.sh --coverage &&
         make cov &&
         bash <(curl -s https://codecov.io/bash) &&
         echo "Uploaded code coverage"


### PR DESCRIPTION
This change locks the test suite version we are testing against, avoiding problems that multiple PRs will result in conflictions.