### PR TITLE
chore: make Bytes public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub use crate::{
     memory::{flat::FlatMemory, sparse::SparseMemory, wxorx::WXorXMemory, Memory},
     syscalls::Syscalls,
 };
-use bytes::Bytes;
+pub use bytes::Bytes;
 
 pub use ckb_vm_definitions::{
     registers, DEFAULT_STACK_SIZE, ISA_B, ISA_IMC, MEMORY_FRAMES, MEMORY_FRAMESIZE,


### PR DESCRIPTION
When we write tests(like https://github.com/nervosnetwork/ckb-vm-test-suite) or gadgets, we don’t need to add the `bytes` library to dependencies anymore, which can reduce conflicts effectively.