### PR TITLE
dependency: use mapr instead of memmap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ derive_more = "0.99.2"
 # Feature detection won't work here
 [target.'cfg(any(windows, unix))'.dependencies]
 libc = "0.2.47"
-memmap = "0.7.0"
+memmap = { package ="mapr", version = "0.8.0" }
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
- Fix #119 
