### PR TITLE
chore: Split aot mode into its own feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ default = []
 asm = []
 # Detect if requirements are met, and enable asm feature when we can.
 detect-asm = []
+aot = ["asm"]
 enable-chaos-mode-by-default = ["ckb-vm-definitions/enable-chaos-mode-by-default"]
 # Disable slow tests to run miri on CI
 miri-ci = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ memmap = { package ="mapr", version = "0.8.0" }
 cc = "1.0"
 
 [dev-dependencies]
-criterion = "0.3.0"
+criterion = "0.3.5"
 proptest = "0.9.1"
 
 [[bench]]

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,17 @@
 test:
 	cargo test --all -- --nocapture
 
-test-all-features:
+test-asm:
 	cargo test --all --features=asm -- --nocapture
 
-test-chaos:
+test-aot:
+	cargo test --all --features=aot -- --nocapture
+
+test-asm-chaos:
 	cargo test --all --features=asm,enable-chaos-mode-by-default -- --nocapture
+
+test-aot-chaos:
+	cargo test --all --features=aot,enable-chaos-mode-by-default -- --nocapture
 
 check:
 	cargo check --all --all-targets --all-features
@@ -44,10 +50,16 @@ ci-deps: security-audit check-licenses check-crates
 ci-quick: test
 	git diff --exit-code Cargo.lock
 
-ci-all-features: test-all-features
+ci-asm: test-asm
 	git diff --exit-code Cargo.lock
 
-ci-chaos: test-chaos
+ci-aot: test-aot
+	git diff --exit-code Cargo.lock
+
+ci-asm-chaos: test-asm-chaos
+	git diff --exit-code Cargo.lock
+
+ci-aot-chaos: test-aot-chaos
 	git diff --exit-code Cargo.lock
 
 ci-miri:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,34 +11,24 @@ variables:
   TEST_SUITE_COMMIT: 1cc531114df6eaa94cc046bc526c8f631bd0bfdd
 
 jobs:
-  - job: WinUnitTest
+  - job: WinCI
     pool:
       vmImage: 'VS2017-Win2016'
     steps:
       - template: devtools/azure/windows-dependencies.yml
         parameters:
           rustup_toolchain: '1.51.0-x86_64-pc-windows-msvc'
-      - script: make test
+      - script: make ci-aot
         displayName: Run unit tests
 
-  - job: WinUnitTestAllFeatures
+  - job: WinCIChaos
     pool:
       vmImage: 'VS2017-Win2016'
     steps:
       - template: devtools/azure/windows-dependencies.yml
         parameters:
           rustup_toolchain: '1.51.0-x86_64-pc-windows-msvc'
-      - script: make test-all-features
-        displayName: Run unit tests with all features
-
-  - job: WinUnitTestChaos
-    pool:
-      vmImage: 'VS2017-Win2016'
-    steps:
-      - template: devtools/azure/windows-dependencies.yml
-        parameters:
-          rustup_toolchain: '1.51.0-x86_64-pc-windows-msvc'
-      - script: make test-chaos
+      - script: make ci-aot-chaos
         displayName: Run unit tests with chaos
 
   - job: OSXCI
@@ -48,18 +38,18 @@ jobs:
       - template: devtools/azure/osx-dependencies.yml
         parameters:
           rustup_toolchain: '1.51.0-x86_64-apple-darwin'
-      - script: make ci
-        displayName: Run ci
+      - script: make ci-aot
+        displayName: Run unit tests
 
-  - job: OSXCIAllFeatures
+  - job: OSXCIChaos
     pool:
       vmImage: 'macOS-10.15'
     steps:
       - template: devtools/azure/osx-dependencies.yml
         parameters:
           rustup_toolchain: '1.51.0-x86_64-apple-darwin'
-      - script: make ci-all-features
-        displayName: Run ci-all-features
+      - script: make ci-aot-chaos
+        displayName: Run unit tests with chaos
 
   - job: LinuxCIDeps
     pool:
@@ -103,25 +93,55 @@ jobs:
       - script: make check
         displayName: Run check
 
-  - job: LinuxCIAllFeatures
+  - job: LinuxCIAOT
     pool:
       vmImage: 'ubuntu-20.04'
     steps:
       - template: devtools/azure/linux-dependencies.yml
         parameters:
           rustup_toolchain: '1.51.0-x86_64-unknown-linux-gnu'
-      - script: make ci-all-features
-        displayName: Run ci-all-features
+      - script: make ci-aot
+        displayName: Run ci-aot
 
-  - job: LinuxCIChaos
+  - job: LinuxCIASM
     pool:
       vmImage: 'ubuntu-20.04'
     steps:
       - template: devtools/azure/linux-dependencies.yml
         parameters:
           rustup_toolchain: '1.51.0-x86_64-unknown-linux-gnu'
-      - script: make ci-chaos
-        displayName: Run ci-chaos
+      - script: make ci-asm
+        displayName: Run ci-asm
+
+  - job: LinuxCI
+    pool:
+      vmImage: 'ubuntu-20.04'
+    steps:
+      - template: devtools/azure/linux-dependencies.yml
+        parameters:
+          rustup_toolchain: '1.51.0-x86_64-unknown-linux-gnu'
+      - script: make ci
+        displayName: Run ci
+
+  - job: LinuxCIASMChaos
+    pool:
+      vmImage: 'ubuntu-20.04'
+    steps:
+      - template: devtools/azure/linux-dependencies.yml
+        parameters:
+          rustup_toolchain: '1.51.0-x86_64-unknown-linux-gnu'
+      - script: make ci-asm-chaos
+        displayName: Run ci-asm-chaos
+
+  - job: LinuxCIAOTChaos
+    pool:
+      vmImage: 'ubuntu-20.04'
+    steps:
+      - template: devtools/azure/linux-dependencies.yml
+        parameters:
+          rustup_toolchain: '1.51.0-x86_64-unknown-linux-gnu'
+      - script: make ci-aot-chaos
+        displayName: Run ci-aot-chaos
 
   - job: LinuxCIMiri
     pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ trigger:
 
 variables:
   RUST_BACKTRACE: full
-  TEST_SUITE_COMMIT: 1cc531114df6eaa94cc046bc526c8f631bd0bfdd
+  TEST_SUITE_COMMIT: 2256b990a84fe50a9bac1fd178ce086bb90d7710
 
 jobs:
   - job: WinCI

--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,6 @@
 [advisories]
 vulnerability = "deny"
-unmaintained = "deny"
+unmaintained = "warn"
 yanked = "deny"
 notice = "deny"
 

--- a/src/machine/aot/mod.rs
+++ b/src/machine/aot/mod.rs
@@ -6,7 +6,7 @@ use std::mem;
 use std::rc::Rc;
 
 use bytes::Bytes;
-use memmap::{Mmap, MmapMut};
+use memmap::MmapMut;
 use scroll::Pread;
 
 use super::super::{
@@ -15,7 +15,7 @@ use super::super::{
         ast::Value, execute, instruction_length, is_basic_block_end_instruction,
         is_slowpath_instruction, Instruction,
     },
-    machine::{elf_adaptor, SupportMachine, VERSION1},
+    machine::{asm::AotCode, elf_adaptor, SupportMachine, VERSION1},
     CoreMachine, DefaultCoreMachine, Error, FlatMemory, InstructionCycleFunc, Machine, Memory,
     Register, RISCV_MAX_MEMORY,
 };
@@ -420,20 +420,6 @@ impl Memory for LabelGatheringMachine {
 
     fn store64(&mut self, _addr: &Value, _value: &Value) -> Result<(), Error> {
         Ok(())
-    }
-}
-
-pub struct AotCode {
-    pub code: Mmap,
-    /// Labels that map RISC-V addresses to offsets into the compiled x86_64
-    /// assembly code. This can be used as entrypoints to start executing in
-    /// AOT code.
-    pub labels: HashMap<u64, u32>,
-}
-
-impl AotCode {
-    pub fn base_address(&self) -> u64 {
-        self.code.as_ptr() as u64
     }
 }
 

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(has_asm)]
+#[cfg(has_aot)]
 pub mod aot;
 #[cfg(has_asm)]
 pub mod asm;

--- a/tests/machine_build.rs
+++ b/tests/machine_build.rs
@@ -1,7 +1,7 @@
 #[cfg(has_asm)]
-use ckb_vm::machine::aot::{AotCode, AotCompilingMachine};
-#[cfg(has_asm)]
 use ckb_vm::machine::asm::{AsmCoreMachine, AsmMachine};
+#[cfg(has_aot)]
+use ckb_vm::machine::{aot::AotCompilingMachine, asm::AotCode};
 
 use ckb_vm::machine::{trace::TraceMachine, DefaultCoreMachine, VERSION1};
 use ckb_vm::{DefaultMachineBuilder, ISA_B, ISA_IMC, ISA_MOP};
@@ -27,7 +27,7 @@ pub fn asm_v1_imcb<'a>(path: &str) -> AsmMachine<'a> {
     machine
 }
 
-#[cfg(has_asm)]
+#[cfg(has_aot)]
 pub fn aot_v1_imcb_code(path: &str) -> AotCode {
     let buffer: Bytes = std::fs::read(path).unwrap().into();
     let mut aot_machine =
@@ -35,7 +35,7 @@ pub fn aot_v1_imcb_code(path: &str) -> AotCode {
     aot_machine.compile().unwrap()
 }
 
-#[cfg(has_asm)]
+#[cfg(has_aot)]
 pub fn aot_v1_imcb<'a>(path: &str, code: &'a AotCode) -> AsmMachine<'a> {
     let buffer: Bytes = std::fs::read(path).unwrap().into();
 
@@ -84,7 +84,7 @@ pub fn asm_v1_mop<'a>(path: &str, args: Vec<Bytes>) -> AsmMachine<'a> {
     machine
 }
 
-#[cfg(has_asm)]
+#[cfg(has_aot)]
 pub fn aot_v1_mop_code(path: &str) -> AotCode {
     let buffer: Bytes = std::fs::read(path).unwrap().into();
     let mut aot_machine =
@@ -92,7 +92,7 @@ pub fn aot_v1_mop_code(path: &str) -> AotCode {
     aot_machine.compile().unwrap()
 }
 
-#[cfg(has_asm)]
+#[cfg(has_aot)]
 pub fn aot_v1_mop<'a>(path: &str, args: Vec<Bytes>, code: &'a AotCode) -> AsmMachine<'a> {
     let buffer: Bytes = std::fs::read(path).unwrap().into();
 

--- a/tests/test_aot.rs
+++ b/tests/test_aot.rs
@@ -1,4 +1,4 @@
-#![cfg(has_asm)]
+#![cfg(has_aot)]
 
 use ckb_vm::{
     machine::{

--- a/tests/test_b_extension.rs
+++ b/tests/test_b_extension.rs
@@ -13,7 +13,10 @@ pub fn test_clzw_bug() {
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
+    }
 
+    #[cfg(has_aot)]
+    {
         let code = machine_build::aot_v1_imcb_code("tests/programs/clzw_bug");
         let mut machine_aot = machine_build::aot_v1_imcb("tests/programs/clzw_bug", &code);
         let ret_aot = machine_aot.run();
@@ -35,7 +38,10 @@ pub fn test_sbinvi_aot_load_imm_bug() {
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
+    }
 
+    #[cfg(has_aot)]
+    {
         let code = machine_build::aot_v1_imcb_code("tests/programs/sbinvi_aot_load_imm_bug");
         let mut machine_aot =
             machine_build::aot_v1_imcb("tests/programs/sbinvi_aot_load_imm_bug", &code);
@@ -59,7 +65,10 @@ pub fn test_rorw_in_end_of_aot_block() {
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
+    }
 
+    #[cfg(has_aot)]
+    {
         let code = machine_build::aot_v1_imcb_code("tests/programs/rorw_in_end_of_aot_block");
         let mut machine_aot =
             machine_build::aot_v1_imcb("tests/programs/rorw_in_end_of_aot_block", &code);
@@ -82,7 +91,10 @@ pub fn test_pcnt() {
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
+    }
 
+    #[cfg(has_aot)]
+    {
         let code = machine_build::aot_v1_imcb_code("tests/programs/pcnt");
         let mut machine_aot = machine_build::aot_v1_imcb("tests/programs/pcnt", &code);
         let ret_aot = machine_aot.run();

--- a/tests/test_mop.rs
+++ b/tests/test_mop.rs
@@ -25,7 +25,10 @@ pub fn test_mop_wide_multiply() {
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
         assert_eq!(machine.machine.cycles(), 9192427);
+    }
 
+    #[cfg(has_aot)]
+    {
         let code = machine_build::aot_v1_mop_code("tests/programs/mop_wide_multiply");
         let mut machine_aot =
             machine_build::aot_v1_mop("tests/programs/mop_wide_multiply", vec![], &code);
@@ -57,7 +60,10 @@ pub fn test_mop_wide_divide() {
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
         assert_eq!(machine.machine.cycles(), 6106583);
+    }
 
+    #[cfg(has_aot)]
+    {
         let code = machine_build::aot_v1_mop_code("tests/programs/mop_wide_divide");
         let mut machine_aot =
             machine_build::aot_v1_mop("tests/programs/mop_wide_divide", vec![], &code);
@@ -88,7 +94,10 @@ pub fn test_mop_far_jump() {
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
         assert_eq!(machine.machine.cycles(), 5);
+    }
 
+    #[cfg(has_aot)]
+    {
         let code = machine_build::aot_v1_mop_code("tests/programs/mop_far_jump");
         let mut machine_aot =
             machine_build::aot_v1_mop("tests/programs/mop_far_jump", vec![], &code);
@@ -119,7 +128,10 @@ pub fn test_mop_ld_32_constants() {
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
+    }
 
+    #[cfg(has_aot)]
+    {
         let code = machine_build::aot_v1_mop_code("tests/programs/mop_ld_signextend_32");
         let mut machine_aot =
             machine_build::aot_v1_mop("tests/programs/mop_ld_signextend_32", vec![], &code);
@@ -153,7 +165,10 @@ pub fn test_mop_secp256k1() {
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
         assert_eq!(machine.machine.cycles(), 611871);
+    }
 
+    #[cfg(has_aot)]
+    {
         let code = machine_build::aot_v1_mop_code("benches/data/secp256k1_bench");
         let mut machine_aot =
             machine_build::aot_v1_mop("benches/data/secp256k1_bench", args.clone(), &code);
@@ -185,7 +200,10 @@ pub fn test_mop_adc() {
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
         assert_eq!(machine.machine.cycles(), 61);
+    }
 
+    #[cfg(has_aot)]
+    {
         let code = machine_build::aot_v1_mop_code("tests/programs/mop_adc");
         let mut machine_aot = machine_build::aot_v1_mop("tests/programs/mop_adc", vec![], &code);
         let ret_aot = machine_aot.run();
@@ -216,7 +234,10 @@ pub fn test_mop_sbb() {
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
         assert_eq!(machine.machine.cycles(), 27);
+    }
 
+    #[cfg(has_aot)]
+    {
         let code = machine_build::aot_v1_mop_code("tests/programs/mop_sbb");
         let mut machine_aot = machine_build::aot_v1_mop("tests/programs/mop_sbb", vec![], &code);
         let ret_aot = machine_aot.run();
@@ -248,7 +269,10 @@ pub fn test_mop_random_adc_sbb() {
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
         assert_eq!(machine.machine.cycles(), 6755);
+    }
 
+    #[cfg(has_aot)]
+    {
         let code = machine_build::aot_v1_mop_code("tests/programs/mop_random_adc_sbb");
         let mut machine_aot =
             machine_build::aot_v1_mop("tests/programs/mop_random_adc_sbb", vec![], &code);
@@ -274,7 +298,10 @@ pub fn test_mop_ld_signextend_32_overflow_bug() {
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
+    }
 
+    #[cfg(has_aot)]
+    {
         let code =
             machine_build::aot_v1_mop_code("tests/programs/mop_ld_signextend_32_overflow_bug");
         let mut machine_aot = machine_build::aot_v1_mop(
@@ -301,7 +328,10 @@ pub fn test_mop_wide_mul_zero() {
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
+    }
 
+    #[cfg(has_aot)]
+    {
         let code = machine_build::aot_v1_mop_code("tests/programs/mop_wide_mul_zero");
         let mut machine_aot =
             machine_build::aot_v1_mop("tests/programs/mop_wide_mul_zero", vec![], &code);
@@ -324,7 +354,10 @@ pub fn test_mop_wide_div_zero() {
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
+    }
 
+    #[cfg(has_aot)]
+    {
         let code = machine_build::aot_v1_mop_code("tests/programs/mop_wide_div_zero");
         let mut machine_aot =
             machine_build::aot_v1_mop("tests/programs/mop_wide_div_zero", vec![], &code);

--- a/tests/test_reset.rs
+++ b/tests/test_reset.rs
@@ -1,5 +1,5 @@
 use bytes::Bytes;
-#[cfg(has_asm)]
+#[cfg(has_aot)]
 use ckb_vm::machine::aot::AotCompilingMachine;
 #[cfg(has_asm)]
 use ckb_vm::machine::asm::{AsmCoreMachine, AsmMachine};
@@ -107,7 +107,7 @@ fn test_reset_asm() {
 }
 
 #[test]
-#[cfg(has_asm)]
+#[cfg(has_aot)]
 pub fn test_reset_aot() {
     let code_data = std::fs::read("tests/programs/reset_caller").unwrap();
     let code = Bytes::from(code_data);

--- a/tests/test_resume.rs
+++ b/tests/test_resume.rs
@@ -1,9 +1,11 @@
 #![cfg(has_asm)]
 
+#[cfg(has_aot)]
+use ckb_vm::machine::{aot::AotCompilingMachine, asm::AotCode};
+
 use bytes::Bytes;
 use ckb_vm::{
     machine::{
-        aot::{AotCode, AotCompilingMachine},
         asm::{AsmCoreMachine, AsmMachine},
         trace::TraceMachine,
         DefaultCoreMachine, DefaultMachine, SupportMachine, VERSION0, VERSION1,
@@ -22,9 +24,17 @@ fn test_resume_interpreter_with_trace_2_asm() {
 }
 
 #[test]
+#[cfg(has_aot)]
 fn test_resume_aot_2_asm() {
     resume_aot_2_asm(VERSION1, 8126917);
     resume_aot_2_asm(VERSION0, 8126917);
+}
+
+#[test]
+#[cfg(has_aot)]
+fn test_resume_asm_2_aot() {
+    resume_asm_2_aot(VERSION1, 8126917);
+    resume_asm_2_aot(VERSION0, 8126917);
 }
 
 #[test]
@@ -65,7 +75,7 @@ pub fn resume_asm_2_asm(version: u32, except_cycles: u64) {
     let buffer = load_program();
 
     // The cycles required for complete execution is 4194622
-    let mut machine1 = MachineTy::Asm.build(version, except_cycles - 30, None);
+    let mut machine1 = MachineTy::Asm.build(version, except_cycles - 30);
     machine1
         .load_program(&buffer, &vec!["alloc_many".into()])
         .unwrap();
@@ -75,7 +85,7 @@ pub fn resume_asm_2_asm(version: u32, except_cycles: u64) {
     assert_eq!(result1.unwrap_err(), Error::InvalidCycles);
     let snapshot = machine1.snapshot().unwrap();
 
-    let mut machine2 = MachineTy::Asm.build(version, 40, None);
+    let mut machine2 = MachineTy::Asm.build(version, 40);
     machine2.resume(&snapshot).unwrap();
     let result2 = machine2.run();
     let cycles2 = machine2.cycles();
@@ -87,7 +97,7 @@ pub fn resume_asm_2_asm(version: u32, except_cycles: u64) {
 pub fn resume_asm_2_asm_2_asm(version: u32, except_cycles: u64) {
     let buffer = load_program();
 
-    let mut machine1 = MachineTy::Asm.build(version, 1000000, None);
+    let mut machine1 = MachineTy::Asm.build(version, 1000000);
     machine1
         .load_program(&buffer, &vec!["alloc_many".into()])
         .unwrap();
@@ -97,7 +107,7 @@ pub fn resume_asm_2_asm_2_asm(version: u32, except_cycles: u64) {
     assert_eq!(result1.unwrap_err(), Error::InvalidCycles);
     let snapshot1 = machine1.snapshot().unwrap();
 
-    let mut machine2 = MachineTy::Asm.build(version, 4000000, None);
+    let mut machine2 = MachineTy::Asm.build(version, 4000000);
     machine2.resume(&snapshot1).unwrap();
     let result2 = machine2.run();
     let cycles2 = machine2.cycles();
@@ -105,7 +115,7 @@ pub fn resume_asm_2_asm_2_asm(version: u32, except_cycles: u64) {
     assert_eq!(result2.unwrap_err(), Error::InvalidCycles);
     let snapshot2 = machine2.snapshot().unwrap();
 
-    let mut machine3 = MachineTy::Asm.build(version, 4000000, None);
+    let mut machine3 = MachineTy::Asm.build(version, 4000000);
     machine3.resume(&snapshot2).unwrap();
     let result3 = machine3.run();
     let cycles3 = machine3.cycles();
@@ -117,7 +127,7 @@ pub fn resume_asm_2_asm_2_asm(version: u32, except_cycles: u64) {
 pub fn resume_asm_2_interpreter(version: u32, except_cycles: u64) {
     let buffer = load_program();
 
-    let mut machine1 = MachineTy::Asm.build(version, except_cycles - 30, None);
+    let mut machine1 = MachineTy::Asm.build(version, except_cycles - 30);
     machine1
         .load_program(&buffer, &vec!["alloc_many".into()])
         .unwrap();
@@ -127,7 +137,7 @@ pub fn resume_asm_2_interpreter(version: u32, except_cycles: u64) {
     assert_eq!(result1.unwrap_err(), Error::InvalidCycles);
     let snapshot = machine1.snapshot().unwrap();
 
-    let mut machine2 = MachineTy::Interpreter.build(version, 40, None);
+    let mut machine2 = MachineTy::Interpreter.build(version, 40);
     machine2.resume(&snapshot).unwrap();
 
     let result2 = machine2.run();
@@ -140,7 +150,7 @@ pub fn resume_asm_2_interpreter(version: u32, except_cycles: u64) {
 pub fn resume_interpreter_2_interpreter(version: u32, except_cycles: u64) {
     let buffer = load_program();
 
-    let mut machine1 = MachineTy::Interpreter.build(version, except_cycles - 30, None);
+    let mut machine1 = MachineTy::Interpreter.build(version, except_cycles - 30);
     machine1
         .load_program(&buffer, &vec!["alloc_many".into()])
         .unwrap();
@@ -150,7 +160,7 @@ pub fn resume_interpreter_2_interpreter(version: u32, except_cycles: u64) {
     assert_eq!(result1.unwrap_err(), Error::InvalidCycles);
     let snapshot = machine1.snapshot().unwrap();
 
-    let mut machine2 = MachineTy::Interpreter.build(version, 30, None);
+    let mut machine2 = MachineTy::Interpreter.build(version, 30);
     machine2.resume(&snapshot).unwrap();
     let result2 = machine2.run();
     let cycles2 = machine2.cycles();
@@ -162,7 +172,7 @@ pub fn resume_interpreter_2_interpreter(version: u32, except_cycles: u64) {
 pub fn resume_interpreter_2_asm(version: u32, except_cycles: u64) {
     let buffer = load_program();
 
-    let mut machine1 = MachineTy::Interpreter.build(version, except_cycles - 30, None);
+    let mut machine1 = MachineTy::Interpreter.build(version, except_cycles - 30);
     machine1
         .load_program(&buffer, &vec!["alloc_many".into()])
         .unwrap();
@@ -172,7 +182,7 @@ pub fn resume_interpreter_2_asm(version: u32, except_cycles: u64) {
     assert_eq!(result1.unwrap_err(), Error::InvalidCycles);
     let snapshot = machine1.snapshot().unwrap();
 
-    let mut machine2 = MachineTy::Asm.build(version, 30, None);
+    let mut machine2 = MachineTy::Asm.build(version, 30);
     machine2.resume(&snapshot).unwrap();
     let result2 = machine2.run();
     let cycles2 = machine2.cycles();
@@ -181,6 +191,7 @@ pub fn resume_interpreter_2_asm(version: u32, except_cycles: u64) {
     assert_eq!(cycles1 + cycles2, except_cycles);
 }
 
+#[cfg(has_aot)]
 pub fn resume_aot_2_asm(version: u32, except_cycles: u64) {
     let buffer = load_program();
 
@@ -188,7 +199,7 @@ pub fn resume_aot_2_asm(version: u32, except_cycles: u64) {
         AotCompilingMachine::load(&buffer, Some(Box::new(dummy_cycle_func)), ISA_IMC, VERSION1)
             .unwrap();
     let code = aot_machine.compile().unwrap();
-    let mut machine1 = MachineTy::Aot.build(version, except_cycles - 30, Some(&code));
+    let mut machine1 = AotMachine::build(version, except_cycles - 30, Some(&code));
     machine1
         .load_program(&buffer, &vec!["alloc_many".into()])
         .unwrap();
@@ -198,7 +209,34 @@ pub fn resume_aot_2_asm(version: u32, except_cycles: u64) {
     assert_eq!(result1.unwrap_err(), Error::InvalidCycles);
     let snapshot = machine1.snapshot().unwrap();
 
-    let mut machine2 = MachineTy::Asm.build(version, 40, None);
+    let mut machine2 = MachineTy::Asm.build(version, 40);
+    machine2.resume(&snapshot).unwrap();
+    let result2 = machine2.run();
+    let cycles2 = machine2.cycles();
+    assert!(result2.is_ok());
+    assert_eq!(result2.unwrap(), 0);
+    assert_eq!(cycles1 + cycles2, except_cycles);
+}
+
+#[cfg(has_aot)]
+pub fn resume_asm_2_aot(version: u32, except_cycles: u64) {
+    let buffer = load_program();
+
+    let mut machine1 = MachineTy::Asm.build(version, except_cycles - 30);
+    machine1
+        .load_program(&buffer, &vec!["alloc_many".into()])
+        .unwrap();
+    let result1 = machine1.run();
+    let cycles1 = machine1.cycles();
+    assert!(result1.is_err());
+    assert_eq!(result1.unwrap_err(), Error::InvalidCycles);
+    let snapshot = machine1.snapshot().unwrap();
+
+    let mut aot_machine =
+        AotCompilingMachine::load(&buffer, Some(Box::new(dummy_cycle_func)), ISA_IMC, VERSION1)
+            .unwrap();
+    let code = aot_machine.compile().unwrap();
+    let mut machine2 = AotMachine::build(version, 40, Some(&code));
     machine2.resume(&snapshot).unwrap();
     let result2 = machine2.run();
     let cycles2 = machine2.cycles();
@@ -210,7 +248,7 @@ pub fn resume_aot_2_asm(version: u32, except_cycles: u64) {
 pub fn resume_interpreter_with_trace_2_asm_inner(version: u32, except_cycles: u64) {
     let buffer = load_program();
 
-    let mut machine1 = MachineTy::InterpreterWithTrace.build(version, except_cycles - 30, None);
+    let mut machine1 = MachineTy::InterpreterWithTrace.build(version, except_cycles - 30);
     machine1
         .load_program(&buffer, &vec!["alloc_many".into()])
         .unwrap();
@@ -220,7 +258,7 @@ pub fn resume_interpreter_with_trace_2_asm_inner(version: u32, except_cycles: u6
     assert_eq!(result1.unwrap_err(), Error::InvalidCycles);
     let snapshot = machine1.snapshot().unwrap();
 
-    let mut machine2 = MachineTy::Asm.build(version, 30, None);
+    let mut machine2 = MachineTy::Asm.build(version, 30);
     machine2.resume(&snapshot).unwrap();
     let result2 = machine2.run();
     let cycles2 = machine2.cycles();
@@ -238,13 +276,12 @@ fn load_program() -> Bytes {
 
 enum MachineTy {
     Asm,
-    Aot,
     Interpreter,
     InterpreterWithTrace,
 }
 
 impl MachineTy {
-    fn build<'a>(self, version: u32, max_cycles: u64, program: Option<&'a AotCode>) -> Machine<'a> {
+    fn build<'a>(self, version: u32, max_cycles: u64) -> Machine {
         match self {
             MachineTy::Asm => {
                 let asm_core1 = AsmCoreMachine::new(ISA_IMC, version, max_cycles);
@@ -252,13 +289,6 @@ impl MachineTy {
                     .instruction_cycle_func(Box::new(dummy_cycle_func))
                     .build();
                 Machine::Asm(AsmMachine::new(core1, None))
-            }
-            MachineTy::Aot => {
-                let asm_core1 = AsmCoreMachine::new(ISA_IMC, version, max_cycles);
-                let core1 = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core1)
-                    .instruction_cycle_func(Box::new(dummy_cycle_func))
-                    .build();
-                Machine::Aot(AsmMachine::new(core1, program))
             }
             MachineTy::Interpreter => {
                 let core_machine1 = DefaultCoreMachine::<u64, WXorXMemory<SparseMemory<u64>>>::new(
@@ -290,21 +320,20 @@ impl MachineTy {
     }
 }
 
-enum Machine<'a> {
+enum Machine {
     Asm(AsmMachine<'static>),
-    Aot(AsmMachine<'a>),
     Interpreter(DefaultMachine<'static, DefaultCoreMachine<u64, WXorXMemory<SparseMemory<u64>>>>),
     InterpreterWithTrace(
         TraceMachine<'static, DefaultCoreMachine<u64, WXorXMemory<SparseMemory<u64>>>>,
     ),
 }
 
-impl<'a> Machine<'a> {
+impl Machine {
     fn load_program(&mut self, program: &Bytes, args: &[Bytes]) -> Result<u64, Error> {
         use Machine::*;
         match self {
             Asm(inner) => inner.load_program(program, args),
-            Aot(inner) => inner.load_program(program, args),
+            // Aot(inner) => inner.load_program(program, args),
             Interpreter(inner) => inner.load_program(program, args),
             InterpreterWithTrace(inner) => inner.load_program(program, args),
         }
@@ -314,7 +343,7 @@ impl<'a> Machine<'a> {
         use Machine::*;
         match self {
             Asm(inner) => inner.run(),
-            Aot(inner) => inner.run(),
+            // Aot(inner) => inner.run(),
             Interpreter(inner) => inner.run(),
             InterpreterWithTrace(inner) => inner.run(),
         }
@@ -324,7 +353,7 @@ impl<'a> Machine<'a> {
         use Machine::*;
         match self {
             Asm(inner) => inner.machine.cycles(),
-            Aot(inner) => inner.machine.cycles(),
+            // Aot(inner) => inner.machine.cycles(),
             Interpreter(inner) => inner.cycles(),
             InterpreterWithTrace(inner) => inner.machine.cycles(),
         }
@@ -334,7 +363,7 @@ impl<'a> Machine<'a> {
         use Machine::*;
         match self {
             Asm(inner) => make_snapshot(&mut inner.machine),
-            Aot(inner) => make_snapshot(&mut inner.machine),
+            // Aot(inner) => make_snapshot(&mut inner.machine),
             Interpreter(inner) => make_snapshot(inner),
             InterpreterWithTrace(inner) => make_snapshot(&mut inner.machine),
         }
@@ -344,9 +373,43 @@ impl<'a> Machine<'a> {
         use Machine::*;
         match self {
             Asm(inner) => resume(&mut inner.machine, snap),
-            Aot(inner) => resume(&mut inner.machine, snap),
+            // Aot(inner) => resume(&mut inner.machine, snap),
             Interpreter(inner) => resume(inner, snap),
             InterpreterWithTrace(inner) => resume(&mut inner.machine, snap),
         }
+    }
+}
+
+#[cfg(has_aot)]
+struct AotMachine<'a>(AsmMachine<'a>);
+
+#[cfg(has_aot)]
+impl<'a> AotMachine<'a> {
+    fn build(version: u32, max_cycles: u64, program: Option<&'a AotCode>) -> AotMachine<'a> {
+        let asm_core1 = AsmCoreMachine::new(ISA_IMC, version, max_cycles);
+        let core1 = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core1)
+            .instruction_cycle_func(Box::new(dummy_cycle_func))
+            .build();
+        AotMachine(AsmMachine::new(core1, program))
+    }
+
+    fn load_program(&mut self, program: &Bytes, args: &[Bytes]) -> Result<u64, Error> {
+        self.0.load_program(program, args)
+    }
+
+    fn run(&mut self) -> Result<i8, Error> {
+        self.0.run()
+    }
+
+    fn cycles(&self) -> u64 {
+        self.0.machine.cycles()
+    }
+
+    fn snapshot(&mut self) -> Result<Snapshot, Error> {
+        make_snapshot(&mut self.0.machine)
+    }
+
+    fn resume(&mut self, snap: &Snapshot) -> Result<(), Error> {
+        resume(&mut self.0.machine, snap)
     }
 }

--- a/tests/test_versions.rs
+++ b/tests/test_versions.rs
@@ -1,8 +1,10 @@
 #![cfg(has_asm)]
 
+#[cfg(has_aot)]
+use ckb_vm::machine::{aot::AotCompilingMachine, asm::AotCode};
+
 use ckb_vm::{
     machine::{
-        aot::{AotCode, AotCompilingMachine},
         asm::{AsmCoreMachine, AsmMachine},
         VERSION0, VERSION1,
     },
@@ -41,6 +43,7 @@ fn create_asm_machine<'a>(program: String, version: u32) -> AsmMachine<'a> {
     machine
 }
 
+#[cfg(has_aot)]
 fn compile_aot_code(program: String, version: u32) -> AotCode {
     let path = format!("tests/programs/{}", program);
     let buffer = fs::read(path).unwrap().into();
@@ -48,6 +51,7 @@ fn compile_aot_code(program: String, version: u32) -> AotCode {
     aot_machine.compile().unwrap()
 }
 
+#[cfg(has_aot)]
 fn create_aot_machine<'a>(program: String, code: &'a AotCode, version: u32) -> AsmMachine<'a> {
     let path = format!("tests/programs/{}", program);
     let buffer = fs::read(path).unwrap().into();
@@ -253,6 +257,7 @@ pub fn test_asm_version1_write_at_boundary() {
 }
 
 #[test]
+#[cfg(has_aot)]
 pub fn test_aot_version0_argv_null() {
     let code = compile_aot_code("argv_null_test".to_string(), VERSION0);
     let mut machine = create_aot_machine("argv_null_test".to_string(), &code, VERSION0);
@@ -262,6 +267,7 @@ pub fn test_aot_version0_argv_null() {
 }
 
 #[test]
+#[cfg(has_aot)]
 pub fn test_aot_version0_sp_alignment() {
     let code = compile_aot_code("sp_alignment_test".to_string(), VERSION0);
     let mut machine = create_aot_machine("sp_alignment_test".to_string(), &code, VERSION0);
@@ -271,6 +277,7 @@ pub fn test_aot_version0_sp_alignment() {
 }
 
 #[test]
+#[cfg(has_aot)]
 pub fn test_aot_version0_jalr_bug() {
     let code = compile_aot_code("jalr_bug".to_string(), VERSION0);
     let mut machine = create_aot_machine("jalr_bug".to_string(), &code, VERSION0);
@@ -280,6 +287,7 @@ pub fn test_aot_version0_jalr_bug() {
 }
 
 #[test]
+#[cfg(has_aot)]
 pub fn test_aot_version0_jalr_bug_noc() {
     let code = compile_aot_code("jalr_bug_noc".to_string(), VERSION0);
     let mut machine = create_aot_machine("jalr_bug_noc".to_string(), &code, VERSION0);
@@ -289,6 +297,7 @@ pub fn test_aot_version0_jalr_bug_noc() {
 }
 
 #[test]
+#[cfg(has_aot)]
 pub fn test_aot_version0_read_at_boundary() {
     let code = compile_aot_code("read_at_boundary64".to_string(), VERSION0);
     let mut machine = create_aot_machine("read_at_boundary64".to_string(), &code, VERSION0);
@@ -298,6 +307,7 @@ pub fn test_aot_version0_read_at_boundary() {
 }
 
 #[test]
+#[cfg(has_aot)]
 pub fn test_aot_version0_write_at_boundary() {
     let code = compile_aot_code("write_at_boundary64".to_string(), VERSION0);
     let mut machine = create_aot_machine("write_at_boundary64".to_string(), &code, VERSION0);
@@ -307,6 +317,7 @@ pub fn test_aot_version0_write_at_boundary() {
 }
 
 #[test]
+#[cfg(has_aot)]
 pub fn test_aot_version1_argv_null() {
     let code = compile_aot_code("argv_null_test".to_string(), VERSION1);
     let mut machine = create_aot_machine("argv_null_test".to_string(), &code, VERSION1);
@@ -316,6 +327,7 @@ pub fn test_aot_version1_argv_null() {
 }
 
 #[test]
+#[cfg(has_aot)]
 pub fn test_aot_version1_sp_alignment() {
     let code = compile_aot_code("sp_alignment_test".to_string(), VERSION1);
     let mut machine = create_aot_machine("sp_alignment_test".to_string(), &code, VERSION1);
@@ -325,6 +337,7 @@ pub fn test_aot_version1_sp_alignment() {
 }
 
 #[test]
+#[cfg(has_aot)]
 pub fn test_aot_version1_jalr_bug() {
     let code = compile_aot_code("jalr_bug".to_string(), VERSION1);
     let mut machine = create_aot_machine("jalr_bug".to_string(), &code, VERSION1);
@@ -334,6 +347,7 @@ pub fn test_aot_version1_jalr_bug() {
 }
 
 #[test]
+#[cfg(has_aot)]
 pub fn test_aot_version1_jalr_bug_noc() {
     let code = compile_aot_code("jalr_bug_noc".to_string(), VERSION1);
     let mut machine = create_aot_machine("jalr_bug_noc".to_string(), &code, VERSION1);
@@ -343,6 +357,7 @@ pub fn test_aot_version1_jalr_bug_noc() {
 }
 
 #[test]
+#[cfg(has_aot)]
 pub fn test_aot_version1_read_at_boundary() {
     let code = compile_aot_code("read_at_boundary64".to_string(), VERSION1);
     let mut machine = create_aot_machine("read_at_boundary64".to_string(), &code, VERSION1);
@@ -352,6 +367,7 @@ pub fn test_aot_version1_read_at_boundary() {
 }
 
 #[test]
+#[cfg(has_aot)]
 pub fn test_aot_version1_write_at_boundary() {
     let code = compile_aot_code("write_at_boundary64".to_string(), VERSION1);
     let mut machine = create_aot_machine("write_at_boundary64".to_string(), &code, VERSION1);
@@ -405,6 +421,7 @@ pub fn test_asm_version1_unaligned64() {
 }
 
 #[test]
+#[cfg(has_aot)]
 pub fn test_aot_version0_unaligned64() {
     let program = "unaligned64";
     let code = compile_aot_code(program.to_string(), VERSION1);
@@ -420,6 +437,7 @@ pub fn test_aot_version0_unaligned64() {
 }
 
 #[test]
+#[cfg(has_aot)]
 pub fn test_aot_version1_unaligned64() {
     let code = compile_aot_code("unaligned64".to_string(), VERSION1);
     let mut machine = create_aot_machine("unaligned64".to_string(), &code, VERSION1);


### PR DESCRIPTION
This PR splits AOT mode into its own feature. As a result, we can work on asm vs aot features individually for new architectures.

The CI pipeline is also cleaned up a bit:

* On Linux we are running CIs for every single configuration
* On Windows and Mac, we are only running CIs for the most complete configurations