### PR TITLE
refactor: use fs::read to read files

### DIFF
--- a/benches/vm_benchmark.rs
+++ b/benches/vm_benchmark.rs
@@ -10,16 +10,11 @@ use ckb_vm::machine::{
 };
 use ckb_vm::{run, SparseMemory, ISA_B, ISA_IMC, ISA_MOP};
 use criterion::Criterion;
-use std::fs::File;
-use std::io::Read;
+use std::fs;
 
 fn interpret_benchmark(c: &mut Criterion) {
     c.bench_function("interpret secp256k1_bench", |b| {
-        let mut file = File::open("benches/data/secp256k1_bench").unwrap();
-        let mut buffer = Vec::new();
-        file.read_to_end(&mut buffer).unwrap();
-
-        let buffer = Bytes::from(buffer);
+        let buffer = fs::read("benches/data/secp256k1_bench").unwrap().into();
         let args: Vec<Bytes> = vec!["secp256k1_bench",
                                       "033f8cf9c4d51a33206a6c1c6b27d2cc5129daa19dbd1fc148d395284f6b26411f",
                                       "304402203679d909f43f073c7c1dcf8468a485090589079ee834e6eed92fea9b09b06a2402201e46f1075afa18f306715e7db87493e7b7e779569aa13c64ab3d09980b3560a3",
@@ -33,11 +28,7 @@ fn interpret_benchmark(c: &mut Criterion) {
 #[cfg(has_asm)]
 fn asm_benchmark(c: &mut Criterion) {
     c.bench_function("interpret secp256k1_bench via assembly", |b| {
-        let mut file = File::open("benches/data/secp256k1_bench").unwrap();
-        let mut buffer = Vec::new();
-        file.read_to_end(&mut buffer).unwrap();
-
-        let buffer = Bytes::from(buffer);
+        let buffer = fs::read("benches/data/secp256k1_bench").unwrap().into();
         let args: Vec<Bytes> = vec!["secp256k1_bench",
                                       "033f8cf9c4d51a33206a6c1c6b27d2cc5129daa19dbd1fc148d395284f6b26411f",
                                       "304402203679d909f43f073c7c1dcf8468a485090589079ee834e6eed92fea9b09b06a2402201e46f1075afa18f306715e7db87493e7b7e779569aa13c64ab3d09980b3560a3",
@@ -55,11 +46,7 @@ fn asm_benchmark(c: &mut Criterion) {
 #[cfg(has_asm)]
 fn aot_benchmark(c: &mut Criterion) {
     c.bench_function("aot secp256k1_bench", |b| {
-        let mut file = File::open("benches/data/secp256k1_bench").unwrap();
-        let mut buffer = Vec::new();
-        file.read_to_end(&mut buffer).unwrap();
-
-        let buffer = Bytes::from(buffer);
+        let buffer = fs::read("benches/data/secp256k1_bench").unwrap().into();
         let args: Vec<Bytes> = vec!["secp256k1_bench",
                                       "033f8cf9c4d51a33206a6c1c6b27d2cc5129daa19dbd1fc148d395284f6b26411f",
                                       "304402203679d909f43f073c7c1dcf8468a485090589079ee834e6eed92fea9b09b06a2402201e46f1075afa18f306715e7db87493e7b7e779569aa13c64ab3d09980b3560a3",
@@ -79,12 +66,7 @@ fn aot_benchmark(c: &mut Criterion) {
 #[cfg(has_asm)]
 fn aot_compiling_benchmark(c: &mut Criterion) {
     c.bench_function("compiling secp256k1_bench for aot", |b| {
-        let mut file = File::open("benches/data/secp256k1_bench").unwrap();
-        let mut buffer = Vec::new();
-        file.read_to_end(&mut buffer).unwrap();
-
-        let buffer = Bytes::from(buffer);
-
+        let buffer = fs::read("benches/data/secp256k1_bench").unwrap().into();
         b.iter(|| {
             AotCompilingMachine::load(&buffer.clone(), None, ISA_IMC, VERSION0)
                 .unwrap()
@@ -97,12 +79,7 @@ fn aot_compiling_benchmark(c: &mut Criterion) {
 #[cfg(has_asm)]
 fn mop_benchmark(c: &mut Criterion) {
     c.bench_function("interpret secp256k1_bench via assembly mop", |b| {
-
-        let mut file = File::open("benches/data/secp256k1_bench").unwrap();
-        let mut buffer = Vec::new();
-        file.read_to_end(&mut buffer).unwrap();
-
-        let buffer = Bytes::from(buffer);
+        let buffer = fs::read("benches/data/secp256k1_bench").unwrap().into();
         let args: Vec<Bytes> = vec!["secp256k1_bench",
                                       "033f8cf9c4d51a33206a6c1c6b27d2cc5129daa19dbd1fc148d395284f6b26411f",
                                       "304402203679d909f43f073c7c1dcf8468a485090589079ee834e6eed92fea9b09b06a2402201e46f1075afa18f306715e7db87493e7b7e779569aa13c64ab3d09980b3560a3",

--- a/benches/vm_benchmark.rs
+++ b/benches/vm_benchmark.rs
@@ -46,7 +46,7 @@ fn asm_benchmark(c: &mut Criterion) {
 #[cfg(has_asm)]
 fn aot_benchmark(c: &mut Criterion) {
     c.bench_function("aot secp256k1_bench", |b| {
-        let buffer = fs::read("benches/data/secp256k1_bench").unwrap().into();
+        let buffer: Bytes = fs::read("benches/data/secp256k1_bench").unwrap().into();
         let args: Vec<Bytes> = vec!["secp256k1_bench",
                                       "033f8cf9c4d51a33206a6c1c6b27d2cc5129daa19dbd1fc148d395284f6b26411f",
                                       "304402203679d909f43f073c7c1dcf8468a485090589079ee834e6eed92fea9b09b06a2402201e46f1075afa18f306715e7db87493e7b7e779569aa13c64ab3d09980b3560a3",
@@ -66,7 +66,7 @@ fn aot_benchmark(c: &mut Criterion) {
 #[cfg(has_asm)]
 fn aot_compiling_benchmark(c: &mut Criterion) {
     c.bench_function("compiling secp256k1_bench for aot", |b| {
-        let buffer = fs::read("benches/data/secp256k1_bench").unwrap().into();
+        let buffer: Bytes = fs::read("benches/data/secp256k1_bench").unwrap().into();
         b.iter(|| {
             AotCompilingMachine::load(&buffer.clone(), None, ISA_IMC, VERSION0)
                 .unwrap()

--- a/tests/test_aot.rs
+++ b/tests/test_aot.rs
@@ -1,6 +1,5 @@
 #![cfg(has_asm)]
 
-use bytes::Bytes;
 use ckb_vm::{
     machine::{
         aot::AotCompilingMachine,
@@ -12,18 +11,13 @@ use ckb_vm::{
     Debugger, DefaultMachineBuilder, Error, Instruction, Register, SupportMachine, Syscalls,
     ISA_IMC,
 };
-use std::fs::File;
-use std::io::Read;
+use std::fs;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
 
 #[test]
 pub fn test_aot_simple64() {
-    let mut file = File::open("tests/programs/simple64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/simple64").unwrap().into();
     let mut aot_machine = AotCompilingMachine::load(&buffer, None, ISA_IMC, VERSION0).unwrap();
     let code = aot_machine.compile().unwrap();
     let mut machine = AsmMachine::default_with_aot_code(&code);
@@ -60,11 +54,7 @@ impl<Mac: SupportMachine> Syscalls<Mac> for CustomSyscall {
 
 #[test]
 pub fn test_aot_with_custom_syscall() {
-    let mut file = File::open("tests/programs/syscall64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/syscall64").unwrap().into();
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::default()
         .syscall(Box::new(CustomSyscall {}))
         .build();
@@ -97,11 +87,7 @@ impl<Mac: SupportMachine> Debugger<Mac> for CustomDebugger {
 
 #[test]
 pub fn test_aot_ebreak() {
-    let mut file = File::open("tests/programs/ebreak64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/ebreak64").unwrap().into();
     let value = Arc::new(AtomicU8::new(0));
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::default()
         .debugger(Box::new(CustomDebugger {
@@ -126,11 +112,7 @@ fn dummy_cycle_func(_i: Instruction) -> u64 {
 
 #[test]
 pub fn test_aot_simple_cycles() {
-    let mut file = File::open("tests/programs/simple64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/simple64").unwrap().into();
     let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, 517);
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
         .instruction_cycle_func(Box::new(dummy_cycle_func))
@@ -152,11 +134,7 @@ pub fn test_aot_simple_cycles() {
 
 #[test]
 pub fn test_aot_simple_max_cycles_reached() {
-    let mut file = File::open("tests/programs/simple64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/simple64").unwrap().into();
     // Running simple64 should consume 517 cycles using dummy cycle func
     let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, 500);
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
@@ -177,11 +155,7 @@ pub fn test_aot_simple_max_cycles_reached() {
 
 #[test]
 pub fn test_aot_trace() {
-    let mut file = File::open("tests/programs/trace64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/trace64").unwrap().into();
     let mut aot_machine = AotCompilingMachine::load(&buffer, None, ISA_IMC, VERSION0).unwrap();
     let code = aot_machine.compile().unwrap();
     let mut machine = AsmMachine::default_with_aot_code(&code);
@@ -195,11 +169,7 @@ pub fn test_aot_trace() {
 
 #[test]
 pub fn test_aot_jump0() {
-    let mut file = File::open("tests/programs/jump0_64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/jump0_64").unwrap().into();
     let mut aot_machine = AotCompilingMachine::load(&buffer, None, ISA_IMC, VERSION0).unwrap();
     let code = aot_machine.compile().unwrap();
     let mut machine = AsmMachine::default_with_aot_code(&code);
@@ -213,11 +183,9 @@ pub fn test_aot_jump0() {
 
 #[test]
 pub fn test_aot_write_large_address() {
-    let mut file = File::open("tests/programs/write_large_address64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/write_large_address64")
+        .unwrap()
+        .into();
     let mut aot_machine = AotCompilingMachine::load(&buffer, None, ISA_IMC, VERSION0).unwrap();
     let code = aot_machine.compile().unwrap();
     let mut machine = AsmMachine::default_with_aot_code(&code);
@@ -231,11 +199,7 @@ pub fn test_aot_write_large_address() {
 
 #[test]
 pub fn test_aot_misaligned_jump64() {
-    let mut file = File::open("tests/programs/misaligned_jump64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/misaligned_jump64").unwrap().into();
     let mut aot_machine = AotCompilingMachine::load(&buffer, None, ISA_IMC, VERSION0).unwrap();
     let code = aot_machine.compile().unwrap();
     let mut machine = AsmMachine::default_with_aot_code(&code);
@@ -248,11 +212,7 @@ pub fn test_aot_misaligned_jump64() {
 
 #[test]
 pub fn test_aot_mulw64() {
-    let mut file = File::open("tests/programs/mulw64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/mulw64").unwrap().into();
     let mut aot_machine = AotCompilingMachine::load(&buffer, None, ISA_IMC, VERSION0).unwrap();
     let code = aot_machine.compile().unwrap();
     let mut machine = AsmMachine::default_with_aot_code(&code);
@@ -266,11 +226,7 @@ pub fn test_aot_mulw64() {
 
 #[test]
 pub fn test_aot_invalid_read64() {
-    let mut file = File::open("tests/programs/invalid_read64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/invalid_read64").unwrap().into();
     let mut aot_machine = AotCompilingMachine::load(&buffer, None, ISA_IMC, VERSION0).unwrap();
     let code = aot_machine.compile().unwrap();
     let mut machine = AsmMachine::default_with_aot_code(&code);
@@ -284,11 +240,7 @@ pub fn test_aot_invalid_read64() {
 
 #[test]
 pub fn test_aot_load_elf_crash_64() {
-    let mut file = File::open("tests/programs/load_elf_crash_64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/load_elf_crash_64").unwrap().into();
     let mut aot_machine = AotCompilingMachine::load(&buffer, None, ISA_IMC, VERSION0).unwrap();
     let code = aot_machine.compile().unwrap();
     let mut machine = AsmMachine::default_with_aot_code(&code);
@@ -301,11 +253,7 @@ pub fn test_aot_load_elf_crash_64() {
 
 #[test]
 pub fn test_aot_wxorx_crash_64() {
-    let mut file = File::open("tests/programs/wxorx_crash_64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/wxorx_crash_64").unwrap().into();
     let mut aot_machine = AotCompilingMachine::load(&buffer, None, ISA_IMC, VERSION0).unwrap();
     let code = aot_machine.compile().unwrap();
     let mut machine = AsmMachine::default_with_aot_code(&code);
@@ -318,44 +266,32 @@ pub fn test_aot_wxorx_crash_64() {
 
 #[test]
 pub fn test_aot_load_elf_section_crash_64() {
-    let mut file = File::open("tests/programs/load_elf_section_crash_64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/load_elf_section_crash_64")
+        .unwrap()
+        .into();
     let result = AotCompilingMachine::load(&buffer, None, ISA_IMC, VERSION0);
     assert_eq!(result.err(), Some(Error::OutOfBound));
 }
 
 #[test]
 pub fn test_aot_load_malformed_elf_crash_64() {
-    let mut file = File::open("tests/programs/load_malformed_elf_crash_64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/load_malformed_elf_crash_64")
+        .unwrap()
+        .into();
     let result = AotCompilingMachine::load(&buffer, None, ISA_IMC, VERSION0);
     assert_eq!(result.err(), Some(Error::ParseError));
 }
 
 #[test]
 pub fn test_aot_flat_crash_64() {
-    let mut file = File::open("tests/programs/flat_crash_64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/flat_crash_64").unwrap().into();
     let result = AotCompilingMachine::load(&buffer, None, ISA_IMC, VERSION0);
     assert_eq!(result.err(), Some(Error::OutOfBound));
 }
 
 #[test]
 pub fn test_aot_alloc_many() {
-    let mut file = File::open("tests/programs/alloc_many").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/alloc_many").unwrap().into();
     let mut aot_machine = AotCompilingMachine::load(&buffer, None, ISA_IMC, VERSION0).unwrap();
     let code = aot_machine.compile().unwrap();
     let mut machine = AsmMachine::default_with_aot_code(&code);
@@ -369,11 +305,7 @@ pub fn test_aot_alloc_many() {
 
 #[test]
 pub fn test_aot_chaos_seed() {
-    let mut file = File::open("tests/programs/read_memory").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/read_memory").unwrap().into();
     let mut aot_machine1 = AotCompilingMachine::load(&buffer, None, ISA_IMC, VERSION1).unwrap();
     let code1 = aot_machine1.compile().unwrap();
     let mut asm_core1 = AsmCoreMachine::new(ISA_IMC, VERSION1, u64::max_value());
@@ -408,11 +340,7 @@ pub fn test_aot_chaos_seed() {
 
 #[test]
 pub fn test_aot_rvc_pageend() {
-    let mut file = File::open("tests/programs/rvc_pageend").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/rvc_pageend").unwrap().into();
     let mut aot_machine = AotCompilingMachine::load(&buffer, None, ISA_IMC, VERSION0).unwrap();
     let code = aot_machine.compile().unwrap();
     let mut machine = AsmMachine::default_with_aot_code(&code);

--- a/tests/test_asm.rs
+++ b/tests/test_asm.rs
@@ -1,6 +1,5 @@
 #![cfg(has_asm)]
 
-use bytes::Bytes;
 use ckb_vm::{
     machine::{
         asm::{AsmCoreMachine, AsmMachine},
@@ -11,18 +10,13 @@ use ckb_vm::{
     Debugger, DefaultMachineBuilder, Error, Instruction, Register, SupportMachine, Syscalls,
     ISA_IMC,
 };
-use std::fs::File;
-use std::io::Read;
+use std::fs;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
 
 #[test]
 pub fn test_asm_simple64() {
-    let mut file = File::open("tests/programs/simple64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/simple64").unwrap().into();
     let mut machine = AsmMachine::default();
     machine
         .load_program(&buffer, &vec!["simple".into()])
@@ -57,11 +51,7 @@ impl<Mac: SupportMachine> Syscalls<Mac> for CustomSyscall {
 
 #[test]
 pub fn test_asm_with_custom_syscall() {
-    let mut file = File::open("tests/programs/syscall64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/syscall64").unwrap().into();
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::default()
         .syscall(Box::new(CustomSyscall {}))
         .build();
@@ -92,11 +82,7 @@ impl<Mac: SupportMachine> Debugger<Mac> for CustomDebugger {
 
 #[test]
 pub fn test_asm_ebreak() {
-    let mut file = File::open("tests/programs/ebreak64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/ebreak64").unwrap().into();
     let value = Arc::new(AtomicU8::new(0));
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::default()
         .debugger(Box::new(CustomDebugger {
@@ -119,11 +105,7 @@ fn dummy_cycle_func(_i: Instruction) -> u64 {
 
 #[test]
 pub fn test_asm_simple_cycles() {
-    let mut file = File::open("tests/programs/simple64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/simple64").unwrap().into();
     let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, 517);
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
         .instruction_cycle_func(Box::new(dummy_cycle_func))
@@ -141,11 +123,7 @@ pub fn test_asm_simple_cycles() {
 
 #[test]
 pub fn test_asm_simple_max_cycles_reached() {
-    let mut file = File::open("tests/programs/simple64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/simple64").unwrap().into();
     // Running simple64 should consume 517 cycles using dummy cycle func
     let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, 500);
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
@@ -162,11 +140,7 @@ pub fn test_asm_simple_max_cycles_reached() {
 
 #[test]
 pub fn test_asm_trace() {
-    let mut file = File::open("tests/programs/trace64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/trace64").unwrap().into();
     let mut machine = AsmMachine::default();
     machine
         .load_program(&buffer, &vec!["simple".into()])
@@ -178,11 +152,7 @@ pub fn test_asm_trace() {
 
 #[test]
 pub fn test_asm_jump0() {
-    let mut file = File::open("tests/programs/jump0_64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/jump0_64").unwrap().into();
     let mut machine = AsmMachine::default();
     machine
         .load_program(&buffer, &vec!["jump0_64".into()])
@@ -194,11 +164,9 @@ pub fn test_asm_jump0() {
 
 #[test]
 pub fn test_asm_write_large_address() {
-    let mut file = File::open("tests/programs/write_large_address64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/write_large_address64")
+        .unwrap()
+        .into();
     let mut machine = AsmMachine::default();
     machine
         .load_program(&buffer, &vec!["write_large_address64".into()])
@@ -210,14 +178,10 @@ pub fn test_asm_write_large_address() {
 
 #[test]
 pub fn test_misaligned_jump64() {
-    let mut file = File::open("tests/programs/misaligned_jump64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/misaligned_jump64").unwrap().into();
     let mut machine = AsmMachine::default();
     machine
-        .load_program(&buffer, &vec!["write_large_address64".into()])
+        .load_program(&buffer, &vec!["misaligned_jump64".into()])
         .unwrap();
     let result = machine.run();
     assert!(result.is_ok());
@@ -225,11 +189,7 @@ pub fn test_misaligned_jump64() {
 
 #[test]
 pub fn test_mulw64() {
-    let mut file = File::open("tests/programs/mulw64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/mulw64").unwrap().into();
     let mut machine = AsmMachine::default();
     machine
         .load_program(&buffer, &vec!["mulw64".into()])
@@ -241,11 +201,7 @@ pub fn test_mulw64() {
 
 #[test]
 pub fn test_invalid_read64() {
-    let mut file = File::open("tests/programs/invalid_read64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/invalid_read64").unwrap().into();
     let mut machine = AsmMachine::default();
     machine
         .load_program(&buffer, &vec!["invalid_read64".into()])
@@ -257,11 +213,7 @@ pub fn test_invalid_read64() {
 
 #[test]
 pub fn test_asm_load_elf_crash_64() {
-    let mut file = File::open("tests/programs/load_elf_crash_64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/load_elf_crash_64").unwrap().into();
     let mut machine = AsmMachine::default();
     machine
         .load_program(&buffer, &vec!["load_elf_crash_64".into()])
@@ -272,11 +224,7 @@ pub fn test_asm_load_elf_crash_64() {
 
 #[test]
 pub fn test_asm_wxorx_crash_64() {
-    let mut file = File::open("tests/programs/wxorx_crash_64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/wxorx_crash_64").unwrap().into();
     let mut machine = AsmMachine::default();
     machine
         .load_program(&buffer, &vec!["wxorx_crash_64".into()])
@@ -287,11 +235,7 @@ pub fn test_asm_wxorx_crash_64() {
 
 #[test]
 pub fn test_asm_alloc_many() {
-    let mut file = File::open("tests/programs/alloc_many").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/alloc_many").unwrap().into();
     let mut machine = AsmMachine::default();
     machine
         .load_program(&buffer, &vec!["alloc_many".into()])
@@ -302,11 +246,7 @@ pub fn test_asm_alloc_many() {
 
 #[test]
 pub fn test_asm_chaos_seed() {
-    let mut file = File::open("tests/programs/read_memory").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/read_memory").unwrap().into();
     let mut asm_core1 = AsmCoreMachine::new(ISA_IMC, VERSION1, u64::max_value());
     asm_core1.chaos_mode = 1;
     asm_core1.chaos_seed = 100;
@@ -337,11 +277,7 @@ pub fn test_asm_chaos_seed() {
 
 #[test]
 pub fn test_asm_rvc_pageend() {
-    let mut file = File::open("tests/programs/rvc_pageend").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/rvc_pageend").unwrap().into();
     let mut machine = AsmMachine::default();
     machine
         .load_program(&buffer, &vec!["rvc_pageend".into()])

--- a/tests/test_minimal.rs
+++ b/tests/test_minimal.rs
@@ -1,17 +1,11 @@
 extern crate ckb_vm;
 
-use bytes::Bytes;
 use ckb_vm::{run, SparseMemory};
-use std::fs::File;
-use std::io::Read;
+use std::fs;
 
 #[test]
 pub fn test_minimal_with_no_args() {
-    let mut file = File::open("tests/programs/minimal").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/minimal").unwrap().into();
     let result = run::<u32, SparseMemory<u32>>(&buffer, &vec!["minimal".into()]);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 1);
@@ -19,11 +13,7 @@ pub fn test_minimal_with_no_args() {
 
 #[test]
 pub fn test_minimal_with_a() {
-    let mut file = File::open("tests/programs/minimal").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/minimal").unwrap().into();
     let result = run::<u32, SparseMemory<u32>>(&buffer, &vec!["minimal".into(), "a".into()]);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 2);
@@ -31,11 +21,7 @@ pub fn test_minimal_with_a() {
 
 #[test]
 pub fn test_minimal_with_b() {
-    let mut file = File::open("tests/programs/minimal").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/minimal").unwrap().into();
     let result = run::<u32, SparseMemory<u32>>(&buffer, &vec!["minimal".into(), "".into()]);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);

--- a/tests/test_misc.rs
+++ b/tests/test_misc.rs
@@ -1,9 +1,7 @@
-use std::fs::File;
-use std::io::Read;
+use std::fs;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
 
-use bytes::Bytes;
 #[cfg(has_asm)]
 use ckb_vm::{
     machine::{asm::AsmCoreMachine, VERSION0},
@@ -18,11 +16,7 @@ use ckb_vm_definitions::RISCV_PAGESIZE;
 
 #[test]
 pub fn test_andi() {
-    let mut file = File::open("tests/programs/andi").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/andi").unwrap().into();
     let result = run::<u32, SparseMemory<u32>>(&buffer, &vec!["andi".into()]);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);
@@ -30,11 +24,7 @@ pub fn test_andi() {
 
 #[test]
 pub fn test_nop() {
-    let mut file = File::open("tests/programs/nop").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/nop").unwrap().into();
     let result = run::<u32, SparseMemory<u32>>(&buffer, &vec!["nop".into()]);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);
@@ -65,11 +55,7 @@ impl<Mac: SupportMachine> Syscalls<Mac> for CustomSyscall {
 
 #[test]
 pub fn test_custom_syscall() {
-    let mut file = File::open("tests/programs/syscall64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/syscall64").unwrap().into();
     let mut machine =
         DefaultMachineBuilder::<DefaultCoreMachine<u64, SparseMemory<u64>>>::default()
             .syscall(Box::new(CustomSyscall {}))
@@ -100,11 +86,7 @@ impl<Mac: SupportMachine> Debugger<Mac> for CustomDebugger {
 
 #[test]
 pub fn test_ebreak() {
-    let mut file = File::open("tests/programs/ebreak64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/ebreak64").unwrap().into();
     let value = Arc::new(AtomicU8::new(0));
     let mut machine =
         DefaultMachineBuilder::<DefaultCoreMachine<u64, SparseMemory<u64>>>::default()
@@ -123,11 +105,7 @@ pub fn test_ebreak() {
 
 #[test]
 pub fn test_trace() {
-    let mut file = File::open("tests/programs/trace64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/trace64").unwrap().into();
     let result = run::<u64, SparseMemory<u64>>(&buffer, &vec!["trace64".into()]);
     assert!(result.is_err());
     assert_eq!(result.err(), Some(Error::InvalidPermission));
@@ -135,11 +113,7 @@ pub fn test_trace() {
 
 #[test]
 pub fn test_jump0() {
-    let mut file = File::open("tests/programs/jump0_64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/jump0_64").unwrap().into();
     let result = run::<u64, SparseMemory<u64>>(&buffer, &vec!["jump0_64".into()]);
     assert!(result.is_err());
     assert_eq!(result.err(), Some(Error::InvalidPermission));
@@ -147,33 +121,23 @@ pub fn test_jump0() {
 
 #[test]
 pub fn test_misaligned_jump64() {
-    let mut file = File::open("tests/programs/misaligned_jump64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/misaligned_jump64").unwrap().into();
     let result = run::<u64, SparseMemory<u64>>(&buffer, &vec!["misaligned_jump64".into()]);
     assert!(result.is_ok());
 }
 
 #[test]
 pub fn test_mulw64() {
-    let mut file = File::open("tests/programs/mulw64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/mulw64").unwrap().into();
     let result = run::<u64, SparseMemory<u64>>(&buffer, &vec!["mulw64".into()]);
     assert!(result.is_ok());
 }
 
 #[test]
 pub fn test_invalid_file_offset64() {
-    let mut file = File::open("tests/programs/invalid_file_offset64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/invalid_file_offset64")
+        .unwrap()
+        .into();
     let result = run::<u64, SparseMemory<u64>>(&buffer, &vec!["invalid_file_offset64".into()]);
     assert_eq!(result.err(), Some(Error::OutOfBound));
 }
@@ -181,11 +145,9 @@ pub fn test_invalid_file_offset64() {
 #[test]
 #[cfg_attr(all(miri, feature = "miri-ci"), ignore)]
 pub fn test_op_rvc_srli_crash_32() {
-    let mut file = File::open("tests/programs/op_rvc_srli_crash_32").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/op_rvc_srli_crash_32")
+        .unwrap()
+        .into();
     let result = run::<u32, SparseMemory<u32>>(&buffer, &vec!["op_rvc_srli_crash_32".into()]);
     assert_eq!(result.err(), Some(Error::InvalidPermission));
 }
@@ -193,11 +155,9 @@ pub fn test_op_rvc_srli_crash_32() {
 #[test]
 #[cfg_attr(all(miri, feature = "miri-ci"), ignore)]
 pub fn test_op_rvc_srai_crash_32() {
-    let mut file = File::open("tests/programs/op_rvc_srai_crash_32").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/op_rvc_srai_crash_32")
+        .unwrap()
+        .into();
     let result = run::<u32, SparseMemory<u32>>(&buffer, &vec!["op_rvc_srai_crash_32".into()]);
     assert!(result.is_ok());
 }
@@ -205,44 +165,30 @@ pub fn test_op_rvc_srai_crash_32() {
 #[test]
 #[cfg_attr(all(miri, feature = "miri-ci"), ignore)]
 pub fn test_op_rvc_slli_crash_32() {
-    let mut file = File::open("tests/programs/op_rvc_slli_crash_32").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/op_rvc_slli_crash_32")
+        .unwrap()
+        .into();
     let result = run::<u32, SparseMemory<u32>>(&buffer, &vec!["op_rvc_slli_crash_32".into()]);
     assert!(result.is_ok());
 }
 
 #[test]
 pub fn test_load_elf_crash_64() {
-    let mut file = File::open("tests/programs/load_elf_crash_64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/load_elf_crash_64").unwrap().into();
     let result = run::<u64, SparseMemory<u64>>(&buffer, &vec!["load_elf_crash_64".into()]);
     assert_eq!(result.err(), Some(Error::InvalidPermission));
 }
 
 #[test]
 pub fn test_wxorx_crash_64() {
-    let mut file = File::open("tests/programs/wxorx_crash_64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/wxorx_crash_64").unwrap().into();
     let result = run::<u64, SparseMemory<u64>>(&buffer, &vec!["wxorx_crash_64".into()]);
     assert_eq!(result.err(), Some(Error::OutOfBound));
 }
 
 #[test]
 pub fn test_flat_crash_64() {
-    let mut file = File::open("tests/programs/flat_crash_64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/flat_crash_64").unwrap().into();
     let mut machine = DefaultMachine::<DefaultCoreMachine<u64, FlatMemory<u64>>>::default();
     let result = machine.load_program(&buffer, &vec!["flat_crash_64".into()]);
     assert_eq!(result.err(), Some(Error::OutOfBound));
@@ -263,11 +209,7 @@ fn assert_memory_store_empty_bytes<M: Memory>(memory: &mut M) {
 }
 
 pub fn test_contains_ckbforks_section() {
-    let mut file = File::open("tests/programs/ckbforks").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/ckbforks").unwrap();
     let ckbforks_exists_v0 = || -> bool {
         let elf = goblin_v023::elf::Elf::parse(&buffer).unwrap();
         for section_header in &elf.section_headers {
@@ -297,11 +239,7 @@ pub fn test_contains_ckbforks_section() {
 #[test]
 pub fn test_rvc_pageend() {
     // The last instruction of a executable memory page is an RVC instruction.
-    let mut file = File::open("tests/programs/rvc_pageend").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/rvc_pageend").unwrap().into();
     let mut machine =
         DefaultMachineBuilder::<DefaultCoreMachine<u64, SparseMemory<u64>>>::default().build();
     machine

--- a/tests/test_simple.rs
+++ b/tests/test_simple.rs
@@ -1,21 +1,15 @@
 extern crate ckb_vm;
 
-use bytes::Bytes;
 use ckb_vm::machine::VERSION0;
 use ckb_vm::{
     run, DefaultCoreMachine, DefaultMachine, DefaultMachineBuilder, Error, FlatMemory, Instruction,
     SparseMemory, SupportMachine, ISA_IMC,
 };
-use std::fs::File;
-use std::io::Read;
+use std::fs;
 
 #[test]
 pub fn test_simple_instructions() {
-    let mut file = File::open("tests/programs/simple").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/simple").unwrap().into();
     let result = run::<u32, SparseMemory<u32>>(&buffer, &vec!["simple".into()]);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);
@@ -23,11 +17,7 @@ pub fn test_simple_instructions() {
 
 #[test]
 pub fn test_simple_instructions_64() {
-    let mut file = File::open("tests/programs/simple64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/simple64").unwrap().into();
     let result = run::<u64, SparseMemory<u64>>(&buffer, &vec!["simple".into()]);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);
@@ -35,11 +25,7 @@ pub fn test_simple_instructions_64() {
 
 #[test]
 pub fn test_simple_instructions_flatmemory() {
-    let mut file = File::open("tests/programs/simple").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/simple").unwrap().into();
     let result = run::<u32, FlatMemory<u32>>(&buffer, &vec!["simple".into()]);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);
@@ -51,11 +37,7 @@ fn dummy_cycle_func(_i: Instruction) -> u64 {
 
 #[test]
 pub fn test_simple_cycles() {
-    let mut file = File::open("tests/programs/simple64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/simple64").unwrap().into();
     let core_machine = DefaultCoreMachine::<u64, SparseMemory<u64>>::new(ISA_IMC, VERSION0, 517);
     let mut machine =
         DefaultMachineBuilder::<DefaultCoreMachine<u64, SparseMemory<u64>>>::new(core_machine)
@@ -73,11 +55,7 @@ pub fn test_simple_cycles() {
 
 #[test]
 pub fn test_simple_max_cycles_reached() {
-    let mut file = File::open("tests/programs/simple64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/simple64").unwrap().into();
     // Running simple64 should consume 517 cycles using dummy cycle func
     let core_machine = DefaultCoreMachine::<u64, SparseMemory<u64>>::new(ISA_IMC, VERSION0, 500);
     let mut machine =
@@ -94,11 +72,7 @@ pub fn test_simple_max_cycles_reached() {
 
 #[test]
 pub fn test_simple_invalid_bits() {
-    let mut file = File::open("tests/programs/simple").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/simple").unwrap().into();
     let result = run::<u64, SparseMemory<u64>>(&buffer, &vec!["simple".into()]);
     assert!(result.is_err());
     assert_eq!(result.unwrap_err(), Error::InvalidElfBits);
@@ -106,11 +80,7 @@ pub fn test_simple_invalid_bits() {
 
 #[test]
 pub fn test_simple_loaded_bytes() {
-    let mut file = File::open("tests/programs/simple64").unwrap();
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer).unwrap();
-    let buffer: Bytes = buffer.into();
-
+    let buffer = fs::read("tests/programs/simple64").unwrap().into();
     let mut machine = DefaultMachine::<DefaultCoreMachine<u64, SparseMemory<u64>>>::default();
     let bytes = machine
         .load_program(&buffer, &vec!["simple".into()])


### PR DESCRIPTION
```rs
let mut file = File::open("benches/data/secp256k1_bench").unwrap();        
let mut buffer = Vec::new();        
file.read_to_end(&amp;mut buffer).unwrap();        
let buffer = Bytes::from(buffer);
```

can be replace with

```rs
let buffer = fs::read("benches/data/secp256k1_bench").unwrap().into();
```

This will make the code compact.

