### PR TITLE
Cherry pick #120 and bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ckb-vm"
 description = "CKB's Virtual machine"
-version = "0.19.2"
+version = "0.19.3"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -19,7 +19,7 @@ byteorder = "1"
 bytes = "0.5.4"
 goblin = "0.2.0"
 scroll = "0.10"
-ckb-vm-definitions = { path = "definitions", version = "0.19.2" }
+ckb-vm-definitions = { path = "definitions", version = "0.19.3" }
 derive_more = "0.99.2"
 
 # Feature detection won't work here

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ derive_more = "0.99.2"
 # Feature detection won't work here
 [target.'cfg(any(windows, unix))'.dependencies]
 libc = "0.2.47"
-memmap = "0.7.0"
+memmap = { package ="mapr", version = "0.8.0" }
 
 [build-dependencies]
 cc = "1.0"

--- a/definitions/Cargo.toml
+++ b/definitions/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ckb-vm-definitions"
 description = "Common definition files for CKB VM"
-version = "0.19.2"
+version = "0.19.3"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"

--- a/src/machine/aot/aot.x64.compiled.c
+++ b/src/machine/aot/aot.x64.compiled.c
@@ -1,6 +1,6 @@
 /*
 ** This file has been pre-processed with DynASM.
-** http://luajit.org/dynasm.html
+** https://luajit.org/dynasm.html
 ** DynASM version 1.4.0, DynASM x64 version 1.4.0
 ** DO NOT EDIT! The original file is in "src/machine/aot/aot.x64.c".
 */

--- a/src/machine/aot/aot.x64.win.compiled.c
+++ b/src/machine/aot/aot.x64.win.compiled.c
@@ -1,6 +1,6 @@
 /*
 ** This file has been pre-processed with DynASM.
-** http://luajit.org/dynasm.html
+** https://luajit.org/dynasm.html
 ** DynASM version 1.4.0, DynASM x64 version 1.4.0
 ** DO NOT EDIT! The original file is in "src/machine/aot/aot.x64.c".
 */


### PR DESCRIPTION
- dependency: use mapr instead of memmap
- bump version to v0.19.3 [crates.io](https://crates.io/crates/ckb-vm)