### PR TITLE
Upgrade libfuzzer-sys

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
-libfuzzer-sys = "0.3"
+libfuzzer-sys = "0.4.0"
 bytes = "0.5.4"
 ckb-vm = { path = "..", features = ["asm"] }
 


### PR DESCRIPTION
I saw this crate was a bit out of date so I upgraded it. I tested and the fuzzer still works.

Signed-off-by: Brian Anderson <andersrb@gmail.com>