### PR TITLE
refactor: simplify memory trait design

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -54,11 +54,7 @@ impl Decoder {
     // Also, due to RISC-V encoding behavior, it's totally okay when we cast a 16-bit
     // RVC instruction into a 32-bit instruction, the meaning of the instruction stays
     // unchanged in the cast conversion.
-    fn decode_bits<R: Register, M: Memory<R>>(
-        &self,
-        memory: &mut M,
-        pc: u64,
-    ) -> Result<u32, Error> {
+    fn decode_bits<M: Memory>(&self, memory: &mut M, pc: u64) -> Result<u32, Error> {
         let mut instruction_bits = u32::from(memory.execute_load16(pc)?);
         if instruction_bits & 0x3 == 0x3 {
             instruction_bits |= u32::from(memory.execute_load16(pc + 2)?) << 16;
@@ -66,11 +62,7 @@ impl Decoder {
         Ok(instruction_bits)
     }
 
-    pub fn decode<R: Register, M: Memory<R>>(
-        &self,
-        memory: &mut M,
-        pc: u64,
-    ) -> Result<Instruction, Error> {
+    pub fn decode<M: Memory>(&self, memory: &mut M, pc: u64) -> Result<Instruction, Error> {
         let instruction_bits = self.decode_bits(memory, pc)?;
         for factory in &self.factories {
             if let Some(instruction) = factory(instruction_bits, self.version) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,11 +31,11 @@ pub use ckb_vm_definitions::{
 
 pub use error::Error;
 
-pub fn run<R: Register, M: Memory<R> + Default>(
+pub fn run<R: Register, M: Memory<REG = R> + Default>(
     program: &Bytes,
     args: &[Bytes],
 ) -> Result<i8, Error> {
-    let core_machine = DefaultCoreMachine::<R, WXorXMemory<R, M>>::latest();
+    let core_machine = DefaultCoreMachine::<R, WXorXMemory<M>>::latest();
     let mut machine = TraceMachine::new(DefaultMachineBuilder::new(core_machine).build());
     machine.load_program(program, args)?;
     machine.run()

--- a/src/machine/aot/mod.rs
+++ b/src/machine/aot/mod.rs
@@ -294,7 +294,9 @@ impl Machine for LabelGatheringMachine {
     }
 }
 
-impl Memory<Value> for LabelGatheringMachine {
+impl Memory for LabelGatheringMachine {
+    type REG = Value;
+
     fn init_pages(
         &mut self,
         _addr: u64,
@@ -623,7 +625,9 @@ impl Machine for AotCompilingMachine {
     }
 }
 
-impl Memory<Value> for AotCompilingMachine {
+impl Memory for AotCompilingMachine {
+    type REG = Value;
+
     fn init_pages(
         &mut self,
         _addr: u64,

--- a/src/machine/asm/mod.rs
+++ b/src/machine/asm/mod.rs
@@ -94,7 +94,9 @@ fn check_memory(machine: &mut AsmCoreMachine, page_indices: &(u64, u64)) -> Resu
     Ok(())
 }
 
-impl Memory<u64> for Box<AsmCoreMachine> {
+impl Memory for Box<AsmCoreMachine> {
+    type REG = u64;
+
     fn init_pages(
         &mut self,
         addr: u64,

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -54,7 +54,7 @@ fn convert_flags(p_flags: u32) -> Result<u8, Error> {
 /// syscall support.
 pub trait CoreMachine {
     type REG: Register;
-    type MEM: Memory<Self::REG>;
+    type MEM: Memory<REG = Self::REG>;
 
     fn pc(&self) -> &Self::REG;
     fn set_pc(&mut self, next_pc: Self::REG);
@@ -244,7 +244,7 @@ pub struct DefaultCoreMachine<R, M> {
     version: u32,
 }
 
-impl<R: Register, M: Memory<R>> CoreMachine for DefaultCoreMachine<R, M> {
+impl<R: Register, M: Memory<REG = R>> CoreMachine for DefaultCoreMachine<R, M> {
     type REG = R;
     type MEM = M;
     fn pc(&self) -> &Self::REG {
@@ -276,7 +276,7 @@ impl<R: Register, M: Memory<R>> CoreMachine for DefaultCoreMachine<R, M> {
     }
 }
 
-impl<R: Register, M: Memory<R>> SupportMachine for DefaultCoreMachine<R, M> {
+impl<R: Register, M: Memory<REG = R>> SupportMachine for DefaultCoreMachine<R, M> {
     fn cycles(&self) -> u64 {
         self.cycles
     }
@@ -298,7 +298,7 @@ impl<R: Register, M: Memory<R>> SupportMachine for DefaultCoreMachine<R, M> {
     }
 }
 
-impl<R: Register, M: Memory<R> + Default> DefaultCoreMachine<R, M> {
+impl<R: Register, M: Memory + Default> DefaultCoreMachine<R, M> {
     pub fn new(version: u32, max_cycles: u64) -> Self {
         Self {
             version,

--- a/src/machine/trace.rs
+++ b/src/machine/trace.rs
@@ -4,7 +4,6 @@ use super::{
         instructions::{
             execute, instruction_length, is_basic_block_end_instruction, Instruction, Register,
         },
-        memory::{wxorx::WXorXMemory, Memory},
         Error,
     },
     CoreMachine, DefaultMachine, Machine, SupportMachine,
@@ -40,9 +39,7 @@ pub struct TraceMachine<'a, Inner> {
     traces: Vec<Trace>,
 }
 
-impl<R: Register, M: Memory<R>, Inner: SupportMachine<REG = R, MEM = WXorXMemory<R, M>>> CoreMachine
-    for TraceMachine<'_, Inner>
-{
+impl<Inner: SupportMachine> CoreMachine for TraceMachine<'_, Inner> {
     type REG = <Inner as CoreMachine>::REG;
     type MEM = <Inner as CoreMachine>::MEM;
 
@@ -75,9 +72,7 @@ impl<R: Register, M: Memory<R>, Inner: SupportMachine<REG = R, MEM = WXorXMemory
     }
 }
 
-impl<R: Register, M: Memory<R>, Inner: SupportMachine<REG = R, MEM = WXorXMemory<R, M>>> Machine
-    for TraceMachine<'_, Inner>
-{
+impl<Inner: SupportMachine> Machine for TraceMachine<'_, Inner> {
     fn ecall(&mut self) -> Result<(), Error> {
         self.machine.ecall()
     }
@@ -87,9 +82,7 @@ impl<R: Register, M: Memory<R>, Inner: SupportMachine<REG = R, MEM = WXorXMemory
     }
 }
 
-impl<'a, R: Register, M: Memory<R>, Inner: SupportMachine<REG = R, MEM = WXorXMemory<R, M>>>
-    TraceMachine<'a, Inner>
-{
+impl<'a, Inner: SupportMachine> TraceMachine<'a, Inner> {
     pub fn new(machine: DefaultMachine<'a, Inner>) -> Self {
         Self {
             machine,

--- a/src/memory/sparse.rs
+++ b/src/memory/sparse.rs
@@ -74,7 +74,9 @@ impl<R> SparseMemory<R> {
     }
 }
 
-impl<R: Register> Memory<R> for SparseMemory<R> {
+impl<R: Register> Memory for SparseMemory<R> {
+    type REG = R;
+
     fn init_pages(
         &mut self,
         addr: u64,
@@ -112,24 +114,24 @@ impl<R: Register> Memory<R> for SparseMemory<R> {
         }
     }
 
-    fn load8(&mut self, addr: &R) -> Result<R, Error> {
+    fn load8(&mut self, addr: &Self::REG) -> Result<Self::REG, Error> {
         let v = self.load(addr.to_u64(), 1).map(|v| v as u8)?;
-        Ok(R::from_u8(v))
+        Ok(Self::REG::from_u8(v))
     }
 
-    fn load16(&mut self, addr: &R) -> Result<R, Error> {
+    fn load16(&mut self, addr: &Self::REG) -> Result<Self::REG, Error> {
         let v = self.load(addr.to_u64(), 2).map(|v| v as u16)?;
-        Ok(R::from_u16(v))
+        Ok(Self::REG::from_u16(v))
     }
 
-    fn load32(&mut self, addr: &R) -> Result<R, Error> {
+    fn load32(&mut self, addr: &Self::REG) -> Result<Self::REG, Error> {
         let v = self.load(addr.to_u64(), 4).map(|v| v as u32)?;
-        Ok(R::from_u32(v))
+        Ok(Self::REG::from_u32(v))
     }
 
-    fn load64(&mut self, addr: &R) -> Result<R, Error> {
+    fn load64(&mut self, addr: &Self::REG) -> Result<Self::REG, Error> {
         let v = self.load(addr.to_u64(), 8)?;
-        Ok(R::from_u64(v))
+        Ok(Self::REG::from_u64(v))
     }
 
     fn execute_load16(&mut self, addr: u64) -> Result<u16, Error> {
@@ -178,17 +180,17 @@ impl<R: Register> Memory<R> for SparseMemory<R> {
         Ok(())
     }
 
-    fn store8(&mut self, addr: &R, value: &R) -> Result<(), Error> {
+    fn store8(&mut self, addr: &Self::REG, value: &Self::REG) -> Result<(), Error> {
         self.store_bytes(addr.to_u64(), &[value.to_u8()])
     }
 
-    fn store16(&mut self, addr: &R, value: &R) -> Result<(), Error> {
+    fn store16(&mut self, addr: &Self::REG, value: &Self::REG) -> Result<(), Error> {
         let value = value.to_u16();
         // RISC-V is little-endian by specification
         self.store_bytes(addr.to_u64(), &[(value & 0xFF) as u8, (value >> 8) as u8])
     }
 
-    fn store32(&mut self, addr: &R, value: &R) -> Result<(), Error> {
+    fn store32(&mut self, addr: &Self::REG, value: &Self::REG) -> Result<(), Error> {
         let value = value.to_u32();
         // RISC-V is little-endian by specification
         self.store_bytes(
@@ -202,7 +204,7 @@ impl<R: Register> Memory<R> for SparseMemory<R> {
         )
     }
 
-    fn store64(&mut self, addr: &R, value: &R) -> Result<(), Error> {
+    fn store64(&mut self, addr: &Self::REG, value: &Self::REG) -> Result<(), Error> {
         let value = value.to_u64();
         // RISC-V is little-endian by specification
         self.store_bytes(

--- a/src/memory/wxorx.rs
+++ b/src/memory/wxorx.rs
@@ -5,29 +5,28 @@ use super::{
 };
 
 use bytes::Bytes;
-use std::marker::PhantomData;
 
-pub struct WXorXMemory<R: Register, M: Memory<R>> {
+pub struct WXorXMemory<M: Memory> {
     inner: M,
-    _inner: PhantomData<R>,
 }
 
-impl<R: Register, M: Memory<R> + Default> Default for WXorXMemory<R, M> {
+impl<M: Memory + Default> Default for WXorXMemory<M> {
     fn default() -> Self {
         Self {
             inner: M::default(),
-            _inner: PhantomData,
         }
     }
 }
 
-impl<R: Register, M: Memory<R>> WXorXMemory<R, M> {
-    pub fn inner_mut(&mut self) -> &mut dyn Memory<R> {
+impl<M: Memory> WXorXMemory<M> {
+    pub fn inner_mut(&mut self) -> &mut M {
         &mut self.inner
     }
 }
 
-impl<R: Register, M: Memory<R>> Memory<R> for WXorXMemory<R, M> {
+impl<M: Memory> Memory for WXorXMemory<M> {
+    type REG = M::REG;
+
     fn init_pages(
         &mut self,
         addr: u64,
@@ -75,41 +74,41 @@ impl<R: Register, M: Memory<R>> Memory<R> for WXorXMemory<R, M> {
         self.inner.execute_load16(addr)
     }
 
-    fn load8(&mut self, addr: &R) -> Result<R, Error> {
+    fn load8(&mut self, addr: &Self::REG) -> Result<Self::REG, Error> {
         self.inner.load8(addr)
     }
 
-    fn load16(&mut self, addr: &R) -> Result<R, Error> {
+    fn load16(&mut self, addr: &Self::REG) -> Result<Self::REG, Error> {
         self.inner.load16(addr)
     }
 
-    fn load32(&mut self, addr: &R) -> Result<R, Error> {
+    fn load32(&mut self, addr: &Self::REG) -> Result<Self::REG, Error> {
         self.inner.load32(addr)
     }
 
-    fn load64(&mut self, addr: &R) -> Result<R, Error> {
+    fn load64(&mut self, addr: &Self::REG) -> Result<Self::REG, Error> {
         self.inner.load64(addr)
     }
 
-    fn store8(&mut self, addr: &R, value: &R) -> Result<(), Error> {
+    fn store8(&mut self, addr: &Self::REG, value: &Self::REG) -> Result<(), Error> {
         let page_indices = get_page_indices(addr.to_u64(), 1)?;
         check_permission(self, &page_indices, FLAG_WRITABLE)?;
         self.inner.store8(addr, value)
     }
 
-    fn store16(&mut self, addr: &R, value: &R) -> Result<(), Error> {
+    fn store16(&mut self, addr: &Self::REG, value: &Self::REG) -> Result<(), Error> {
         let page_indices = get_page_indices(addr.to_u64(), 2)?;
         check_permission(self, &page_indices, FLAG_WRITABLE)?;
         self.inner.store16(addr, value)
     }
 
-    fn store32(&mut self, addr: &R, value: &R) -> Result<(), Error> {
+    fn store32(&mut self, addr: &Self::REG, value: &Self::REG) -> Result<(), Error> {
         let page_indices = get_page_indices(addr.to_u64(), 4)?;
         check_permission(self, &page_indices, FLAG_WRITABLE)?;
         self.inner.store32(addr, value)
     }
 
-    fn store64(&mut self, addr: &R, value: &R) -> Result<(), Error> {
+    fn store64(&mut self, addr: &Self::REG, value: &Self::REG) -> Result<(), Error> {
         let page_indices = get_page_indices(addr.to_u64(), 8)?;
         check_permission(self, &page_indices, FLAG_WRITABLE)?;
         self.inner.store64(addr, value)

--- a/tests/test_versions.rs
+++ b/tests/test_versions.rs
@@ -14,7 +14,7 @@ use ckb_vm::{
 use std::fs::File;
 use std::io::Read;
 
-type Mem = WXorXMemory<u64, SparseMemory<u64>>;
+type Mem = WXorXMemory<SparseMemory<u64>>;
 
 fn create_rust_machine<'a>(
     program: String,


### PR DESCRIPTION
This PR replaced `Memory` trait's `Register` generic type by associated type, which simplifed the fn parameter and removed some dynamic dispatches, for example:
https://github.com/nervosnetwork/ckb-vm/blob/3a4484b0472193c29329560c0d461096b4352e17/src/memory/mod.rs#L64

We can move fn `set_dirty` and `check_permission` to `Memory` trait as a default implementation after this PR.