### PR TITLE
Add a path with the path to the bench file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,10 @@ proptest = "0.9.1"
 
 [[bench]]
 name = "bits_benchmark"
+path = "benches/bits_benchmark.rs"
 harness = false
 
 [[bench]]
 name = "vm_benchmark"
+path = "benches/vm_benchmark.rs"
 harness = false


### PR DESCRIPTION
Since we excluded bench and tests by https://github.com/nervosnetwork/ckb-vm/commit/6da2cf89e7f00c3b68c4c8dd0b61edfdbd1e2677, `cargo publish` fails:

```text
$ cargo publish
    Updating crates.io index
warning: manifest has no documentation, homepage or repository.
See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
   Packaging ckb-vm v0.20.0-rc6 (/tmp/ckb-vm)
   Verifying ckb-vm v0.20.0-rc6 (/tmp/ckb-vm)
error: failed to verify package tarball

Caused by:
  failed to parse manifest at `/tmp/ckb-vm/target/package/ckb-vm-0.20.0-rc6/Cargo.toml`

Caused by:
  can't find `bits_benchmark` bench, specify bench.path
```

Fixed this following the suggestions provided on this page: https://users.rust-lang.org/t/cargo-publish-with-excluded-benchmark-fails-validation/53444