### PR TITLE
Bump version to 0.20.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ckb-vm"
 description = "CKB's Virtual machine"
-version = "0.20.0-rc6"
+version = "0.20.0"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -25,7 +25,7 @@ goblin_v023 = { package = "goblin", version = "=0.2.3" }
 goblin_v040 = { package = "goblin", version = "=0.4.0" }
 scroll = "0.10"
 serde = { version = "1.0", features = ["derive"] }
-ckb-vm-definitions = { path = "definitions", version = "0.20.0-rc6" }
+ckb-vm-definitions = { path = "definitions", version = "0.20.0" }
 derive_more = "0.99.2"
 rand = "0.7.3"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - template: devtools/azure/linux-dependencies.yml
         parameters:
-          rustup_toolchain: 'stable'
+          rustup_toolchain: '1.51.0-x86_64-unknown-linux-gnu'
       - script: cargo install cargo-deny --locked
         displayName: Install cargo deny
       - script: make ci-deps

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,7 +68,7 @@ jobs:
       - template: devtools/azure/linux-dependencies.yml
         parameters:
           rustup_toolchain: '1.51.0-x86_64-unknown-linux-gnu'
-      - script: cargo install cargo-deny --locked
+      - script: cargo install cargo-deny --locked --version 0.9.0
         displayName: Install cargo deny
       - script: make ci-deps
         displayName: Run ci-deps

--- a/definitions/Cargo.toml
+++ b/definitions/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ckb-vm-definitions"
 description = "Common definition files for CKB VM"
-version = "0.20.0-rc6"
+version = "0.20.0"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"


### PR DESCRIPTION
- Remove the rc-tag. 
- The latest version of cargo-deny uses the newly rust syntax, which is not supported in rust 1.51
```
$ cargo install cargo-deny
...
...
Compiling spdx v0.6.2
error[E0658]: or-patterns syntax is experimental
  --> /home/vsts/.cargo/registry/src/github.com-1ecc6299db9ec823/spdx-0.6.2/src/expression/parser.rs:79:29
   |
79 |                 None | Some(Token::And | Token::Or | Token::OpenParen) => &["<license>", "("],
|                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #54883 <https://github.com/rust-lang/rust/issues/54883> for more information
...
...
```