### PR TITLE
Bump version to 0.20.0-rc6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ckb-vm"
 description = "CKB's Virtual machine"
-version = "0.20.0-rc5"
+version = "0.20.0-rc6"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -25,7 +25,7 @@ goblin_v023 = { package = "goblin", version = "=0.2.3" }
 goblin_v040 = { package = "goblin", version = "=0.4.0" }
 scroll = "0.10"
 serde = { version = "1.0", features = ["derive"] }
-ckb-vm-definitions = { path = "definitions", version = "0.20.0-rc5" }
+ckb-vm-definitions = { path = "definitions", version = "0.20.0-rc6" }
 derive_more = "0.99.2"
 rand = "0.7.3"
 

--- a/definitions/Cargo.toml
+++ b/definitions/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ckb-vm-definitions"
 description = "Common definition files for CKB VM"
-version = "0.20.0-rc5"
+version = "0.20.0-rc6"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"


### PR DESCRIPTION
Update:

- Fix some bugs in B extension, see https://github.com/nervosnetwork/ckb-vm/pull/209