### PR TITLE
feat: support dynamic reset max cycles

### DIFF
--- a/src/machine/asm/mod.rs
+++ b/src/machine/asm/mod.rs
@@ -303,10 +303,6 @@ impl SupportMachine for Box<AsmCoreMachine> {
         self.max_cycles
     }
 
-    fn set_max_cycles(&mut self, cycles: u64) {
-        self.max_cycles = cycles;
-    }
-
     fn reset(&mut self, max_cycles: u64) {
         self.registers = [0; RISCV_GENERAL_REGISTER_NUMBER];
         self.pc = 0;
@@ -361,6 +357,10 @@ impl<'a> AsmMachine<'a> {
             machine: DefaultMachine::<'a, Box<AsmCoreMachine>>::default(),
             aot_code: Some(aot_code),
         }
+    }
+
+    pub fn set_max_cycles(&mut self, cycles: u64) {
+        self.machine.inner.max_cycles = cycles;
     }
 
     pub fn load_program(&mut self, program: &Bytes, args: &[Bytes]) -> Result<u64, Error> {

--- a/src/machine/asm/mod.rs
+++ b/src/machine/asm/mod.rs
@@ -303,6 +303,10 @@ impl SupportMachine for Box<AsmCoreMachine> {
         self.max_cycles
     }
 
+    fn set_max_cycles(&mut self, cycles: u64) {
+        self.max_cycles = cycles;
+    }
+
     fn reset(&mut self, max_cycles: u64) {
         self.registers = [0; RISCV_GENERAL_REGISTER_NUMBER];
         self.pc = 0;

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -70,7 +70,6 @@ pub trait SupportMachine: CoreMachine {
     fn cycles(&self) -> u64;
     fn set_cycles(&mut self, cycles: u64);
     fn max_cycles(&self) -> u64;
-    fn set_max_cycles(&mut self, cycles: u64);
 
     fn running(&self) -> bool;
     fn set_running(&mut self, running: bool);
@@ -329,10 +328,6 @@ impl<R: Register, M: Memory<REG = R> + Default> SupportMachine for DefaultCoreMa
         self.max_cycles
     }
 
-    fn set_max_cycles(&mut self, cycles: u64) {
-        self.max_cycles = cycles;
-    }
-
     fn reset(&mut self, max_cycles: u64) {
         self.registers = Default::default();
         self.pc = Default::default();
@@ -373,6 +368,10 @@ impl<R: Register, M: Memory + Default> DefaultCoreMachine<R, M> {
             version: VERSION1,
             ..Default::default()
         }
+    }
+
+    pub fn set_max_cycles(&mut self, cycles: u64) {
+        self.max_cycles = cycles;
     }
 
     pub fn take_memory(self) -> M {
@@ -448,10 +447,6 @@ impl<Inner: SupportMachine> SupportMachine for DefaultMachine<'_, Inner> {
 
     fn max_cycles(&self) -> u64 {
         self.inner.max_cycles()
-    }
-
-    fn set_max_cycles(&mut self, cycles: u64) {
-        self.inner.set_max_cycles(cycles)
     }
 
     fn reset(&mut self, max_cycles: u64) {

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -70,6 +70,7 @@ pub trait SupportMachine: CoreMachine {
     fn cycles(&self) -> u64;
     fn set_cycles(&mut self, cycles: u64);
     fn max_cycles(&self) -> u64;
+    fn set_max_cycles(&mut self, cycles: u64);
 
     fn running(&self) -> bool;
     fn set_running(&mut self, running: bool);
@@ -328,6 +329,10 @@ impl<R: Register, M: Memory<REG = R> + Default> SupportMachine for DefaultCoreMa
         self.max_cycles
     }
 
+    fn set_max_cycles(&mut self, cycles: u64) {
+        self.max_cycles = cycles;
+    }
+
     fn reset(&mut self, max_cycles: u64) {
         self.registers = Default::default();
         self.pc = Default::default();
@@ -443,6 +448,10 @@ impl<Inner: SupportMachine> SupportMachine for DefaultMachine<'_, Inner> {
 
     fn max_cycles(&self) -> u64 {
         self.inner.max_cycles()
+    }
+
+    fn set_max_cycles(&mut self, cycles: u64) {
+        self.inner.set_max_cycles(cycles)
     }
 
     fn reset(&mut self, max_cycles: u64) {


### PR DESCRIPTION
#### Why need this?

In the scenario where the program is executed step by step, after the VM executes to the initialization max, jump out of execution to check whether the snapshot operation needs to be executed, if not, continue execution with the current VM state. 

At this time, `set_max_cycles` is required because the remaining executable cycles may not be equal to the initialized one

The code currently available for [reference](https://github.com/driftluo/ckb/blob/tmp-vm/tx-pool/src/chunk_process.rs#L174)