### PR TITLE
perf: avoids vec allocation

### DIFF
--- a/src/machine/asm/mod.rs
+++ b/src/machine/asm/mod.rs
@@ -82,12 +82,9 @@ pub extern "C" fn inited_memory(frame_index: u64, machine: &mut AsmCoreMachine) 
     }
 }
 
-fn check_memory(machine: &mut AsmCoreMachine, page_indices: &[u64]) -> Result<(), Error> {
-    if page_indices.is_empty() {
-        return Ok(());
-    }
-    let frame = page_indices[0] >> MEMORY_FRAME_PAGE_SHIFTS;
-    let frame_end = page_indices.last().unwrap() >> MEMORY_FRAME_PAGE_SHIFTS;
+fn check_memory(machine: &mut AsmCoreMachine, page_indices: &(u64, u64)) -> Result<(), Error> {
+    let frame = page_indices.0 >> MEMORY_FRAME_PAGE_SHIFTS;
+    let frame_end = page_indices.1 >> MEMORY_FRAME_PAGE_SHIFTS;
     for i in frame..=frame_end {
         if machine.frames[i as usize] == 0 {
             inited_memory(i, machine);


### PR DESCRIPTION
This PR resolves performance regression issue by avoiding vec allocation in the `get_page_indices` fn, v.s develop branch benchmark result:

This PR:
```
interpret secp256k1_bench                                                                            
                        time:   [14.380 ms 14.470 ms 14.563 ms]
                        change: [-25.810% -25.247% -24.691%] (p = 0.00 < 0.05)

interpret secp256k1_bench via assembly                                                                             
                        time:   [2.5516 ms 2.5567 ms 2.5621 ms]
                        change: [-78.186% -77.968% -77.798%] (p = 0.00 < 0.05)
```

develop branch:
```
nterpret secp256k1_bench                                                                            
                        time:   [19.299 ms 19.357 ms 19.427 ms]

interpret secp256k1_bench via assembly                                                                            
                        time:   [11.519 ms 11.605 ms 11.720 ms]
```