### PR TITLE
Add a CI config for running under miri

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,14 @@ matrix:
             - git
             - build-essential
       env: SUITE=ci-chaos
+    - name: ci-miri
+      rust: nightly-2021-03-20
+      addons:
+        apt:
+          packages:
+            - git
+            - build-essential
+      env: SUITE=ci-miri
     - name: Test Suite
       rust: 1.46.0
       dist: xenial

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ asm = []
 # Detect if requirements are met, and enable asm feature when we can.
 detect-asm = []
 enable-chaos-mode-by-default = ["ckb-vm-definitions/enable-chaos-mode-by-default"]
+# Disable slow tests to run miri on CI
+miri-ci = []
 
 [dependencies]
 byteorder = "1"

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,11 @@ ci-all-features: test-all-features
 ci-chaos: test-chaos
 	git diff --exit-code Cargo.lock
 
+ci-miri:
+	rustup component add miri
+	cargo miri setup
+	MIRIFLAGS="-Zmiri-disable-isolation" cargo miri test --all
+
 ci-generated: src/machine/aot/aot.x64.compiled.c src/machine/aot/aot.x64.win.compiled.c update-cdefinitions
 	git diff --exit-code src/machine/aot/aot.x64.compiled.c src/machine/aot/aot.x64.win.compiled.c src/machine/asm/cdefinitions_generated.h
 

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ ci-chaos: test-chaos
 ci-miri:
 	rustup component add miri
 	cargo miri setup
-	MIRIFLAGS="-Zmiri-disable-isolation" cargo miri test --all
+	MIRIFLAGS="-Zmiri-disable-isolation" cargo miri test --all --features=miri-ci
 
 ci-generated: src/machine/aot/aot.x64.compiled.c src/machine/aot/aot.x64.win.compiled.c update-cdefinitions
 	git diff --exit-code src/machine/aot/aot.x64.compiled.c src/machine/aot/aot.x64.win.compiled.c src/machine/asm/cdefinitions_generated.h

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -40,6 +40,7 @@ mod tests {
 
     proptest! {
         #[test]
+        #[cfg_attr(miri, ignore)] // slow
         fn roundup_proptest(x: u64, round in (0u32..16).prop_map(|d| 2u64.pow(d))) {
             prop_assume!(x.checked_add(round).is_some(), "avoid integer overflow");
             let result = roundup(x, round);
@@ -55,6 +56,7 @@ mod tests {
         }
 
         #[test]
+        #[cfg_attr(miri, ignore)] // slow
         fn rounddown_proptest(x: u64, round in (0u32..16).prop_map(|d| 2u64.pow(d))) {
             let result = rounddown(x, round);
 

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -40,7 +40,7 @@ mod tests {
 
     proptest! {
         #[test]
-        #[cfg_attr(miri, ignore)] // slow
+        #[cfg_attr(all(miri, feature = "miri-ci"), ignore)]
         fn roundup_proptest(x: u64, round in (0u32..16).prop_map(|d| 2u64.pow(d))) {
             prop_assume!(x.checked_add(round).is_some(), "avoid integer overflow");
             let result = roundup(x, round);
@@ -56,7 +56,7 @@ mod tests {
         }
 
         #[test]
-        #[cfg_attr(miri, ignore)] // slow
+        #[cfg_attr(all(miri, feature = "miri-ci"), ignore)]
         fn rounddown_proptest(x: u64, round in (0u32..16).prop_map(|d| 2u64.pow(d))) {
             let result = rounddown(x, round);
 

--- a/tests/test_b_extension.rs
+++ b/tests/test_b_extension.rs
@@ -1,7 +1,7 @@
 mod machine_run;
 
 #[test]
-#[cfg_attr(miri, ignore)] // slow
+#[cfg_attr(miri, ignore)] // takes at least 9 hours
 pub fn test_b_extension() {
     machine_run::int_v1_imcb("tests/programs/b_extension");
     #[cfg(has_asm)]

--- a/tests/test_b_extension.rs
+++ b/tests/test_b_extension.rs
@@ -1,6 +1,7 @@
 mod machine_run;
 
 #[test]
+#[cfg_attr(miri, ignore)] // slow
 pub fn test_b_extension() {
     machine_run::int_v1_imcb("tests/programs/b_extension");
     #[cfg(has_asm)]

--- a/tests/test_misc.rs
+++ b/tests/test_misc.rs
@@ -179,6 +179,7 @@ pub fn test_invalid_file_offset64() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // slow
 pub fn test_op_rvc_srli_crash_32() {
     let mut file = File::open("tests/programs/op_rvc_srli_crash_32").unwrap();
     let mut buffer = Vec::new();
@@ -190,6 +191,7 @@ pub fn test_op_rvc_srli_crash_32() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // slow
 pub fn test_op_rvc_srai_crash_32() {
     let mut file = File::open("tests/programs/op_rvc_srai_crash_32").unwrap();
     let mut buffer = Vec::new();
@@ -201,6 +203,7 @@ pub fn test_op_rvc_srai_crash_32() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // slow
 pub fn test_op_rvc_slli_crash_32() {
     let mut file = File::open("tests/programs/op_rvc_slli_crash_32").unwrap();
     let mut buffer = Vec::new();

--- a/tests/test_misc.rs
+++ b/tests/test_misc.rs
@@ -179,7 +179,7 @@ pub fn test_invalid_file_offset64() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // slow
+#[cfg_attr(all(miri, feature = "miri-ci"), ignore)]
 pub fn test_op_rvc_srli_crash_32() {
     let mut file = File::open("tests/programs/op_rvc_srli_crash_32").unwrap();
     let mut buffer = Vec::new();
@@ -191,7 +191,7 @@ pub fn test_op_rvc_srli_crash_32() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // slow
+#[cfg_attr(all(miri, feature = "miri-ci"), ignore)]
 pub fn test_op_rvc_srai_crash_32() {
     let mut file = File::open("tests/programs/op_rvc_srai_crash_32").unwrap();
     let mut buffer = Vec::new();
@@ -203,7 +203,7 @@ pub fn test_op_rvc_srai_crash_32() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // slow
+#[cfg_attr(all(miri, feature = "miri-ci"), ignore)]
 pub fn test_op_rvc_slli_crash_32() {
     let mut file = File::open("tests/programs/op_rvc_slli_crash_32").unwrap();
     let mut buffer = Vec::new();


### PR DESCRIPTION
I said earlier I would add such a configuration. This takes around 4 minutes to run locally. If that is too long for the CI I can try reduce the time further.

cc @mohanson 