### PR TITLE
chore: don't package the benches and the tests when publish to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 build = "build.rs"
+exclude = ["/benches", "/tests"]
 
 [features]
 default = []


### PR DESCRIPTION
The `benches` directory (2.4 MiB) and the `tests` directory (1.2 MiB) have a lot of binaries.

Don't package them can reduce the published `ckb-vm` crate size by 82.4% (`4.4 MiB -> 780K`).

p.s. `ckb-vm = "0.20.0-rc4"` is 5.6 MiB.