### PR TITLE
misc: update ci script

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ trigger:
 
 variables:
   RUST_BACKTRACE: full
-  TEST_SUITE_COMMIT: f8707fdd208ffedc7c51b83722cbe9fb5fdc5d4f
+  TEST_SUITE_COMMIT: 1cc531114df6eaa94cc046bc526c8f631bd0bfdd
 
 jobs:
   - job: WinUnitTest

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -136,7 +136,7 @@ jobs:
 
   - job: LinuxTestSuite
     pool:
-      vmImage: 'ubuntu-16.04'
+      vmImage: 'ubuntu-18.04'
     steps:
       - template: devtools/azure/linux-dependencies.yml
         parameters:
@@ -158,7 +158,7 @@ jobs:
       - script: |
           git clone https://github.com/nervosnetwork/ckb-vm-test-suite &&
           ln -snf .. ckb-vm-test-suite/ckb-vm &&
-          docker run --rm -v `pwd`:/code xxuejie/riscv-gnu-toolchain-rv64imac:xenial-20190606 cp -r /riscv /code/riscv &&
+          docker run --rm -v `pwd`:/code nervos/ckb-riscv-gnu-toolchain:bionic-20210804 cp -r /riscv /code/riscv &&
           cd ckb-vm-test-suite &&
           git checkout $TEST_SUITE_COMMIT &&
           git submodule update --init --recursive &&
@@ -182,7 +182,7 @@ jobs:
   - job: LinuxCodeCoverage
     condition: eq(variables['Build.SourceBranch'], 'refs/heads/release')
     pool:
-      vmImage: 'ubuntu-16.04'
+      vmImage: 'ubuntu-18.04'
     steps:
       - template: devtools/azure/linux-dependencies.yml
         parameters:
@@ -218,7 +218,7 @@ jobs:
           rm -rf kcov-36 v36.tar.gz &&
           git clone https://github.com/nervosnetwork/ckb-vm-test-suite &&
           ln -snf .. ckb-vm-test-suite/ckb-vm &&
-          docker run --rm -v `pwd`:/code xxuejie/riscv-gnu-toolchain-rv64imac:xenial-20190606 cp -r /riscv /code/riscv &&
+          docker run --rm -v `pwd`:/code nervos/ckb-riscv-gnu-toolchain:bionic-20210804 cp -r /riscv /code/riscv &&
           cd ckb-vm-test-suite && git checkout $TEST_SUITE_COMMIT && git submodule update --init --recursive &&
           RISCV=`pwd`/../riscv ./test.sh --coverage &&
           cd .. &&


### PR DESCRIPTION
It seems Azure pipelines does not support ubuntu16.04 anymore.

[https://dev.azure.com/nervosnetwork/ckb-vm/_build/results?buildId=17868&view=logs&j=59996fe9-e97f-5209-faa9-c3dec101ec25](https://dev.azure.com/nervosnetwork/ckb-vm/_build/results?buildId=17868&view=logs&j=59996fe9-e97f-5209-faa9-c3dec101ec25)

```
##[warning]An image label with the label ubuntu-16.04 does not exist.
,##[error]The remote provider was unable to process the request.
```