### PR TITLE
Rename Immediate to SImmediate

### DIFF
--- a/src/instructions/b.rs
+++ b/src/instructions/b.rs
@@ -111,7 +111,7 @@ pub fn factory<R: Register>(instruction_bits: u32, _: u32) -> Option<Instruction
                     _ => None,
                 };
                 inst_opt.map(|inst| {
-                    Itype::new(
+                    Itype::new_u(
                         inst,
                         rd(instruction_bits),
                         rs1(instruction_bits),
@@ -141,7 +141,7 @@ pub fn factory<R: Register>(instruction_bits: u32, _: u32) -> Option<Instruction
                         })
                     }
                     0b_101 => Some(
-                        Itype::new(
+                        Itype::new_u(
                             insts::OP_RORIW,
                             rd(instruction_bits),
                             rs1(instruction_bits),
@@ -154,7 +154,7 @@ pub fn factory<R: Register>(instruction_bits: u32, _: u32) -> Option<Instruction
                 _ => {
                     if funct7_value >> 1 == 0b_000010 && funct3_value == 0b_001 {
                         Some(
-                            Itype::new(
+                            Itype::new_u(
                                 insts::OP_SLLIUW,
                                 rd(instruction_bits),
                                 rs1(instruction_bits),

--- a/src/instructions/common.rs
+++ b/src/instructions/common.rs
@@ -3,7 +3,7 @@ use super::super::memory::Memory;
 use super::super::RISCV_MAX_MEMORY;
 use super::register::Register;
 use super::utils::update_register;
-use super::{Error, Immediate, RegisterIndex, UImmediate};
+use super::{Error, RegisterIndex, SImmediate, UImmediate};
 
 // Other instruction set functions common with RVC
 
@@ -62,7 +62,7 @@ pub fn addi<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
-    imm: Immediate,
+    imm: SImmediate,
 ) {
     let value = machine.registers()[rs1 as usize].overflowing_add(&Mac::REG::from_i32(imm));
     update_register(machine, rd, value);
@@ -72,7 +72,7 @@ pub fn addiw<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
-    imm: Immediate,
+    imm: SImmediate,
 ) {
     let value = machine.registers()[rs1 as usize].overflowing_add(&Mac::REG::from_i32(imm));
     update_register(machine, rd, value.sign_extend(&Mac::REG::from_u8(32)));
@@ -96,7 +96,7 @@ pub fn lb<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
-    imm: Immediate,
+    imm: SImmediate,
     version0: bool,
 ) -> Result<(), Error> {
     let address = machine.registers()[rs1 as usize].overflowing_add(&Mac::REG::from_i32(imm));
@@ -111,7 +111,7 @@ pub fn lh<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
-    imm: Immediate,
+    imm: SImmediate,
     version0: bool,
 ) -> Result<(), Error> {
     let address = machine.registers()[rs1 as usize].overflowing_add(&Mac::REG::from_i32(imm));
@@ -126,7 +126,7 @@ pub fn lw<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
-    imm: Immediate,
+    imm: SImmediate,
     version0: bool,
 ) -> Result<(), Error> {
     let address = machine.registers()[rs1 as usize].overflowing_add(&Mac::REG::from_i32(imm));
@@ -140,7 +140,7 @@ pub fn ld<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
-    imm: Immediate,
+    imm: SImmediate,
     version0: bool,
 ) -> Result<(), Error> {
     let address = machine.registers()[rs1 as usize].overflowing_add(&Mac::REG::from_i32(imm));
@@ -154,7 +154,7 @@ pub fn lbu<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
-    imm: Immediate,
+    imm: SImmediate,
     version0: bool,
 ) -> Result<(), Error> {
     let address = machine.registers()[rs1 as usize].overflowing_add(&Mac::REG::from_i32(imm));
@@ -168,7 +168,7 @@ pub fn lhu<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
-    imm: Immediate,
+    imm: SImmediate,
     version0: bool,
 ) -> Result<(), Error> {
     let address = machine.registers()[rs1 as usize].overflowing_add(&Mac::REG::from_i32(imm));
@@ -182,7 +182,7 @@ pub fn lwu<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
-    imm: Immediate,
+    imm: SImmediate,
     version0: bool,
 ) -> Result<(), Error> {
     let address = machine.registers()[rs1 as usize].overflowing_add(&Mac::REG::from_i32(imm));
@@ -199,7 +199,7 @@ pub fn sb<Mac: Machine>(
     machine: &mut Mac,
     rs1: RegisterIndex,
     rs2: RegisterIndex,
-    imm: Immediate,
+    imm: SImmediate,
 ) -> Result<(), Error> {
     let address = machine.registers()[rs1 as usize].overflowing_add(&Mac::REG::from_i32(imm));
     let value = machine.registers()[rs2 as usize].clone();
@@ -211,7 +211,7 @@ pub fn sh<Mac: Machine>(
     machine: &mut Mac,
     rs1: RegisterIndex,
     rs2: RegisterIndex,
-    imm: Immediate,
+    imm: SImmediate,
 ) -> Result<(), Error> {
     let address = machine.registers()[rs1 as usize].overflowing_add(&Mac::REG::from_i32(imm));
     let value = machine.registers()[rs2 as usize].clone();
@@ -223,7 +223,7 @@ pub fn sw<Mac: Machine>(
     machine: &mut Mac,
     rs1: RegisterIndex,
     rs2: RegisterIndex,
-    imm: Immediate,
+    imm: SImmediate,
 ) -> Result<(), Error> {
     let address = machine.registers()[rs1 as usize].overflowing_add(&Mac::REG::from_i32(imm));
     let value = machine.registers()[rs2 as usize].clone();
@@ -235,7 +235,7 @@ pub fn sd<Mac: Machine>(
     machine: &mut Mac,
     rs1: RegisterIndex,
     rs2: RegisterIndex,
-    imm: Immediate,
+    imm: SImmediate,
 ) -> Result<(), Error> {
     let address = machine.registers()[rs1 as usize].overflowing_add(&Mac::REG::from_i32(imm));
     let value = machine.registers()[rs2 as usize].clone();
@@ -286,7 +286,7 @@ pub fn andi<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
-    imm: Immediate,
+    imm: SImmediate,
 ) {
     let value = machine.registers()[rs1 as usize].clone() & Mac::REG::from_i32(imm);
     update_register(machine, rd, value);
@@ -296,13 +296,18 @@ pub fn xori<Mac: Machine>(
     machine: &mut Mac,
     rd: RegisterIndex,
     rs1: RegisterIndex,
-    imm: Immediate,
+    imm: SImmediate,
 ) {
     let value = machine.registers()[rs1 as usize].clone() ^ Mac::REG::from_i32(imm);
     update_register(machine, rd, value);
 }
 
-pub fn ori<Mac: Machine>(machine: &mut Mac, rd: RegisterIndex, rs1: RegisterIndex, imm: Immediate) {
+pub fn ori<Mac: Machine>(
+    machine: &mut Mac,
+    rd: RegisterIndex,
+    rs1: RegisterIndex,
+    imm: SImmediate,
+) {
     let value = machine.registers()[rs1 as usize].clone() | Mac::REG::from_i32(imm);
     update_register(machine, rd, value);
 }
@@ -373,7 +378,7 @@ pub fn sraiw<Mac: Machine>(
 // =======================
 // #  JUMP instructions  #
 // =======================
-pub fn jal<Mac: Machine>(machine: &mut Mac, rd: RegisterIndex, imm: Immediate, xbytes: u8) {
+pub fn jal<Mac: Machine>(machine: &mut Mac, rd: RegisterIndex, imm: SImmediate, xbytes: u8) {
     let link = machine.pc().overflowing_add(&Mac::REG::from_u8(xbytes));
     update_register(machine, rd, link);
     machine.update_pc(machine.pc().overflowing_add(&Mac::REG::from_i32(imm)));

--- a/src/instructions/execute.rs
+++ b/src/instructions/execute.rs
@@ -220,27 +220,27 @@ pub fn execute_instruction<Mac: Machine>(
         }
         insts::OP_SLLI => {
             let i = Itype(inst);
-            common::slli(machine, i.rd(), i.rs1(), i.immediate());
+            common::slli(machine, i.rd(), i.rs1(), i.immediate_u());
         }
         insts::OP_SRLI => {
             let i = Itype(inst);
-            common::srli(machine, i.rd(), i.rs1(), i.immediate());
+            common::srli(machine, i.rd(), i.rs1(), i.immediate_u());
         }
         insts::OP_SRAI => {
             let i = Itype(inst);
-            common::srai(machine, i.rd(), i.rs1(), i.immediate());
+            common::srai(machine, i.rd(), i.rs1(), i.immediate_u());
         }
         insts::OP_SLLIW => {
             let i = Itype(inst);
-            common::slliw(machine, i.rd(), i.rs1(), i.immediate());
+            common::slliw(machine, i.rd(), i.rs1(), i.immediate_u());
         }
         insts::OP_SRLIW => {
             let i = Itype(inst);
-            common::srliw(machine, i.rd(), i.rs1(), i.immediate());
+            common::srliw(machine, i.rd(), i.rs1(), i.immediate_u());
         }
         insts::OP_SRAIW => {
             let i = Itype(inst);
-            common::sraiw(machine, i.rd(), i.rs1(), i.immediate());
+            common::sraiw(machine, i.rd(), i.rs1(), i.immediate_u());
         }
         insts::OP_SB => {
             let i = Stype(inst);
@@ -484,7 +484,7 @@ pub fn execute_instruction<Mac: Machine>(
         insts::OP_BCLRI => {
             let i = Itype(inst);
             let rs1_value = &machine.registers()[i.rs1()];
-            let rs2_value = &Mac::REG::from_u32(i.immediate());
+            let rs2_value = &Mac::REG::from_u32(i.immediate_u());
             let shamt = rs2_value.clone() & Mac::REG::from_u8(Mac::REG::SHIFT_MASK);
             let value = rs1_value.clone() & !(Mac::REG::one() << shamt);
             update_register(machine, i.rd(), value);
@@ -500,7 +500,7 @@ pub fn execute_instruction<Mac: Machine>(
         insts::OP_BEXTI => {
             let i = Itype(inst);
             let rs1_value = &machine.registers()[i.rs1()];
-            let rs2_value = &Mac::REG::from_u32(i.immediate());
+            let rs2_value = &Mac::REG::from_u32(i.immediate_u());
             let shamt = rs2_value.clone() & Mac::REG::from_u8(Mac::REG::SHIFT_MASK);
             let value = Mac::REG::one() & (rs1_value.clone() >> shamt);
             update_register(machine, i.rd(), value);
@@ -516,7 +516,7 @@ pub fn execute_instruction<Mac: Machine>(
         insts::OP_BINVI => {
             let i = Itype(inst);
             let rs1_value = &machine.registers()[i.rs1()];
-            let rs2_value = &Mac::REG::from_u32(i.immediate());
+            let rs2_value = &Mac::REG::from_u32(i.immediate_u());
             let shamt = rs2_value.clone() & Mac::REG::from_u8(Mac::REG::SHIFT_MASK);
             let value = rs1_value.clone() ^ (Mac::REG::one() << shamt);
             update_register(machine, i.rd(), value);
@@ -532,7 +532,7 @@ pub fn execute_instruction<Mac: Machine>(
         insts::OP_BSETI => {
             let i = Itype(inst);
             let rs1_value = &machine.registers()[i.rs1()];
-            let rs2_value = &Mac::REG::from_u32(i.immediate());
+            let rs2_value = &Mac::REG::from_u32(i.immediate_u());
             let shamt = rs2_value.clone() & Mac::REG::from_u8(Mac::REG::SHIFT_MASK);
             let value = rs1_value.clone() | (Mac::REG::one() << shamt);
             update_register(machine, i.rd(), value);
@@ -674,7 +674,7 @@ pub fn execute_instruction<Mac: Machine>(
         insts::OP_RORI => {
             let i = Itype(inst);
             let rs1_value = &machine.registers()[i.rs1()];
-            let rs2_value = &Mac::REG::from_u32(i.immediate());
+            let rs2_value = &Mac::REG::from_u32(i.immediate_u());
             let shamt = rs2_value.clone() & Mac::REG::from_u8(Mac::REG::SHIFT_MASK);
             let value = rs1_value.ror(&shamt);
             update_register(machine, i.rd(), value);
@@ -682,7 +682,7 @@ pub fn execute_instruction<Mac: Machine>(
         insts::OP_RORIW => {
             let i = Itype(inst);
             let rs1_value = &machine.registers()[i.rs1()];
-            let rs2_value = &Mac::REG::from_u32(i.immediate());
+            let rs2_value = &Mac::REG::from_u32(i.immediate_u());
             let shamt = rs2_value.clone() & Mac::REG::from_u8(31);
             let twins = rs1_value
                 .zero_extend(&Mac::REG::from_u8(32))
@@ -763,7 +763,7 @@ pub fn execute_instruction<Mac: Machine>(
         insts::OP_SLLIUW => {
             let i = Itype(inst);
             let rs1_value = &machine.registers()[i.rs1()];
-            let rs2_value = Mac::REG::from_u32(i.immediate());
+            let rs2_value = Mac::REG::from_u32(i.immediate_u());
             let rs1_u = rs1_value.clone().zero_extend(&Mac::REG::from_u8(32));
             let shamt = rs2_value & Mac::REG::from_u8(Mac::REG::SHIFT_MASK);
             let value = rs1_u << shamt;

--- a/src/instructions/i.rs
+++ b/src/instructions/i.rs
@@ -285,5 +285,5 @@ pub fn factory<R: Register>(instruction_bits: u32, _: u32) -> Option<Instruction
 }
 
 pub fn nop() -> Instruction {
-    Itype::new(insts::OP_ADDI, 0, 0, 0).0
+    Itype::new_u(insts::OP_ADDI, 0, 0, 0).0
 }

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -17,7 +17,7 @@ pub use ckb_vm_definitions::instructions::{
 pub use execute::{execute, execute_instruction};
 
 type RegisterIndex = usize;
-type Immediate = i32;
+type SImmediate = i32;
 type UImmediate = u32;
 
 #[inline(always)]
@@ -73,11 +73,11 @@ impl Rtype {
 pub struct Itype(pub Instruction);
 
 impl Itype {
-    pub fn new(
+    pub fn new_u(
         op: InstructionOpcode,
         rd: RegisterIndex,
         rs1: RegisterIndex,
-        immediate: UImmediate,
+        immediate_u: UImmediate,
     ) -> Self {
         Itype(
             (u64::from(op) >> 8 << 16) |
@@ -86,7 +86,7 @@ impl Itype {
               (u64::from(rs1 as u8) << 32) |
               // Per RISC-V spec, I-type uses 12 bits at most, so it's perfectly
               // fine we store them in 3-byte location.
-              (u64::from(immediate) << 40),
+              (u64::from(immediate_u) << 40),
         )
     }
 
@@ -94,9 +94,9 @@ impl Itype {
         op: InstructionOpcode,
         rd: RegisterIndex,
         rs1: RegisterIndex,
-        immediate: Immediate,
+        immediate_s: SImmediate,
     ) -> Self {
-        Self::new(op, rd, rs1, immediate as UImmediate)
+        Self::new_u(op, rd, rs1, immediate_s as UImmediate)
     }
 
     pub fn op(self) -> InstructionOpcode {
@@ -111,12 +111,12 @@ impl Itype {
         (self.0 >> 32) as u8 as RegisterIndex
     }
 
-    pub fn immediate(self) -> UImmediate {
+    pub fn immediate_u(self) -> UImmediate {
         self.immediate_s() as UImmediate
     }
 
-    pub fn immediate_s(self) -> Immediate {
-        ((self.0 as i64) >> 40) as Immediate
+    pub fn immediate_s(self) -> SImmediate {
+        ((self.0 as i64) >> 40) as SImmediate
     }
 }
 
@@ -124,9 +124,9 @@ impl Itype {
 pub struct Stype(pub Instruction);
 
 impl Stype {
-    pub fn new(
+    pub fn new_u(
         op: InstructionOpcode,
-        immediate: UImmediate,
+        immediate_u: UImmediate,
         rs1: RegisterIndex,
         rs2: RegisterIndex,
     ) -> Self {
@@ -137,17 +137,17 @@ impl Stype {
               (u64::from(rs1 as u8) << 32) |
               // Per RISC-V spec, S/B type uses 13 bits at most, so it's perfectly
               // fine we store them in 3-byte location.
-              (u64::from(immediate) << 40),
+              (u64::from(immediate_u) << 40),
         )
     }
 
     pub fn new_s(
         op: InstructionOpcode,
-        immediate: Immediate,
+        immediate_s: SImmediate,
         rs1: RegisterIndex,
         rs2: RegisterIndex,
     ) -> Self {
-        Self::new(op, immediate as UImmediate, rs1, rs2)
+        Self::new_u(op, immediate_s as UImmediate, rs1, rs2)
     }
 
     pub fn op(self) -> InstructionOpcode {
@@ -162,12 +162,12 @@ impl Stype {
         (self.0 >> 8) as u8 as RegisterIndex
     }
 
-    pub fn immediate(self) -> UImmediate {
+    pub fn immediate_u(self) -> UImmediate {
         self.immediate_s() as UImmediate
     }
 
-    pub fn immediate_s(self) -> Immediate {
-        ((self.0 as i64) >> 40) as Immediate
+    pub fn immediate_s(self) -> SImmediate {
+        ((self.0 as i64) >> 40) as SImmediate
     }
 }
 
@@ -175,17 +175,17 @@ impl Stype {
 pub struct Utype(pub Instruction);
 
 impl Utype {
-    pub fn new(op: InstructionOpcode, rd: RegisterIndex, immediate: UImmediate) -> Self {
+    pub fn new(op: InstructionOpcode, rd: RegisterIndex, immediate_u: UImmediate) -> Self {
         Utype(
             (u64::from(op) >> 8 << 16)
                 | u64::from(op as u8)
                 | (u64::from(rd as u8) << 8)
-                | (u64::from(immediate) << 32),
+                | (u64::from(immediate_u) << 32),
         )
     }
 
-    pub fn new_s(op: InstructionOpcode, rd: RegisterIndex, immediate: Immediate) -> Self {
-        Self::new(op, rd, immediate as UImmediate)
+    pub fn new_s(op: InstructionOpcode, rd: RegisterIndex, immediate_s: SImmediate) -> Self {
+        Self::new(op, rd, immediate_s as UImmediate)
     }
 
     pub fn op(self) -> InstructionOpcode {
@@ -196,12 +196,12 @@ impl Utype {
         (self.0 >> 8) as u8 as RegisterIndex
     }
 
-    pub fn immediate(self) -> UImmediate {
+    pub fn immediate_u(self) -> UImmediate {
         self.immediate_s() as UImmediate
     }
 
-    pub fn immediate_s(self) -> Immediate {
-        ((self.0 as i64) >> 32) as Immediate
+    pub fn immediate_s(self) -> SImmediate {
+        ((self.0 as i64) >> 32) as SImmediate
     }
 }
 

--- a/src/instructions/rvc.rs
+++ b/src/instructions/rvc.rs
@@ -107,7 +107,7 @@ pub fn factory<R: Register>(instruction_bits: u32, version: u32) -> Option<Instr
             if nzuimm != 0 {
                 // C.ADDI4SPN
                 Some(
-                    Itype::new(
+                    Itype::new_u(
                         insts::OP_ADDI,
                         compact_register_number(instruction_bits, 2),
                         SP,
@@ -122,7 +122,7 @@ pub fn factory<R: Register>(instruction_bits: u32, version: u32) -> Option<Instr
         }
         0b_010_00000000000_00 => Some(
             // C.LW
-            Itype::new(
+            Itype::new_u(
                 insts::OP_LW,
                 compact_register_number(instruction_bits, 2),
                 compact_register_number(instruction_bits, 7),
@@ -136,7 +136,7 @@ pub fn factory<R: Register>(instruction_bits: u32, version: u32) -> Option<Instr
             } else {
                 // C.LD
                 Some(
-                    Itype::new(
+                    Itype::new_u(
                         insts::OP_LD,
                         compact_register_number(instruction_bits, 2),
                         compact_register_number(instruction_bits, 7),
@@ -150,7 +150,7 @@ pub fn factory<R: Register>(instruction_bits: u32, version: u32) -> Option<Instr
         0b_100_00000000000_00 => None,
         0b_110_00000000000_00 => Some(
             // C.SW
-            Stype::new(
+            Stype::new_u(
                 insts::OP_SW,
                 sw_uimmediate(instruction_bits),
                 compact_register_number(instruction_bits, 7),
@@ -164,7 +164,7 @@ pub fn factory<R: Register>(instruction_bits: u32, version: u32) -> Option<Instr
             } else {
                 // C.SD
                 Some(
-                    Stype::new(
+                    Stype::new_u(
                         insts::OP_SD,
                         fld_uimmediate(instruction_bits),
                         compact_register_number(instruction_bits, 7),
@@ -340,13 +340,13 @@ pub fn factory<R: Register>(instruction_bits: u32, version: u32) -> Option<Instr
                         (0b_00_000_00000_00, 0) => None,
                         // C.SRLI
                         (0b_00_000_00000_00, uimm) => Some(
-                            Itype::new(insts::OP_SRLI, rd, rd, uimm & u32::from(R::SHIFT_MASK)).0,
+                            Itype::new_u(insts::OP_SRLI, rd, rd, uimm & u32::from(R::SHIFT_MASK)).0,
                         ),
                         // Invalid instruction
                         (0b_01_000_00000_00, 0) => None,
                         // C.SRAI
                         (0b_01_000_00000_00, uimm) => Some(
-                            Itype::new(insts::OP_SRAI, rd, rd, uimm & u32::from(R::SHIFT_MASK)).0,
+                            Itype::new_u(insts::OP_SRAI, rd, rd, uimm & u32::from(R::SHIFT_MASK)).0,
                         ),
                         // C.ANDI
                         (0b_10_000_00000_00, _) => Some(
@@ -387,7 +387,7 @@ pub fn factory<R: Register>(instruction_bits: u32, version: u32) -> Option<Instr
             let rd = rd(instruction_bits);
             if rd != 0 && uimm != 0 {
                 // C.SLLI
-                Some(Itype::new(insts::OP_SLLI, rd, rd, uimm & u32::from(R::SHIFT_MASK)).0)
+                Some(Itype::new_u(insts::OP_SLLI, rd, rd, uimm & u32::from(R::SHIFT_MASK)).0)
             } else if version >= 1 {
                 // HINTs
                 Some(nop())
@@ -399,7 +399,7 @@ pub fn factory<R: Register>(instruction_bits: u32, version: u32) -> Option<Instr
             let rd = rd(instruction_bits);
             if rd != 0 {
                 // C.LWSP
-                Some(Itype::new(insts::OP_LW, rd, SP, lwsp_uimmediate(instruction_bits)).0)
+                Some(Itype::new_u(insts::OP_LW, rd, SP, lwsp_uimmediate(instruction_bits)).0)
             } else {
                 // Reserved
                 None
@@ -412,7 +412,7 @@ pub fn factory<R: Register>(instruction_bits: u32, version: u32) -> Option<Instr
                 let rd = rd(instruction_bits);
                 if rd != 0 {
                     // C.LDSP
-                    Some(Itype::new(insts::OP_LD, rd, SP, fldsp_uimmediate(instruction_bits)).0)
+                    Some(Itype::new_u(insts::OP_LD, rd, SP, fldsp_uimmediate(instruction_bits)).0)
                 } else {
                     // Reserved
                     None
@@ -470,7 +470,7 @@ pub fn factory<R: Register>(instruction_bits: u32, version: u32) -> Option<Instr
         }
         0b_110_00000000000_10 => Some(
             // C.SWSP
-            Stype::new(
+            Stype::new_u(
                 insts::OP_SW,
                 swsp_uimmediate(instruction_bits),
                 SP,
@@ -484,7 +484,7 @@ pub fn factory<R: Register>(instruction_bits: u32, version: u32) -> Option<Instr
             } else {
                 // C.SDSP
                 Some(
-                    Stype::new(
+                    Stype::new_u(
                         insts::OP_SD,
                         fsdsp_uimmediate(instruction_bits),
                         2,


### PR DESCRIPTION
The naming here is confusing, rename `Immediate` to `SImmediate` is better.

https://github.com/nervosnetwork/ckb-vm/blob/develop/src/instructions/mod.rs#L20

https://github.com/nervosnetwork/ckb-vm/blob/develop/src/instructions/mod.rs#L114