### PR TITLE
Add external error and pc field for invalid instruction error

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -103,7 +103,10 @@ impl Decoder {
                 return Ok(instruction);
             }
         }
-        Err(Error::InvalidInstruction(instruction_bits))
+        Err(Error::InvalidInstruction {
+            pc: pc,
+            instruction: instruction_bits,
+        })
     }
 
     // Macro-Operation Fusion (also Macro-Op Fusion, MOP Fusion, or Macrofusion) is a hardware optimization technique found

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -104,7 +104,7 @@ impl Decoder {
             }
         }
         Err(Error::InvalidInstruction {
-            pc: pc,
+            pc,
             instruction: instruction_bits,
         })
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use std::error::Error as StdError;
 use std::io::{Error as IOError, ErrorKind};
 
-#[derive(Debug, PartialEq, Clone, Copy, Eq, Display)]
+#[derive(Debug, PartialEq, Clone, Eq, Display)]
 pub enum Error {
     #[display(fmt = "parse error")]
     ParseError,
@@ -13,8 +13,12 @@ pub enum Error {
     InvalidCycles,
     #[display(fmt = "cycles overflow")]
     CyclesOverflow,
-    #[display(fmt = "invalid instruction {}", "_0")]
-    InvalidInstruction(u32),
+    #[display(
+        fmt = "invalid instruction pc=0x{:x} instruction=0x{:x}",
+        "pc",
+        "instruction"
+    )]
+    InvalidInstruction { pc: u64, instruction: u32 },
     #[display(fmt = "invalid syscall {}", "_0")]
     InvalidEcall(u64),
     #[display(fmt = "invalid elf")]
@@ -37,6 +41,10 @@ pub enum Error {
     Unexpected,
     #[display(fmt = "unimplemented")]
     Unimplemented,
+    // Unknown error type is for the debugging tool of CKB-VM, it should not be
+    // used in this project.
+    #[display(fmt = "external error: {}", "_0")]
+    External(String),
 }
 
 impl StdError for Error {}

--- a/src/machine/aot/mod.rs
+++ b/src/machine/aot/mod.rs
@@ -226,7 +226,10 @@ impl LabelGatheringMachine {
                         }
                         self.pc = Value::from_u64(next_pc);
                     }
-                    Err(Error::InvalidInstruction(i)) if i == 0 => {
+                    Err(Error::InvalidInstruction {
+                        pc: _,
+                        instruction: i,
+                    }) if i == 0 => {
                         // Due to alignment or other reasons, the code might
                         // certain invalid instructions in the executable
                         // sections, for a normal VM instance that's executing

--- a/tests/test_versions.rs
+++ b/tests/test_versions.rs
@@ -470,7 +470,13 @@ pub fn test_asm_version0_cadd_hints() {
     let mut machine = create_rust_machine("cadd_hints".to_string(), VERSION0);
     let result = machine.run();
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err(), Error::InvalidInstruction(36906));
+    assert_eq!(
+        result.unwrap_err(),
+        Error::InvalidInstruction {
+            pc: 65656,
+            instruction: 36906
+        }
+    );
 }
 
 #[test]


### PR DESCRIPTION
- Add pc field for InvalidInstruction error
- Add external error, so we can return an error instead of panic: https://github.com/nervosnetwork/ckb-vm-pprof/blob/master/src/lib.rs#L203-L205
