### PR TITLE
fix: resolve overflow issue of store_bytes fn

### DIFF
--- a/src/machine/asm/mod.rs
+++ b/src/machine/asm/mod.rs
@@ -163,7 +163,9 @@ impl Memory for Box<AsmCoreMachine> {
     }
 
     fn store_bytes(&mut self, addr: u64, value: &[u8]) -> Result<(), Error> {
-        // Out of bound check is already performed in get_page_indices
+        if value.is_empty() {
+            return Ok(());
+        }
         let page_indices = get_page_indices(addr, value.len() as u64)?;
         check_permission(self, &page_indices, FLAG_WRITABLE)?;
         check_memory(self, &page_indices)?;
@@ -174,6 +176,9 @@ impl Memory for Box<AsmCoreMachine> {
     }
 
     fn store_byte(&mut self, addr: u64, size: u64, value: u8) -> Result<(), Error> {
+        if size == 0 {
+            return Ok(());
+        }
         let page_indices = get_page_indices(addr, size)?;
         check_permission(self, &page_indices, FLAG_WRITABLE)?;
         check_memory(self, &page_indices)?;

--- a/src/memory/flat.rs
+++ b/src/memory/flat.rs
@@ -172,6 +172,9 @@ impl<R: Register> Memory for FlatMemory<R> {
 
     fn store_bytes(&mut self, addr: u64, value: &[u8]) -> Result<(), Error> {
         let size = value.len() as u64;
+        if size == 0 {
+            return Ok(());
+        }
         let page_indices = get_page_indices(addr.to_u64(), size)?;
         set_dirty(self, &page_indices)?;
         let slice = &mut self[addr as usize..(addr + size) as usize];
@@ -180,6 +183,9 @@ impl<R: Register> Memory for FlatMemory<R> {
     }
 
     fn store_byte(&mut self, addr: u64, size: u64, value: u8) -> Result<(), Error> {
+        if size == 0 {
+            return Ok(());
+        }
         let page_indices = get_page_indices(addr.to_u64(), size)?;
         set_dirty(self, &page_indices)?;
         memset(&mut self[addr as usize..(addr + size) as usize], value);

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -88,6 +88,7 @@ pub(crate) fn fill_page_data<M: Memory>(
     Ok(())
 }
 
+// `size` should be none zero u64
 pub fn get_page_indices(addr: u64, size: u64) -> Result<(u64, u64), Error> {
     let (addr_end, overflowed) = addr.overflowing_add(size);
     if overflowed {

--- a/src/memory/wxorx.rs
+++ b/src/memory/wxorx.rs
@@ -115,12 +115,18 @@ impl<M: Memory> Memory for WXorXMemory<M> {
     }
 
     fn store_bytes(&mut self, addr: u64, value: &[u8]) -> Result<(), Error> {
+        if value.is_empty() {
+            return Ok(());
+        }
         let page_indices = get_page_indices(addr, value.len() as u64)?;
         check_permission(self, &page_indices, FLAG_WRITABLE)?;
         self.inner.store_bytes(addr, value)
     }
 
     fn store_byte(&mut self, addr: u64, size: u64, value: u8) -> Result<(), Error> {
+        if size == 0 {
+            return Ok(());
+        }
         let page_indices = get_page_indices(addr, size)?;
         check_permission(self, &page_indices, FLAG_WRITABLE)?;
         self.inner.store_byte(addr, size, value)


### PR DESCRIPTION
This PR resolved a overflow issue which introduced by https://github.com/nervosnetwork/ckb-vm/pull/134/files#diff-762e55e61a0bd1b5517c8df0f88f1b2b35cbecbbaaf877098a48a424921ac093L89-L92

move the empty checking to `store_bytes` fn since other store16/32/... fn are using none zero u64 already.