### PR TITLE
fix: asm enable condition

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -6,14 +6,15 @@
 fn main() {
     use std::env;
 
-    let target_pointer_width = env::var("CARGO_CFG_TARGET_POINTER_WIDTH").unwrap();
     let target_family = env::var("CARGO_CFG_TARGET_FAMILY").unwrap_or_default();
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
     let is_windows = target_family == "windows";
     let is_unix = target_family == "unix";
-    let can_enable_asm = (target_pointer_width == "64") && (is_windows || is_unix);
+    let is_x86_64 = target_arch == "x86_64";
+    let can_enable_asm = is_x86_64 && (is_windows || is_unix);
 
     if cfg!(feature = "asm") && (!can_enable_asm) {
-        panic!("asm feature can only be enabled on 64-bit Linux, macOS and Windows platforms!");
+        panic!("asm feature can only be enabled on x86_64 Linux, macOS and Windows platforms!");
     }
 
     if cfg!(any(feature = "asm", feature = "detect-asm")) && can_enable_asm {


### PR DESCRIPTION
Asm shouldn't enable on arm64 Linux, Well now Apple Silicon is also arm64 but runs macOS ;-)