### PR TITLE
chore: bump goblin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ enable-chaos-mode-by-default = ["ckb-vm-definitions/enable-chaos-mode-by-default
 [dependencies]
 byteorder = "1"
 bytes = "0.5.4"
-goblin = "0.2.0"
+goblin_v020 = { package = "goblin", version = "0.2.0" }
+goblin_v034 = { package = "goblin", version = "0.3.4" }
 scroll = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 ckb-vm-definitions = { path = "definitions", version = "0.19.1" }

--- a/definitions/src/asm.rs
+++ b/definitions/src/asm.rs
@@ -1,6 +1,6 @@
 use crate::{
-    instructions::Instruction, MEMORY_FRAMES, RISCV_GENERAL_REGISTER_NUMBER, RISCV_MAX_MEMORY,
-    RISCV_PAGES,
+    instructions::Instruction, ISA_IMC, MEMORY_FRAMES, RISCV_GENERAL_REGISTER_NUMBER,
+    RISCV_MAX_MEMORY, RISCV_PAGES,
 };
 use std::alloc::{alloc, Layout};
 
@@ -56,19 +56,12 @@ impl Default for Box<AsmCoreMachine> {
         // Since in AsmCoreMachine we will always have max_cycles, the best
         // way to solve the case that a max cycle is not available, is just
         // to assign the maximum value allowed in u64.
-        AsmCoreMachine::new_with_max_cycles(u64::max_value())
+        AsmCoreMachine::new(ISA_IMC, 0, u64::max_value())
     }
 }
 
 impl AsmCoreMachine {
     pub fn new(isa: u8, version: u32, max_cycles: u64) -> Box<AsmCoreMachine> {
-        let mut machine = Self::new_with_max_cycles(max_cycles);
-        machine.isa = isa;
-        machine.version = version;
-        machine
-    }
-
-    pub fn new_with_max_cycles(max_cycles: u64) -> Box<AsmCoreMachine> {
         let mut machine = unsafe {
             let layout = Layout::new::<AsmCoreMachine>();
             #[allow(clippy::cast_ptr_alignment)]
@@ -89,6 +82,8 @@ impl AsmCoreMachine {
             machine.chaos_mode = 0;
         }
         machine.chaos_seed = 0;
+        machine.version = version;
+        machine.isa = isa;
         machine.flags = [0; RISCV_PAGES];
         for i in 0..TRACE_SIZE {
             machine.traces[i] = Trace::default();

--- a/fuzz/fuzz_targets/asm.rs
+++ b/fuzz/fuzz_targets/asm.rs
@@ -1,13 +1,12 @@
 #![no_main]
 use bytes::Bytes;
-use ckb_vm::{
-    machine::asm::{AsmCoreMachine, AsmMachine},
-    DefaultMachineBuilder
-};
+use ckb_vm::machine::asm::{AsmCoreMachine, AsmMachine};
+use ckb_vm::machine::{DefaultMachineBuilder, VERSION0};
+use ckb_vm::ISA_IMC;
 use libfuzzer_sys::fuzz_target;
 
 fn run(data: &[u8]) {
-    let asm_core = AsmCoreMachine::new_with_max_cycles(200_000);
+    let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, 200_000);
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
         .instruction_cycle_func(Box::new(|_| 1))
         .build();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,10 @@ pub use crate::{
     debugger::Debugger,
     instructions::{Instruction, Register},
     machine::{
-        parse_elf, trace::TraceMachine, CoreMachine, DefaultCoreMachine, DefaultMachine,
-        DefaultMachineBuilder, InstructionCycleFunc, Machine, SupportMachine,
+        elf_adaptor::{parse_elf_v0, parse_elf_v1},
+        trace::TraceMachine,
+        CoreMachine, DefaultCoreMachine, DefaultMachine, DefaultMachineBuilder,
+        InstructionCycleFunc, Machine, SupportMachine,
     },
     memory::{flat::FlatMemory, sparse::SparseMemory, wxorx::WXorXMemory, Memory},
     syscalls::Syscalls,

--- a/src/machine/asm/mod.rs
+++ b/src/machine/asm/mod.rs
@@ -11,7 +11,6 @@ use ckb_vm_definitions::{
     instructions::OP_CUSTOM_TRACE_END,
     MEMORY_FRAME_PAGE_SHIFTS,
 };
-use goblin::elf::Elf;
 use libc::c_uchar;
 use rand::{prelude::RngCore, SeedableRng};
 
@@ -21,7 +20,7 @@ use crate::{
         blank_instruction, execute_instruction, extract_opcode, instruction_length,
         is_basic_block_end_instruction,
     },
-    machine::aot::AotCode,
+    machine::{aot::AotCode, elf_adaptor},
     memory::{
         check_permission, fill_page_data, get_page_indices, memset, round_page_down, round_page_up,
         set_dirty, FLAG_EXECUTABLE, FLAG_FREEZED, FLAG_WRITABLE,
@@ -347,7 +346,7 @@ impl<'a> AsmMachine<'a> {
         &mut self,
         program: &Bytes,
         args: &[Bytes],
-        elf: &Elf,
+        elf: &elf_adaptor::Elf,
     ) -> Result<u64, Error> {
         self.machine.load_program_elf(program, args, elf)
     }

--- a/src/machine/elf_adaptor.rs
+++ b/src/machine/elf_adaptor.rs
@@ -1,0 +1,187 @@
+// This module maps the data structure of different versions of goblin to the
+// same internal structure.
+use crate::memory::{FLAG_EXECUTABLE, FLAG_FREEZED};
+use crate::Error;
+
+use bytes::Bytes;
+
+// Even for different versions of goblin, their values must be consistent.
+pub use goblin_v020::elf::program_header::{PF_R, PF_W, PF_X, PT_LOAD};
+pub use goblin_v020::elf::section_header::SHF_EXECINSTR;
+
+pub fn parse_elf_v0(program: &Bytes) -> Result<goblin_v020::elf::Elf, Error> {
+    goblin_v020::elf::Elf::parse(program).map_err(|_e| Error::ParseError)
+}
+
+pub fn parse_elf_v1(program: &Bytes) -> Result<goblin_v034::elf::Elf, Error> {
+    goblin_v034::elf::Elf::parse(program).map_err(|_e| Error::ParseError)
+}
+
+/// Converts goblin's ELF flags into RISC-V flags
+pub fn convert_flags(p_flags: u32) -> Result<u8, Error> {
+    let readable = p_flags & PF_R != 0;
+    let writable = p_flags & PF_W != 0;
+    let executable = p_flags & PF_X != 0;
+    if (!readable) || (writable && executable) {
+        return Err(Error::InvalidPermission);
+    }
+    if executable {
+        Ok(FLAG_EXECUTABLE | FLAG_FREEZED)
+    } else {
+        Ok(FLAG_FREEZED)
+    }
+}
+
+/// Same as goblin::elf::Header.
+pub struct Header {
+    // Container is 32 or 64.
+    pub container: u8,
+    pub e_entry: u64,
+}
+
+impl Header {
+    pub fn from_v0(header: goblin_v020::elf::Header) -> Result<Self, Error> {
+        let container = header.container().map_err(|_e| Error::InvalidElfBits)?;
+        let bits = if container.is_big() { 64 } else { 32 };
+        Ok(Header {
+            container: bits,
+            e_entry: header.e_entry,
+        })
+    }
+
+    pub fn from_v1(header: goblin_v034::elf::Header) -> Result<Self, Error> {
+        let container = header.container().map_err(|_e| Error::InvalidElfBits)?;
+        let bits = if container.is_big() { 64 } else { 32 };
+        Ok(Header {
+            container: bits,
+            e_entry: header.e_entry,
+        })
+    }
+}
+
+/// Same as goblin::elf::ProgramHeader.
+pub struct ProgramHeader {
+    pub p_type: u32,
+    pub p_flags: u32,
+    pub p_offset: u64,
+    pub p_vaddr: u64,
+    pub p_paddr: u64,
+    pub p_filesz: u64,
+    pub p_memsz: u64,
+    pub p_align: u64,
+}
+
+impl ProgramHeader {
+    pub fn from_v0(header: &goblin_v020::elf::ProgramHeader) -> Self {
+        Self {
+            p_type: header.p_type,
+            p_flags: header.p_flags,
+            p_offset: header.p_offset,
+            p_vaddr: header.p_vaddr,
+            p_paddr: header.p_paddr,
+            p_filesz: header.p_filesz,
+            p_memsz: header.p_memsz,
+            p_align: header.p_align,
+        }
+    }
+
+    pub fn from_v1(header: &goblin_v034::elf::ProgramHeader) -> Self {
+        Self {
+            p_type: header.p_type,
+            p_flags: header.p_flags,
+            p_offset: header.p_offset,
+            p_vaddr: header.p_vaddr,
+            p_paddr: header.p_paddr,
+            p_filesz: header.p_filesz,
+            p_memsz: header.p_memsz,
+            p_align: header.p_align,
+        }
+    }
+}
+
+/// Same as goblin::elf::SectionHeader.
+pub struct SectionHeader {
+    pub sh_name: usize,
+    pub sh_type: u32,
+    pub sh_flags: u64,
+    pub sh_addr: u64,
+    pub sh_offset: u64,
+    pub sh_size: u64,
+    pub sh_link: u32,
+    pub sh_info: u32,
+    pub sh_addralign: u64,
+    pub sh_entsize: u64,
+}
+
+impl SectionHeader {
+    pub fn from_v0(header: &goblin_v020::elf::SectionHeader) -> Self {
+        Self {
+            sh_name: header.sh_name,
+            sh_type: header.sh_type,
+            sh_flags: header.sh_flags,
+            sh_addr: header.sh_addr,
+            sh_offset: header.sh_offset,
+            sh_size: header.sh_size,
+            sh_link: header.sh_link,
+            sh_info: header.sh_info,
+            sh_addralign: header.sh_addralign,
+            sh_entsize: header.sh_entsize,
+        }
+    }
+
+    pub fn from_v1(header: &goblin_v034::elf::SectionHeader) -> Self {
+        Self {
+            sh_name: header.sh_name,
+            sh_type: header.sh_type,
+            sh_flags: header.sh_flags,
+            sh_addr: header.sh_addr,
+            sh_offset: header.sh_offset,
+            sh_size: header.sh_size,
+            sh_link: header.sh_link,
+            sh_info: header.sh_info,
+            sh_addralign: header.sh_addralign,
+            sh_entsize: header.sh_entsize,
+        }
+    }
+}
+
+/// An internal ELF binary.
+pub struct Elf {
+    pub header: Header,
+    pub program_headers: Vec<ProgramHeader>,
+    pub section_headers: Vec<SectionHeader>,
+}
+
+impl Elf {
+    pub fn from_v0(elf: goblin_v020::elf::Elf) -> Result<Self, Error> {
+        Ok(Elf {
+            header: Header::from_v0(elf.header)?,
+            program_headers: elf
+                .program_headers
+                .iter()
+                .map(|e| ProgramHeader::from_v0(e))
+                .collect(),
+            section_headers: elf
+                .section_headers
+                .iter()
+                .map(|e| SectionHeader::from_v0(e))
+                .collect(),
+        })
+    }
+
+    pub fn from_v1(elf: goblin_v034::elf::Elf) -> Result<Self, Error> {
+        Ok(Elf {
+            header: Header::from_v1(elf.header)?,
+            program_headers: elf
+                .program_headers
+                .iter()
+                .map(|e| ProgramHeader::from_v1(e))
+                .collect(),
+            section_headers: elf
+                .section_headers
+                .iter()
+                .map(|e| SectionHeader::from_v1(e))
+                .collect(),
+        })
+    }
+}

--- a/src/machine/trace.rs
+++ b/src/machine/trace.rs
@@ -6,10 +6,9 @@ use super::{
         },
         Error,
     },
-    CoreMachine, DefaultMachine, Machine, SupportMachine,
+    elf_adaptor, CoreMachine, DefaultMachine, Machine, SupportMachine,
 };
 use bytes::Bytes;
-use goblin::elf::Elf;
 
 // The number of trace items to keep
 const TRACE_SIZE: usize = 8192;
@@ -102,9 +101,9 @@ impl<'a, Inner: SupportMachine> TraceMachine<'a, Inner> {
         &mut self,
         program: &Bytes,
         args: &[Bytes],
-        elf: &Elf,
+        elf_adaptor: &elf_adaptor::Elf,
     ) -> Result<u64, Error> {
-        self.machine.load_program_elf(program, args, elf)
+        self.machine.load_program_elf(program, args, elf_adaptor)
     }
 
     pub fn run(&mut self) -> Result<i8, Error> {

--- a/tests/test_aot.rs
+++ b/tests/test_aot.rs
@@ -131,7 +131,7 @@ pub fn test_aot_simple_cycles() {
     file.read_to_end(&mut buffer).unwrap();
     let buffer: Bytes = buffer.into();
 
-    let asm_core = AsmCoreMachine::new_with_max_cycles(517);
+    let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, 517);
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
         .instruction_cycle_func(Box::new(dummy_cycle_func))
         .build();
@@ -158,7 +158,7 @@ pub fn test_aot_simple_max_cycles_reached() {
     let buffer: Bytes = buffer.into();
 
     // Running simple64 should consume 517 cycles using dummy cycle func
-    let asm_core = AsmCoreMachine::new_with_max_cycles(500);
+    let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, 500);
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
         .instruction_cycle_func(Box::new(dummy_cycle_func))
         .build();

--- a/tests/test_asm.rs
+++ b/tests/test_asm.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 use ckb_vm::{
     machine::{
         asm::{AsmCoreMachine, AsmMachine},
-        CoreMachine, VERSION1,
+        CoreMachine, VERSION0, VERSION1,
     },
     memory::Memory,
     registers::{A0, A1, A2, A3, A4, A5, A7},
@@ -124,7 +124,7 @@ pub fn test_asm_simple_cycles() {
     file.read_to_end(&mut buffer).unwrap();
     let buffer: Bytes = buffer.into();
 
-    let asm_core = AsmCoreMachine::new_with_max_cycles(517);
+    let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, 517);
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
         .instruction_cycle_func(Box::new(dummy_cycle_func))
         .build();
@@ -147,7 +147,7 @@ pub fn test_asm_simple_max_cycles_reached() {
     let buffer: Bytes = buffer.into();
 
     // Running simple64 should consume 517 cycles using dummy cycle func
-    let asm_core = AsmCoreMachine::new_with_max_cycles(500);
+    let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, 500);
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
         .instruction_cycle_func(Box::new(dummy_cycle_func))
         .build();

--- a/tests/test_misc.rs
+++ b/tests/test_misc.rs
@@ -4,10 +4,11 @@ use bytes::Bytes;
 #[cfg(has_asm)]
 use ckb_vm::machine::asm::AsmCoreMachine;
 use ckb_vm::{
-    parse_elf,
+    machine::{elf_adaptor::Elf, VERSION0},
+    parse_elf_v0 as parse_elf,
     registers::{A0, A1, A2, A3, A4, A5, A7},
     run, CoreMachine, Debugger, DefaultCoreMachine, DefaultMachine, DefaultMachineBuilder, Error,
-    FlatMemory, Memory, Register, SparseMemory, SupportMachine, Syscalls, WXorXMemory,
+    FlatMemory, Memory, Register, SparseMemory, SupportMachine, Syscalls, WXorXMemory, ISA_IMC,
 };
 use ckb_vm_definitions::RISCV_PAGESIZE;
 use std::fs::File;
@@ -250,7 +251,7 @@ pub fn test_memory_store_empty_bytes() {
     assert_memory_store_empty_bytes(&mut SparseMemory::<u64>::default());
     assert_memory_store_empty_bytes(&mut WXorXMemory::<FlatMemory<u64>>::default());
     #[cfg(has_asm)]
-    assert_memory_store_empty_bytes(&mut AsmCoreMachine::new_with_max_cycles(200_000));
+    assert_memory_store_empty_bytes(&mut AsmCoreMachine::new(ISA_IMC, VERSION0, 200_000));
 }
 
 fn assert_memory_store_empty_bytes<M: Memory>(memory: &mut M) {
@@ -281,7 +282,7 @@ pub fn test_contains_ckbforks_section() {
     let mut machine =
         DefaultMachineBuilder::<DefaultCoreMachine<u64, SparseMemory<u64>>>::default().build();
     machine
-        .load_program_elf(&buffer, &vec!["ebreak".into()], &elf)
+        .load_program_elf(&buffer, &vec!["ebreak".into()], &Elf::from_v0(elf).unwrap())
         .unwrap();
     let result = machine.run();
     assert!(result.is_ok());

--- a/tests/test_simple.rs
+++ b/tests/test_simple.rs
@@ -1,9 +1,10 @@
 extern crate ckb_vm;
 
 use bytes::Bytes;
+use ckb_vm::machine::VERSION0;
 use ckb_vm::{
     run, DefaultCoreMachine, DefaultMachine, DefaultMachineBuilder, Error, FlatMemory, Instruction,
-    SparseMemory, SupportMachine,
+    SparseMemory, SupportMachine, ISA_IMC,
 };
 use std::fs::File;
 use std::io::Read;
@@ -55,7 +56,7 @@ pub fn test_simple_cycles() {
     file.read_to_end(&mut buffer).unwrap();
     let buffer: Bytes = buffer.into();
 
-    let core_machine = DefaultCoreMachine::<u64, SparseMemory<u64>>::new_with_max_cycles(517);
+    let core_machine = DefaultCoreMachine::<u64, SparseMemory<u64>>::new(ISA_IMC, VERSION0, 517);
     let mut machine =
         DefaultMachineBuilder::<DefaultCoreMachine<u64, SparseMemory<u64>>>::new(core_machine)
             .instruction_cycle_func(Box::new(dummy_cycle_func))
@@ -78,7 +79,7 @@ pub fn test_simple_max_cycles_reached() {
     let buffer: Bytes = buffer.into();
 
     // Running simple64 should consume 517 cycles using dummy cycle func
-    let core_machine = DefaultCoreMachine::<u64, SparseMemory<u64>>::new_with_max_cycles(500);
+    let core_machine = DefaultCoreMachine::<u64, SparseMemory<u64>>::new(ISA_IMC, VERSION0, 500);
     let mut machine =
         DefaultMachineBuilder::<DefaultCoreMachine<u64, SparseMemory<u64>>>::new(core_machine)
             .instruction_cycle_func(Box::new(dummy_cycle_func))


### PR DESCRIPTION
Different version of goblin crates will be used for different version of machines:

- when machine.version == VERSION0, goblin = "0.2.0"
- when machine.version == VERSION1, goblin = "0.3.4"

Fix:
- In the test case, AsmMachineCore.version is now fixed to VERSION0 instead of a random value.