### PR TITLE
chore: upgrade bytes to 1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
 env:
   global:
     - RUST_BACKTRACE=full
-    - TEST_SUITE_COMMIT=9cef87fbc8966169ad4d41d992d69ac45c4da695
+    - TEST_SUITE_COMMIT=dea02067247a17e5d5059485e3f8ccb5c92a6810
 
 matrix:
   include:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ miri-ci = []
 
 [dependencies]
 byteorder = "1"
-bytes = "0.5.4"
+bytes = "1"
 goblin_v023 = { package = "goblin", version = "=0.2.3" }
 goblin_v040 = { package = "goblin", version = "=0.4.0" }
 scroll = "0.10"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4.0"
-bytes = "0.5.4"
+bytes = "1"
 ckb-vm = { path = "..", features = ["asm"] }
 
 # Prevent this from interfering with workspaces


### PR DESCRIPTION
I am upgrading tokio/bytes of `ckb` to 1.x, `ckb-vm` should be upgraded accordingly, including the current 0.19.x 

Do I need another PR for the release branch? 