### PR TITLE
Fix instruction length setting in asm's step()

### DIFF
--- a/src/machine/asm/mod.rs
+++ b/src/machine/asm/mod.rs
@@ -448,9 +448,8 @@ impl<'a> AsmMachine<'a> {
         let pc = *self.machine.pc();
         let slot = calculate_slot(pc);
         let mut trace = Trace::default();
-        let mut instruction = decoder.decode(self.machine.memory_mut(), pc)?;
+        let instruction = decoder.decode(self.machine.memory_mut(), pc)?;
         let len = instruction_length(instruction) as u8;
-        instruction |= u64::from(len) << 24;
         trace.instructions[0] = instruction;
         trace.cycles += self
             .machine

--- a/tests/test_asm.rs
+++ b/tests/test_asm.rs
@@ -402,10 +402,10 @@ pub fn test_asm_step() {
         .unwrap();
 
     let result = || -> Result<i8, Error> {
-        let decoder = build_decoder::<u64>(ISA_IMC);
+        let mut decoder = build_decoder::<u64>(ISA_IMC);
         machine.machine.set_running(true);
         while machine.machine.running() {
-            machine.step(&decoder)?;
+            machine.step(&mut decoder)?;
         }
         Ok(machine.machine.exit_code())
     }();


### PR DESCRIPTION
There is no need to write the real length into the instruction, it should be a bug caused by the previous modification of the instruction format.

**The assembly code will get the correct length by shifting**

https://github.com/nervosnetwork/ckb-vm/blob/develop/src/machine/asm/execute.S#L477-L478
