### PR TITLE
Save all dirty memory pages (including executable pages) and it's flag to snapshot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ckb-vm"
 description = "CKB's Virtual machine"
-version = "0.20.0"
+version = "0.20.1"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
@@ -25,7 +25,7 @@ goblin_v023 = { package = "goblin", version = "=0.2.3" }
 goblin_v040 = { package = "goblin", version = "=0.4.0" }
 scroll = "0.10"
 serde = { version = "1.0", features = ["derive"] }
-ckb-vm-definitions = { path = "definitions", version = "0.20.0" }
+ckb-vm-definitions = { path = "definitions", version = "0.20.1" }
 derive_more = "0.99.2"
 rand = "0.7.3"
 

--- a/definitions/Cargo.toml
+++ b/definitions/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ckb-vm-definitions"
 description = "Common definition files for CKB VM"
-version = "0.20.0"
+version = "0.20.1"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -13,12 +13,11 @@ use scroll::Pread;
 use super::debugger::Debugger;
 use super::decoder::{build_decoder, Decoder};
 use super::instructions::{execute, Instruction, Register};
-use super::memory::{round_page_down, round_page_up, Memory, FLAG_DIRTY};
+use super::memory::{round_page_down, round_page_up, Memory};
 use super::syscalls::Syscalls;
 use super::{
     registers::{A0, A7, REGISTER_ABI_NAMES, SP},
     Error, DEFAULT_STACK_SIZE, ISA_MOP, RISCV_GENERAL_REGISTER_NUMBER, RISCV_MAX_MEMORY,
-    RISCV_PAGES,
 };
 
 // Version 0 is the initial launched CKB VM, it is used in CKB Lina mainnet
@@ -179,9 +178,6 @@ pub trait SupportMachine: CoreMachine {
         if update_pc {
             self.update_pc(Self::REG::from_u64(e_entry));
             self.commit_pc();
-        }
-        for i in 0..RISCV_PAGES {
-            self.memory_mut().clear_flag(i as u64, FLAG_DIRTY)?;
         }
         Ok(bytes)
     }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -71,7 +71,8 @@ pub fn make_snapshot<T: CoreMachine>(machine: &mut T) -> Result<Snapshot, Error>
             }
 
             snap.page_indices.push(i as u64);
-            snap.page_flags.push(machine.memory_mut().fetch_flag(i as u64)?);
+            snap.page_flags
+                .push(machine.memory_mut().fetch_flag(i as u64)?);
             snap.pages.push(page);
         }
     }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -71,8 +71,7 @@ pub fn make_snapshot<T: CoreMachine>(machine: &mut T) -> Result<Snapshot, Error>
             }
 
             snap.page_indices.push(i as u64);
-            snap.page_flags
-                .push(machine.memory_mut().fetch_flag(i as u64)?);
+            snap.page_flags.push(flag);
             snap.pages.push(page);
         }
     }

--- a/tests/test_versions.rs
+++ b/tests/test_versions.rs
@@ -6,7 +6,7 @@ use ckb_vm::{
         asm::{AsmCoreMachine, AsmMachine},
         VERSION0, VERSION1,
     },
-    memory::FLAG_FREEZED,
+    memory::{FLAG_DIRTY, FLAG_FREEZED},
     CoreMachine, DefaultCoreMachine, DefaultMachine, DefaultMachineBuilder, Error, Memory,
     SparseMemory, WXorXMemory, ISA_IMC, RISCV_PAGESIZE,
 };
@@ -434,7 +434,7 @@ pub fn test_asm_version0_writable_page() {
     // 0x12000 is the address of the variable "buffer", which can be found from the dump file.
     let page_index = 0x12000 / RISCV_PAGESIZE as u64;
     let flag = machine.machine.memory_mut().fetch_flag(page_index).unwrap();
-    assert_eq!(flag, FLAG_FREEZED);
+    assert_eq!(flag, FLAG_DIRTY | FLAG_FREEZED);
     let result = machine.run();
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);
@@ -445,7 +445,7 @@ pub fn test_asm_version1_writable_page() {
     let mut machine = create_asm_machine("writable_page".to_string(), VERSION1);
     let page_index = 0x12000 / RISCV_PAGESIZE as u64;
     let flag = machine.machine.memory_mut().fetch_flag(page_index).unwrap();
-    assert_eq!(flag, 0);
+    assert_eq!(flag, FLAG_DIRTY);
     let result = machine.run();
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);


### PR DESCRIPTION
When making a snapshot, the code loaded by `load_cell_data_as_code` and `exec` syscall in ckb could not be persisted. This  bug caused an error in the ckb chunk_run function. 

ref: https://github.com/nervosnetwork/ckb/pull/3176