### PR TITLE
chore: add take api

### DIFF
--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -538,6 +538,18 @@ impl<'a, Inner: SupportMachine> DefaultMachine<'a, Inner> {
         self.inner
     }
 
+    pub fn take_cycle_func(&mut self) -> Option<Box<InstructionCycleFunc>> {
+        self.instruction_cycle_func.take()
+    }
+
+    pub fn take_syscalls(&mut self) -> Vec<Box<dyn Syscalls<Inner> + 'a>> {
+        ::std::mem::take(&mut self.syscalls)
+    }
+
+    pub fn take_debugger(&mut self) -> Option<Box<dyn Debugger<Inner> + 'a>> {
+        self.debugger.take()
+    }
+
     pub fn exit_code(&self) -> i8 {
         self.exit_code
     }
@@ -610,6 +622,11 @@ impl<'a, Inner> DefaultMachineBuilder<'a, Inner> {
 
     pub fn syscall(mut self, syscall: Box<dyn Syscalls<Inner> + 'a>) -> Self {
         self.syscalls.push(syscall);
+        self
+    }
+
+    pub fn syscalls(mut self, syscalls: Vec<Box<dyn Syscalls<Inner> + 'a>>) -> Self {
+        self.syscalls = syscalls;
         self
     }
 


### PR DESCRIPTION
The snapshot only records the internal state(registers and memory) of the running VM. To fully restore the scene, we need to support all syscall、cycle calculation function and debugger function, rebuilding is too expensive each time, this PR will be added all `take_*` API to get the information inside the VM to facilitate the reconstruction 