### PR TITLE
feat: compile aot code in AsmMachine.load_elf

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ trigger:
 
 variables:
   RUST_BACKTRACE: full
-  TEST_SUITE_COMMIT: dea02067247a17e5d5059485e3f8ccb5c92a6810
+  TEST_SUITE_COMMIT: 8c0c2239194dc283308377c3fd4e04744b01c988
 
 jobs:
   - job: WinUnitTest

--- a/benches/vm_benchmark.rs
+++ b/benches/vm_benchmark.rs
@@ -1,52 +1,64 @@
 #[macro_use]
 extern crate criterion;
 
-use bytes::Bytes;
-#[cfg(has_asm)]
-use ckb_vm::machine::{
-    aot::AotCompilingMachine,
-    asm::{AsmCoreMachine, AsmMachine},
-    DefaultMachineBuilder, VERSION0, VERSION1,
+use ckb_vm::{
+    machine::VERSION0, memory::wxorx::WXorXMemory, Bytes, DefaultCoreMachine,
+    DefaultMachineBuilder, SparseMemory, TraceMachine, ISA_IMC,
 };
-use ckb_vm::{run, SparseMemory, ISA_B, ISA_IMC, ISA_MOP};
+#[cfg(has_asm)]
+use ckb_vm::{
+    machine::{
+        aot::AotCompilingMachine,
+        asm::{AsmCoreMachine, AsmMachine, AsmWrapMachine},
+        VERSION1,
+    },
+    ISA_B, ISA_MOP,
+};
 use criterion::Criterion;
-use std::fs::File;
-use std::io::Read;
 
 fn interpret_benchmark(c: &mut Criterion) {
     c.bench_function("interpret secp256k1_bench", |b| {
-        let mut file = File::open("benches/data/secp256k1_bench").unwrap();
-        let mut buffer = Vec::new();
-        file.read_to_end(&mut buffer).unwrap();
-
-        let buffer = Bytes::from(buffer);
+        let path = "benches/data/secp256k1_bench";
+        let code = std::fs::read(path).unwrap().into();
         let args: Vec<Bytes> = vec!["secp256k1_bench",
                                       "033f8cf9c4d51a33206a6c1c6b27d2cc5129daa19dbd1fc148d395284f6b26411f",
                                       "304402203679d909f43f073c7c1dcf8468a485090589079ee834e6eed92fea9b09b06a2402201e46f1075afa18f306715e7db87493e7b7e779569aa13c64ab3d09980b3560a3",
                                       "foo",
                                       "bar"].into_iter().map(|a| a.into()).collect();
-
-        b.iter(|| run::<u64, SparseMemory<u64>>(&buffer, &args[..]).unwrap());
+        b.iter(|| {
+            let core_machine = DefaultCoreMachine::<u64, WXorXMemory<SparseMemory<u64>>>::new(
+                ISA_IMC,
+                VERSION0,
+                u64::max_value(),
+            );
+            let mut machine = TraceMachine::new(
+                DefaultMachineBuilder::new(core_machine)
+                    .build(),
+            );
+            machine
+                .load_program(&code, &args[..])
+                .unwrap();
+            machine.run().unwrap();
+        });
     });
 }
 
 #[cfg(has_asm)]
 fn asm_benchmark(c: &mut Criterion) {
     c.bench_function("interpret secp256k1_bench via assembly", |b| {
-        let mut file = File::open("benches/data/secp256k1_bench").unwrap();
-        let mut buffer = Vec::new();
-        file.read_to_end(&mut buffer).unwrap();
-
-        let buffer = Bytes::from(buffer);
+        let path = "benches/data/secp256k1_bench";
+        let code = std::fs::read(path).unwrap().into();
         let args: Vec<Bytes> = vec!["secp256k1_bench",
                                       "033f8cf9c4d51a33206a6c1c6b27d2cc5129daa19dbd1fc148d395284f6b26411f",
                                       "304402203679d909f43f073c7c1dcf8468a485090589079ee834e6eed92fea9b09b06a2402201e46f1075afa18f306715e7db87493e7b7e779569aa13c64ab3d09980b3560a3",
                                       "foo",
                                       "bar"].into_iter().map(|a| a.into()).collect();
-
         b.iter(|| {
-            let mut machine = AsmMachine::default();
-            machine.load_program(&buffer, &args[..]).unwrap();
+            let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::max_value());
+            let asm_wrap = AsmWrapMachine::new(asm_core, false);
+            let core = DefaultMachineBuilder::new(asm_wrap).build();
+            let mut machine = AsmMachine::new(core);
+            machine.load_program(&code, &args[..]).unwrap();
             machine.run().unwrap()
         });
     });
@@ -55,22 +67,19 @@ fn asm_benchmark(c: &mut Criterion) {
 #[cfg(has_asm)]
 fn aot_benchmark(c: &mut Criterion) {
     c.bench_function("aot secp256k1_bench", |b| {
-        let mut file = File::open("benches/data/secp256k1_bench").unwrap();
-        let mut buffer = Vec::new();
-        file.read_to_end(&mut buffer).unwrap();
-
-        let buffer = Bytes::from(buffer);
+        let path = "benches/data/secp256k1_bench";
+        let code = std::fs::read(path).unwrap().into();
         let args: Vec<Bytes> = vec!["secp256k1_bench",
                                       "033f8cf9c4d51a33206a6c1c6b27d2cc5129daa19dbd1fc148d395284f6b26411f",
                                       "304402203679d909f43f073c7c1dcf8468a485090589079ee834e6eed92fea9b09b06a2402201e46f1075afa18f306715e7db87493e7b7e779569aa13c64ab3d09980b3560a3",
                                       "foo",
                                       "bar"].into_iter().map(|a| a.into()).collect();
-        let mut aot_machine = AotCompilingMachine::load(&buffer.clone(), None, ISA_IMC, VERSION0).unwrap();
-        let result = aot_machine.compile().unwrap();
-
         b.iter(|| {
-            let mut machine = AsmMachine::default_with_aot_code(&result);
-            machine.load_program(&buffer, &args[..]).unwrap();
+            let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::max_value());
+            let asm_wrap = AsmWrapMachine::new(asm_core, true);
+            let core = DefaultMachineBuilder::new(asm_wrap).build();
+            let mut machine = AsmMachine::new(core);
+            machine.load_program(&code, &args[..]).unwrap();
             machine.run().unwrap()
         });
     });
@@ -79,16 +88,12 @@ fn aot_benchmark(c: &mut Criterion) {
 #[cfg(has_asm)]
 fn aot_compiling_benchmark(c: &mut Criterion) {
     c.bench_function("compiling secp256k1_bench for aot", |b| {
-        let mut file = File::open("benches/data/secp256k1_bench").unwrap();
-        let mut buffer = Vec::new();
-        file.read_to_end(&mut buffer).unwrap();
-
-        let buffer = Bytes::from(buffer);
-
+        let path = "benches/data/secp256k1_bench";
+        let code: Bytes = std::fs::read(path).unwrap().into();
         b.iter(|| {
-            AotCompilingMachine::load(&buffer.clone(), None, ISA_IMC, VERSION0)
+            AotCompilingMachine::load(&code, ISA_IMC, VERSION0)
                 .unwrap()
-                .compile()
+                .compile(&None)
                 .unwrap()
         });
     });
@@ -97,12 +102,8 @@ fn aot_compiling_benchmark(c: &mut Criterion) {
 #[cfg(has_asm)]
 fn mop_benchmark(c: &mut Criterion) {
     c.bench_function("interpret secp256k1_bench via assembly mop", |b| {
-
-        let mut file = File::open("benches/data/secp256k1_bench").unwrap();
-        let mut buffer = Vec::new();
-        file.read_to_end(&mut buffer).unwrap();
-
-        let buffer = Bytes::from(buffer);
+        let path = "benches/data/secp256k1_bench";
+        let code = std::fs::read(path).unwrap().into();
         let args: Vec<Bytes> = vec!["secp256k1_bench",
                                       "033f8cf9c4d51a33206a6c1c6b27d2cc5129daa19dbd1fc148d395284f6b26411f",
                                       "304402203679d909f43f073c7c1dcf8468a485090589079ee834e6eed92fea9b09b06a2402201e46f1075afa18f306715e7db87493e7b7e779569aa13c64ab3d09980b3560a3",
@@ -110,10 +111,10 @@ fn mop_benchmark(c: &mut Criterion) {
                                       "bar"].into_iter().map(|a| a.into()).collect();
         b.iter(|| {
             let asm_core = AsmCoreMachine::new(ISA_IMC | ISA_B | ISA_MOP, VERSION1, u64::max_value());
-            let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
-                .build();
-            let mut machine = AsmMachine::new(core, None);
-            machine.load_program(&buffer, &args).unwrap();
+            let asm_wrap = AsmWrapMachine::new(asm_core, false);
+            let core = DefaultMachineBuilder::new(asm_wrap).build();
+            let mut machine = AsmMachine::new(core);
+            machine.load_program(&code, &args).unwrap();
             machine.run().unwrap()
         });
     });

--- a/examples/is13.rs
+++ b/examples/is13.rs
@@ -25,7 +25,7 @@
 //     $ cargo run --example is13 13
 //  or $ cargo run --example is13 0xd
 //  or $ cargo run --example is13 HELLO
-use bytes::Bytes;
+use ckb_vm::{machine::VERSION0, Bytes, ISA_IMC};
 use std::io::Read;
 
 fn main() {
@@ -36,7 +36,8 @@ fn main() {
     file.read_to_end(&mut buffer).unwrap();
     let buffer = Bytes::from(buffer);
 
-    let r = ckb_vm::run::<u32, ckb_vm::SparseMemory<u32>>(&buffer, &args[..]).unwrap();
+    let r = ckb_vm::run::<u32, ckb_vm::SparseMemory<u32>>(&buffer, &args[..], ISA_IMC, VERSION0)
+        .unwrap();
     match r {
         1 => println!("{:?} is not thirteen", args[1]),
         0 => println!("{:?} is thirteen", args[1]),

--- a/fuzz/fuzz_targets/asm.rs
+++ b/fuzz/fuzz_targets/asm.rs
@@ -1,16 +1,16 @@
 #![no_main]
-use bytes::Bytes;
-use ckb_vm::machine::asm::{AsmCoreMachine, AsmMachine};
+use ckb_vm::machine::asm::{AsmCoreMachine, AsmWrapMachine, AsmMachine};
 use ckb_vm::machine::{DefaultMachineBuilder, VERSION0};
-use ckb_vm::ISA_IMC;
+use ckb_vm::{ISA_IMC, Bytes};
 use libfuzzer_sys::fuzz_target;
 
 fn run(data: &[u8]) {
     let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, 200_000);
-    let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
+    let asm_wrap = AsmWrapMachine::new(asm_core, false);
+    let core = DefaultMachineBuilder::new(asm_wrap)
         .instruction_cycle_func(Box::new(|_| 1))
         .build();
-    let mut machine = AsmMachine::new(core, None);
+    let mut machine = AsmMachine::new(core);
     let program = Bytes::copy_from_slice(data);
     if let Ok(_) = machine.load_program(&program, &[]) {
         let _ = machine.run();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,10 @@ pub use error::Error;
 pub fn run<R: Register, M: Memory<REG = R> + Default>(
     program: &Bytes,
     args: &[Bytes],
+    isa: u8,
+    version: u32,
 ) -> Result<i8, Error> {
-    let core_machine = DefaultCoreMachine::<R, WXorXMemory<M>>::latest();
+    let core_machine = DefaultCoreMachine::<R, WXorXMemory<M>>::new(isa, version, u64::max_value());
     let mut machine = TraceMachine::new(DefaultMachineBuilder::new(core_machine).build());
     machine.load_program(program, args)?;
     machine.run()

--- a/src/machine/aot/mod.rs
+++ b/src/machine/aot/mod.rs
@@ -476,7 +476,6 @@ impl AotCompilingMachine {
             dummy_sections: label_gathering_machine.dummy_sections,
             writes: vec![],
             next_pc_write: None,
-            // instruction_cycle_func,
         })
     }
 

--- a/src/machine/asm/mod.rs
+++ b/src/machine/asm/mod.rs
@@ -525,7 +525,7 @@ impl<'a> AsmMachine<'a> {
     }
 
     pub fn set_max_cycles(&mut self, cycles: u64) {
-        self.machine.inner.max_cycles = cycles;
+        self.machine.inner.machine.max_cycles = cycles;
     }
 
     pub fn load_program(&mut self, program: &Bytes, args: &[Bytes]) -> Result<u64, Error> {

--- a/tests/test_b_extension.rs
+++ b/tests/test_b_extension.rs
@@ -15,8 +15,7 @@ pub fn test_b_extension() {
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
 
-        let code = machine_build::aot_v1_imcb_code("tests/programs/b_extension");
-        let mut machine_aot = machine_build::aot_v1_imcb("tests/programs/b_extension", &code);
+        let mut machine_aot = machine_build::aot_v1_imcb("tests/programs/b_extension");
         let ret_aot = machine_aot.run();
         assert!(ret_aot.is_ok());
         assert_eq!(ret_aot.unwrap(), 0);
@@ -37,8 +36,7 @@ pub fn test_clzw_bug() {
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
 
-        let code = machine_build::aot_v1_imcb_code("tests/programs/clzw_bug");
-        let mut machine_aot = machine_build::aot_v1_imcb("tests/programs/clzw_bug", &code);
+        let mut machine_aot = machine_build::aot_v1_imcb("tests/programs/clzw_bug");
         let ret_aot = machine_aot.run();
         assert!(ret_aot.is_ok());
         assert_eq!(ret_aot.unwrap(), 0);
@@ -59,8 +57,7 @@ pub fn test_packw_signextend() {
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
 
-        let code = machine_build::aot_v1_imcb_code("tests/programs/packw_signextend");
-        let mut machine_aot = machine_build::aot_v1_imcb("tests/programs/packw_signextend", &code);
+        let mut machine_aot = machine_build::aot_v1_imcb("tests/programs/packw_signextend");
         let ret_aot = machine_aot.run();
         assert!(ret_aot.is_ok());
         assert_eq!(ret_aot.unwrap(), 0);
@@ -81,9 +78,7 @@ pub fn test_single_bit_signextend() {
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
 
-        let code = machine_build::aot_v1_imcb_code("tests/programs/single_bit_signextend");
-        let mut machine_aot =
-            machine_build::aot_v1_imcb("tests/programs/single_bit_signextend", &code);
+        let mut machine_aot = machine_build::aot_v1_imcb("tests/programs/single_bit_signextend");
         let ret_aot = machine_aot.run();
         assert!(ret_aot.is_ok());
         assert_eq!(ret_aot.unwrap(), 0);
@@ -104,9 +99,7 @@ pub fn test_sbinvi_aot_load_imm_bug() {
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
 
-        let code = machine_build::aot_v1_imcb_code("tests/programs/sbinvi_aot_load_imm_bug");
-        let mut machine_aot =
-            machine_build::aot_v1_imcb("tests/programs/sbinvi_aot_load_imm_bug", &code);
+        let mut machine_aot = machine_build::aot_v1_imcb("tests/programs/sbinvi_aot_load_imm_bug");
         let ret_aot = machine_aot.run();
         assert!(ret_aot.is_ok());
         assert_eq!(ret_aot.unwrap(), 0);
@@ -128,9 +121,7 @@ pub fn test_rorw_in_end_of_aot_block() {
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
 
-        let code = machine_build::aot_v1_imcb_code("tests/programs/rorw_in_end_of_aot_block");
-        let mut machine_aot =
-            machine_build::aot_v1_imcb("tests/programs/rorw_in_end_of_aot_block", &code);
+        let mut machine_aot = machine_build::aot_v1_imcb("tests/programs/rorw_in_end_of_aot_block");
         let ret_aot = machine_aot.run();
         assert!(ret_aot.is_ok());
         assert_eq!(ret_aot.unwrap(), 0);
@@ -151,8 +142,7 @@ pub fn test_fsri_decode_bug() {
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
 
-        let code = machine_build::aot_v1_imcb_code("tests/programs/fsri_decode_bug");
-        let mut machine_aot = machine_build::aot_v1_imcb("tests/programs/fsri_decode_bug", &code);
+        let mut machine_aot = machine_build::aot_v1_imcb("tests/programs/fsri_decode_bug");
         let ret_aot = machine_aot.run();
         assert!(ret_aot.is_ok());
         assert_eq!(ret_aot.unwrap(), 0);
@@ -173,8 +163,7 @@ pub fn test_pcnt() {
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
 
-        let code = machine_build::aot_v1_imcb_code("tests/programs/pcnt");
-        let mut machine_aot = machine_build::aot_v1_imcb("tests/programs/pcnt", &code);
+        let mut machine_aot = machine_build::aot_v1_imcb("tests/programs/pcnt");
         let ret_aot = machine_aot.run();
         assert!(ret_aot.is_ok());
         assert_eq!(ret_aot.unwrap(), 0);

--- a/tests/test_minimal.rs
+++ b/tests/test_minimal.rs
@@ -1,42 +1,34 @@
-extern crate ckb_vm;
-
-use bytes::Bytes;
-use ckb_vm::{run, SparseMemory};
-use std::fs::File;
-use std::io::Read;
+use ckb_vm::{machine::VERSION0, run, SparseMemory, ISA_IMC};
 
 #[test]
 pub fn test_minimal_with_no_args() {
-    let mut file = File::open("tests/programs/minimal").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
-    let result = run::<u32, SparseMemory<u32>>(&buffer, &vec!["minimal".into()]);
+    let path = "tests/programs/minimal";
+    let code = std::fs::read(path).unwrap().into();
+    let result = run::<u32, SparseMemory<u32>>(&code, &vec!["minimal".into()], ISA_IMC, VERSION0);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 1);
 }
 
 #[test]
 pub fn test_minimal_with_a() {
-    let mut file = File::open("tests/programs/minimal").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
-    let result = run::<u32, SparseMemory<u32>>(&buffer, &vec!["minimal".into(), "a".into()]);
+    let path = "tests/programs/minimal";
+    let code = std::fs::read(path).unwrap().into();
+    let result = run::<u32, SparseMemory<u32>>(
+        &code,
+        &vec!["minimal".into(), "a".into()],
+        ISA_IMC,
+        VERSION0,
+    );
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 2);
 }
 
 #[test]
 pub fn test_minimal_with_b() {
-    let mut file = File::open("tests/programs/minimal").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
-    let result = run::<u32, SparseMemory<u32>>(&buffer, &vec!["minimal".into(), "".into()]);
+    let path = "tests/programs/minimal";
+    let code = std::fs::read(path).unwrap().into();
+    let result =
+        run::<u32, SparseMemory<u32>>(&code, &vec!["minimal".into(), "".into()], ISA_IMC, VERSION0);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);
 }

--- a/tests/test_mop.rs
+++ b/tests/test_mop.rs
@@ -1,8 +1,6 @@
 pub mod machine_build;
 
-use bytes::Bytes;
-
-use ckb_vm::SupportMachine;
+use ckb_vm::{Bytes, SupportMachine};
 
 #[test]
 #[cfg_attr(miri, ignore)]
@@ -19,15 +17,13 @@ pub fn test_mop_wide_multiply() {
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
-        assert_eq!(machine.machine.cycles(), 9143110);
+        assert_eq!(machine_asm.machine.cycles(), 9143110);
 
-        let code = machine_build::aot_v1_mop_code("tests/programs/mop_wide_multiply");
-        let mut machine_aot =
-            machine_build::aot_v1_mop("tests/programs/mop_wide_multiply", vec![], &code);
+        let mut machine_aot = machine_build::aot_v1_mop("tests/programs/mop_wide_multiply", vec![]);
         let ret_aot = machine_aot.run();
         assert!(ret_aot.is_ok());
         assert_eq!(ret_aot.unwrap(), 0);
-        assert_eq!(machine.machine.cycles(), 9143110);
+        assert_eq!(machine_aot.machine.cycles(), 9143110);
     }
 }
 
@@ -46,15 +42,13 @@ pub fn test_mop_wide_divide() {
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
-        assert_eq!(machine.machine.cycles(), 6073650);
+        assert_eq!(machine_asm.machine.cycles(), 6073650);
 
-        let code = machine_build::aot_v1_mop_code("tests/programs/mop_wide_divide");
-        let mut machine_aot =
-            machine_build::aot_v1_mop("tests/programs/mop_wide_divide", vec![], &code);
+        let mut machine_aot = machine_build::aot_v1_mop("tests/programs/mop_wide_divide", vec![]);
         let ret_aot = machine_aot.run();
         assert!(ret_aot.is_ok());
         assert_eq!(ret_aot.unwrap(), 0);
-        assert_eq!(machine.machine.cycles(), 6073650);
+        assert_eq!(machine_aot.machine.cycles(), 6073650);
     }
 }
 
@@ -72,15 +66,13 @@ pub fn test_mop_far_jump() {
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
-        assert_eq!(machine.machine.cycles(), 5);
+        assert_eq!(machine_asm.machine.cycles(), 5);
 
-        let code = machine_build::aot_v1_mop_code("tests/programs/mop_far_jump");
-        let mut machine_aot =
-            machine_build::aot_v1_mop("tests/programs/mop_far_jump", vec![], &code);
+        let mut machine_aot = machine_build::aot_v1_mop("tests/programs/mop_far_jump", vec![]);
         let ret_aot = machine_aot.run();
         assert!(ret_aot.is_ok());
         assert_eq!(ret_aot.unwrap(), 0);
-        assert_eq!(machine.machine.cycles(), 5);
+        assert_eq!(machine_aot.machine.cycles(), 5);
     }
 }
 
@@ -100,9 +92,8 @@ pub fn test_mop_ld_32_constants() {
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
 
-        let code = machine_build::aot_v1_mop_code("tests/programs/mop_ld_signextend_32");
         let mut machine_aot =
-            machine_build::aot_v1_mop("tests/programs/mop_ld_signextend_32", vec![], &code);
+            machine_build::aot_v1_mop("tests/programs/mop_ld_signextend_32", vec![]);
         let ret_aot = machine_aot.run();
         assert!(ret_aot.is_ok());
         assert_eq!(ret_aot.unwrap(), 0);
@@ -132,14 +123,13 @@ pub fn test_mop_secp256k1() {
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
-        assert_eq!(machine.machine.cycles(), 684053);
+        assert_eq!(machine_asm.machine.cycles(), 684053);
 
-        let code = machine_build::aot_v1_mop_code("benches/data/secp256k1_bench");
         let mut machine_aot =
-            machine_build::aot_v1_mop("benches/data/secp256k1_bench", args.clone(), &code);
+            machine_build::aot_v1_mop("benches/data/secp256k1_bench", args.clone());
         let ret_aot = machine_aot.run();
         assert!(ret_aot.is_ok());
         assert_eq!(ret_aot.unwrap(), 0);
-        assert_eq!(machine.machine.cycles(), 684053);
+        assert_eq!(machine_aot.machine.cycles(), 684053);
     }
 }

--- a/tests/test_reset.rs
+++ b/tests/test_reset.rs
@@ -1,16 +1,11 @@
-use bytes::Bytes;
 #[cfg(has_asm)]
-use ckb_vm::machine::aot::AotCompilingMachine;
-#[cfg(has_asm)]
-use ckb_vm::machine::asm::{AsmCoreMachine, AsmMachine};
-use ckb_vm::machine::{DefaultCoreMachine, DefaultMachineBuilder, VERSION1};
+use ckb_vm::machine::asm::{AsmCoreMachine, AsmMachine, AsmWrapMachine};
 use ckb_vm::{
-    registers::A7, Error, Register, SparseMemory, SupportMachine, Syscalls, TraceMachine,
-    WXorXMemory, DEFAULT_STACK_SIZE, ISA_IMC, ISA_MOP, RISCV_MAX_MEMORY,
+    machine::{DefaultCoreMachine, DefaultMachineBuilder, VERSION1},
+    registers::A7,
+    Bytes, Error, Register, SparseMemory, SupportMachine, Syscalls, TraceMachine, WXorXMemory,
+    DEFAULT_STACK_SIZE, ISA_IMC, ISA_MOP, RISCV_MAX_MEMORY,
 };
-
-#[allow(dead_code)]
-mod machine_build;
 
 pub struct CustomSyscall {}
 
@@ -50,7 +45,7 @@ fn test_reset_int() {
         u64::max_value(),
     );
     let mut machine = DefaultMachineBuilder::new(core_machine)
-        .instruction_cycle_func(Box::new(machine_build::instruction_cycle_func))
+        .instruction_cycle_func(Box::new(|_| 1))
         .syscall(Box::new(CustomSyscall {}))
         .build();
     machine.load_program(&code, &vec![]).unwrap();
@@ -73,7 +68,7 @@ fn test_reset_int_with_trace() {
     );
     let mut machine = TraceMachine::new(
         DefaultMachineBuilder::new(core_machine)
-            .instruction_cycle_func(Box::new(machine_build::instruction_cycle_func))
+            .instruction_cycle_func(Box::new(|_| 1))
             .syscall(Box::new(CustomSyscall {}))
             .build(),
     );
@@ -92,11 +87,12 @@ fn test_reset_asm() {
     let code = Bytes::from(code_data);
 
     let asm_core = AsmCoreMachine::new(ISA_IMC | ISA_MOP, VERSION1, u64::max_value());
-    let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
-        .instruction_cycle_func(Box::new(machine_build::instruction_cycle_func))
+    let asm_wrap = AsmWrapMachine::new(asm_core, false);
+    let core = DefaultMachineBuilder::new(asm_wrap)
+        .instruction_cycle_func(Box::new(|_| 1))
         .syscall(Box::new(CustomSyscall {}))
         .build();
-    let mut machine = AsmMachine::new(core, None);
+    let mut machine = AsmMachine::new(core);
     machine.load_program(&code, &vec![]).unwrap();
 
     let result = machine.run();
@@ -111,26 +107,14 @@ fn test_reset_asm() {
 pub fn test_reset_aot() {
     let code_data = std::fs::read("tests/programs/reset_caller").unwrap();
     let code = Bytes::from(code_data);
-
-    let mut aot_machine = AotCompilingMachine::load(
-        &code,
-        Some(Box::new(machine_build::instruction_cycle_func)),
-        ISA_IMC | ISA_MOP,
-        VERSION1,
-    )
-    .unwrap();
-    let code = aot_machine.compile().unwrap();
-
-    let buffer: Bytes = std::fs::read("tests/programs/reset_caller").unwrap().into();
-
     let asm_core = AsmCoreMachine::new(ISA_IMC | ISA_MOP, VERSION1, u64::max_value());
-    let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
-        .instruction_cycle_func(Box::new(machine_build::instruction_cycle_func))
+    let asm_wrap = AsmWrapMachine::new(asm_core, true);
+    let core = DefaultMachineBuilder::new(asm_wrap)
+        .instruction_cycle_func(Box::new(|_| 1))
         .syscall(Box::new(CustomSyscall {}))
         .build();
-    let mut machine = AsmMachine::new(core, Some(&code));
-    machine.load_program(&buffer, &vec![]).unwrap();
-
+    let mut machine = AsmMachine::new(core);
+    machine.load_program(&code, &vec![]).unwrap();
     let result = machine.run();
     let cycles = machine.machine.cycles();
     assert!(result.is_ok());


### PR DESCRIPTION
Rewrite the logic of aot machine when processing reset, now the second program can also be compiled to aot code normally.

- Add a new structure AsmWrapMachine
- `instruction_cycle_func` is now used as a parameter of `AotCompilingMachine.compile()` instead of a parameter of `AotCompilingMachine::new()`
- Remove confusing constructor like machine::latest() or machine::default(): https://github.com/nervosnetwork/ckb-vm/issues/163
