### PR TITLE
fix: ensure that the PC is updated after every instructions

### DIFF
--- a/src/instructions/execute.rs
+++ b/src/instructions/execute.rs
@@ -912,7 +912,7 @@ pub fn execute<Mac: Machine>(inst: Instruction, machine: &mut Mac) -> Result<(),
         .pc()
         .overflowing_add(&Mac::REG::from_u8(instruction_size));
     machine.update_pc(next_pc);
-    execute_instruction(inst, machine)?;
+    let r = execute_instruction(inst, machine);
     machine.commit_pc();
-    Ok(())
+    r
 }


### PR DESCRIPTION
A rare situation, when the registers are modified and cycles exceeds max_cycles in a syscall, if we use snapshot and resume to restart the vm, the vm after restarting will given the wrong result(because the pc is not updated and the register is updated).
