### PR TITLE
Refactor Error

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -88,7 +88,7 @@ impl Decoder {
     pub fn decode_raw<M: Memory>(&mut self, memory: &mut M, pc: u64) -> Result<Instruction, Error> {
         // since we are using RISCV_MAX_MEMORY as the default key in the instruction cache, have to check out of bound error first
         if pc as usize >= RISCV_MAX_MEMORY {
-            return Err(Error::OutOfBound);
+            return Err(Error::MemOutOfBound);
         }
         // according to RISC-V instruction encoding, the lowest bit in PC will always be zero
         let instruction_cache_key = (pc >> 1) as usize % INSTRUCTION_CACHE_SIZE;

--- a/src/error.rs
+++ b/src/error.rs
@@ -64,7 +64,7 @@ pub enum Error {
     #[display(fmt = "memory error: write on freezed page")]
     MemWriteOnFreezedPage,
     #[display(fmt = "unexpected error")]
-    Unexpected,
+    Unexpected(String),
     #[display(fmt = "unimplemented")]
     Unimplemented,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,10 @@ pub enum Error {
     Asm(u8),
     #[display(fmt = "elf error: {}", "_0")]
     ElfParseError(String),
+    #[display(fmt = "elf error: segments is unreadable")]
+    ElfSegmentUnreadable,
+    #[display(fmt = "elf error: segments is writable and executable")]
+    ElfSegmentWritableAndExecutable,
     #[display(fmt = "I/O error: {:?}", "_0")]
     IO(std::io::ErrorKind),
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,10 @@ pub enum Error {
     ElfSegmentUnreadable,
     #[display(fmt = "elf error: segments is writable and executable")]
     ElfSegmentWritableAndExecutable,
+    // Unknown error type is for the debugging tool of CKB-VM, it should not be
+    // used in this project.
+    #[display(fmt = "external error: {}", "_0")]
+    External(String),
     #[display(fmt = "invalid syscall {}", "_0")]
     InvalidEcall(u64),
     #[display(
@@ -30,27 +34,23 @@ pub enum Error {
         "instruction"
     )]
     InvalidInstruction { pc: u64, instruction: u32 },
+    #[display(fmt = "invalid operand {}", "_0")]
+    InvalidOp(u16),
+    #[display(fmt = "invalid version")]
+    InvalidVersion,
     #[display(fmt = "I/O error: {:?}", "_0")]
     IO(std::io::ErrorKind),
     #[display(fmt = "memory error: unaligned page access")]
     MemPageUnalignedAccess,
-
-    #[display(fmt = "out of bound access")]
-    OutOfBound,
-    #[display(fmt = "invalid operand {}", "_0")]
-    InvalidOp(u16),
-    #[display(fmt = "invalid permission")] // FIXME: Distinguish which permission
-    InvalidPermission,
-    #[display(fmt = "invalid version")]
-    InvalidVersion,
     #[display(fmt = "unexpected error")]
     Unexpected,
     #[display(fmt = "unimplemented")]
     Unimplemented,
-    // Unknown error type is for the debugging tool of CKB-VM, it should not be
-    // used in this project.
-    #[display(fmt = "external error: {}", "_0")]
-    External(String),
+
+    #[display(fmt = "out of bound access")]
+    OutOfBound,
+    #[display(fmt = "invalid permission")] // FIXME: Distinguish which permission
+    InvalidPermission,
 }
 
 impl std::error::Error for Error {}

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,7 +32,7 @@ pub enum Error {
     ElfSegmentWritableAndExecutable,
     #[display(fmt = "elf error: segment addr or size is wrong")]
     ElfSegmentAddrOrSizeError,
-    // Unknown error type is for the debugging tool of CKB-VM, it should not be
+    // External error type is for the debugging tool of CKB-VM, it should not be
     // used in this project.
     #[display(fmt = "external error: {}", "_0")]
     External(String),
@@ -48,8 +48,11 @@ pub enum Error {
     InvalidOp(u16),
     #[display(fmt = "invalid version")]
     InvalidVersion,
-    #[display(fmt = "I/O error: {:?}", "_0")]
-    IO(std::io::ErrorKind),
+    #[display(fmt = "I/O error: {:?} {}", "kind", "data")]
+    IO {
+        kind: std::io::ErrorKind,
+        data: String,
+    },
     #[display(fmt = "memory error: out of bound")]
     MemOutOfBound,
     #[display(fmt = "memory error: out of stack")]
@@ -70,7 +73,10 @@ impl std::error::Error for Error {}
 
 impl From<std::io::Error> for Error {
     fn from(error: std::io::Error) -> Self {
-        Error::IO(error.kind())
+        Error::IO {
+            kind: error.kind(),
+            data: error.to_string(),
+        }
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,12 +14,16 @@ pub enum Error {
     CyclesExceeded,
     #[display(fmt = "cycles error: overflow")]
     CyclesOverflow,
+    #[display(fmt = "elf error: bits")]
+    ElfBits,
     #[display(fmt = "elf error: {}", "_0")]
     ElfParseError(String),
     #[display(fmt = "elf error: segments is unreadable")]
     ElfSegmentUnreadable,
     #[display(fmt = "elf error: segments is writable and executable")]
     ElfSegmentWritableAndExecutable,
+    #[display(fmt = "invalid syscall {}", "_0")]
+    InvalidEcall(u64),
     #[display(
         fmt = "invalid instruction pc=0x{:x} instruction=0x{:x}",
         "pc",
@@ -33,10 +37,6 @@ pub enum Error {
     Unaligned,
     #[display(fmt = "out of bound access")]
     OutOfBound,
-    #[display(fmt = "invalid syscall {}", "_0")]
-    InvalidEcall(u64),
-    #[display(fmt = "invalid elf")]
-    InvalidElfBits,
     #[display(fmt = "invalid operand {}", "_0")]
     InvalidOp(u16),
     #[display(fmt = "invalid permission")] // FIXME: Distinguish which permission

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,12 +10,22 @@ pub enum Error {
     AotLimitReachedMaximumSections,
     #[display(fmt = "asm error: {}", "_0")]
     Asm(u8),
+    #[display(fmt = "cycles error: max cycles exceeded")]
+    CyclesExceeded,
+    #[display(fmt = "cycles error: overflow")]
+    CyclesOverflow,
     #[display(fmt = "elf error: {}", "_0")]
     ElfParseError(String),
     #[display(fmt = "elf error: segments is unreadable")]
     ElfSegmentUnreadable,
     #[display(fmt = "elf error: segments is writable and executable")]
     ElfSegmentWritableAndExecutable,
+    #[display(
+        fmt = "invalid instruction pc=0x{:x} instruction=0x{:x}",
+        "pc",
+        "instruction"
+    )]
+    InvalidInstruction { pc: u64, instruction: u32 },
     #[display(fmt = "I/O error: {:?}", "_0")]
     IO(std::io::ErrorKind),
 
@@ -23,16 +33,6 @@ pub enum Error {
     Unaligned,
     #[display(fmt = "out of bound access")]
     OutOfBound,
-    #[display(fmt = "max cycles exceeded")]
-    InvalidCycles,
-    #[display(fmt = "cycles overflow")]
-    CyclesOverflow,
-    #[display(
-        fmt = "invalid instruction pc=0x{:x} instruction=0x{:x}",
-        "pc",
-        "instruction"
-    )]
-    InvalidInstruction { pc: u64, instruction: u32 },
     #[display(fmt = "invalid syscall {}", "_0")]
     InvalidEcall(u64),
     #[display(fmt = "invalid elf")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,3 @@
-use std::error::Error as StdError;
-use std::io::{Error as IOError, ErrorKind};
-
 #[derive(Debug, PartialEq, Clone, Eq, Display)]
 pub enum Error {
     #[display(fmt = "aot error: dynasm ret {}", "_0")]
@@ -11,11 +8,13 @@ pub enum Error {
     AotLimitReachedMaximumLabels,
     #[display(fmt = "aot error: limit reached maximum sections")]
     AotLimitReachedMaximumSections,
-    #[display(fmt = "asm error {}", "_0")]
+    #[display(fmt = "asm error: {}", "_0")]
     Asm(u8),
+    #[display(fmt = "elf error: {}", "_0")]
+    ElfParseError(String),
+    #[display(fmt = "I/O error: {:?}", "_0")]
+    IO(std::io::ErrorKind),
 
-    #[display(fmt = "parse error")]
-    ParseError,
     #[display(fmt = "unaligned page access")]
     Unaligned,
     #[display(fmt = "out of bound access")]
@@ -36,8 +35,6 @@ pub enum Error {
     InvalidElfBits,
     #[display(fmt = "invalid operand {}", "_0")]
     InvalidOp(u16),
-    #[display(fmt = "I/O error: {:?}", "_0")]
-    IO(ErrorKind),
     #[display(fmt = "invalid permission")] // FIXME: Distinguish which permission
     InvalidPermission,
     #[display(fmt = "invalid version")]
@@ -52,10 +49,22 @@ pub enum Error {
     External(String),
 }
 
-impl StdError for Error {}
+impl std::error::Error for Error {}
 
-impl From<IOError> for Error {
-    fn from(error: IOError) -> Self {
+impl From<std::io::Error> for Error {
+    fn from(error: std::io::Error) -> Self {
         Error::IO(error.kind())
+    }
+}
+
+impl From<goblin_v023::error::Error> for Error {
+    fn from(error: goblin_v023::error::Error) -> Self {
+        Error::ElfParseError(error.to_string())
+    }
+}
+
+impl From<goblin_v040::error::Error> for Error {
+    fn from(error: goblin_v040::error::Error) -> Self {
+        Error::ElfParseError(error.to_string())
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,6 +42,10 @@ pub enum Error {
     IO(std::io::ErrorKind),
     #[display(fmt = "memory error: unaligned page access")]
     MemPageUnalignedAccess,
+    #[display(fmt = "memory error: write on executable page")]
+    MemWriteOnExecutablePage,
+    #[display(fmt = "memory error: write on freezed page")]
+    MemWriteOnFreezedPage,
     #[display(fmt = "unexpected error")]
     Unexpected,
     #[display(fmt = "unimplemented")]
@@ -49,8 +53,6 @@ pub enum Error {
 
     #[display(fmt = "out of bound access")]
     OutOfBound,
-    #[display(fmt = "invalid permission")] // FIXME: Distinguish which permission
-    InvalidPermission,
 }
 
 impl std::error::Error for Error {}

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,17 @@ use std::io::{Error as IOError, ErrorKind};
 
 #[derive(Debug, PartialEq, Clone, Eq, Display)]
 pub enum Error {
+    #[display(fmt = "aot error: dynasm ret {}", "_0")]
+    AotDynasm(i32),
+    #[display(fmt = "aot error: limit reached maximum dummy sections")]
+    AotLimitReachedMaximumDummySections,
+    #[display(fmt = "aot error: limit reached maximum labels")]
+    AotLimitReachedMaximumLabels,
+    #[display(fmt = "aot error: limit reached maximum sections")]
+    AotLimitReachedMaximumSections,
+    #[display(fmt = "asm error {}", "_0")]
+    Asm(u8),
+
     #[display(fmt = "parse error")]
     ParseError,
     #[display(fmt = "unaligned page access")]
@@ -27,12 +38,6 @@ pub enum Error {
     InvalidOp(u16),
     #[display(fmt = "I/O error: {:?}", "_0")]
     IO(ErrorKind),
-    #[display(fmt = "dynasm error {}", "_0")]
-    Dynasm(i32),
-    #[display(fmt = "assembly error {}", "_0")]
-    Asm(u8),
-    #[display(fmt = "limit reached")] // FIXME: Distinguish which limit
-    LimitReached,
     #[display(fmt = "invalid permission")] // FIXME: Distinguish which permission
     InvalidPermission,
     #[display(fmt = "invalid version")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,9 +32,9 @@ pub enum Error {
     InvalidInstruction { pc: u64, instruction: u32 },
     #[display(fmt = "I/O error: {:?}", "_0")]
     IO(std::io::ErrorKind),
+    #[display(fmt = "memory error: unaligned page access")]
+    MemPageUnalignedAccess,
 
-    #[display(fmt = "unaligned page access")]
-    Unaligned,
     #[display(fmt = "out of bound access")]
     OutOfBound,
     #[display(fmt = "invalid operand {}", "_0")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,12 +2,20 @@
 pub enum Error {
     #[display(fmt = "aot error: dynasm ret {}", "_0")]
     AotDynasm(i32),
+    #[display(fmt = "aot error: section is empty")]
+    AotSectionIsEmpty,
+    #[display(fmt = "aot error: section overlaps with another")]
+    AotSectionOverlaps,
     #[display(fmt = "aot error: limit reached maximum dummy sections")]
     AotLimitReachedMaximumDummySections,
     #[display(fmt = "aot error: limit reached maximum labels")]
     AotLimitReachedMaximumLabels,
     #[display(fmt = "aot error: limit reached maximum sections")]
     AotLimitReachedMaximumSections,
+    #[display(fmt = "aot error: limit reached maximum temp register")]
+    AotLimitReachedMaximumTempRegisters,
+    #[display(fmt = "aot error: out of bound due to not start of basic block")]
+    AotOutOfBoundDueToNotStartOfBasicBlock,
     #[display(fmt = "asm error: {}", "_0")]
     Asm(u8),
     #[display(fmt = "cycles error: max cycles exceeded")]
@@ -18,10 +26,12 @@ pub enum Error {
     ElfBits,
     #[display(fmt = "elf error: {}", "_0")]
     ElfParseError(String),
-    #[display(fmt = "elf error: segments is unreadable")]
+    #[display(fmt = "elf error: segment is unreadable")]
     ElfSegmentUnreadable,
-    #[display(fmt = "elf error: segments is writable and executable")]
+    #[display(fmt = "elf error: segment is writable and executable")]
     ElfSegmentWritableAndExecutable,
+    #[display(fmt = "elf error: segment addr or size is wrong")]
+    ElfSegmentAddrOrSizeError,
     // Unknown error type is for the debugging tool of CKB-VM, it should not be
     // used in this project.
     #[display(fmt = "external error: {}", "_0")]
@@ -40,6 +50,10 @@ pub enum Error {
     InvalidVersion,
     #[display(fmt = "I/O error: {:?}", "_0")]
     IO(std::io::ErrorKind),
+    #[display(fmt = "memory error: out of bound")]
+    MemOutOfBound,
+    #[display(fmt = "memory error: out of stack")]
+    MemOutOfStack,
     #[display(fmt = "memory error: unaligned page access")]
     MemPageUnalignedAccess,
     #[display(fmt = "memory error: write on executable page")]
@@ -50,9 +64,6 @@ pub enum Error {
     Unexpected,
     #[display(fmt = "unimplemented")]
     Unimplemented,
-
-    #[display(fmt = "out of bound access")]
-    OutOfBound,
 }
 
 impl std::error::Error for Error {}

--- a/src/instructions/common.rs
+++ b/src/instructions/common.rs
@@ -84,9 +84,9 @@ pub fn addiw<Mac: Machine>(
 fn check_load_boundary<R: Register>(version0: bool, address: &R, bytes: u64) -> Result<(), Error> {
     if version0 {
         let address = address.to_u64();
-        let end = address.checked_add(bytes).ok_or(Error::OutOfBound)?;
+        let end = address.checked_add(bytes).ok_or(Error::MemOutOfBound)?;
         if end == RISCV_MAX_MEMORY as u64 {
-            return Err(Error::OutOfBound);
+            return Err(Error::MemOutOfBound);
         }
     }
     Ok(())

--- a/src/machine/aot/emitter.rs
+++ b/src/machine/aot/emitter.rs
@@ -142,7 +142,7 @@ fn check_aot_result(result: c_int) -> Result<(), Error> {
     if result == 0 {
         Ok(())
     } else {
-        Err(Error::Dynasm(result))
+        Err(Error::AotDynasm(result))
     }
 }
 
@@ -198,7 +198,7 @@ impl Emitter {
     pub fn new(labels: usize, version: u32) -> Result<Emitter, Error> {
         let aot = unsafe { aot_new(labels as u32, version) };
         if aot.is_null() {
-            Err(Error::Dynasm(-1))
+            Err(Error::AotDynasm(-1))
         } else {
             let emitter = Emitter {
                 aot,
@@ -212,7 +212,7 @@ impl Emitter {
         let mut buffer_size: usize = 0;
         let result = unsafe { aot_link(self.aot, &mut buffer_size) };
         if result != 0 {
-            return Err(Error::Dynasm(result));
+            return Err(Error::AotDynasm(result));
         }
         Ok(buffer_size)
     }
@@ -220,7 +220,7 @@ impl Emitter {
     pub fn encode(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
         let result = unsafe { aot_encode(self.aot, buffer.as_mut_ptr() as *mut c_void) };
         if result != 0 {
-            return Err(Error::Dynasm(result));
+            return Err(Error::AotDynasm(result));
         }
         Ok(())
     }
@@ -229,7 +229,7 @@ impl Emitter {
         let mut offset = 0;
         let result = unsafe { aot_getpclabel(self.aot, label, &mut offset as *mut u32) };
         if result != 0 {
-            return Err(Error::Dynasm(result));
+            return Err(Error::AotDynasm(result));
         }
         Ok(offset)
     }
@@ -237,7 +237,7 @@ impl Emitter {
     pub fn emit_label(&mut self, label: u32) -> Result<(), Error> {
         let result = unsafe { aot_label(self.aot, label) };
         if result != 0 {
-            return Err(Error::Dynasm(result));
+            return Err(Error::AotDynasm(result));
         }
         Ok(())
     }
@@ -245,7 +245,7 @@ impl Emitter {
     pub fn emit_add_cycles(&mut self, cycles: u64) -> Result<(), Error> {
         let result = unsafe { aot_add_cycles(self.aot, cycles) };
         if result != 0 {
-            return Err(Error::Dynasm(result));
+            return Err(Error::AotDynasm(result));
         }
         Ok(())
     }

--- a/src/machine/aot/emitter.rs
+++ b/src/machine/aot/emitter.rs
@@ -266,7 +266,7 @@ impl Emitter {
                     pc_write = Some(self.emit_value(value)?);
                 }
                 _ => {
-                    return Err(Error::Unexpected);
+                    return Err(Error::Unexpected(String::from("Unexpected write type")));
                 }
             }
         }

--- a/src/machine/aot/emitter.rs
+++ b/src/machine/aot/emitter.rs
@@ -161,7 +161,7 @@ impl Default for TempRegisterAllocator {
 impl TempRegisterAllocator {
     pub fn next(&mut self) -> Result<usize, Error> {
         if self.next > MAXIMAL_TEMP_REGISTER {
-            return Err(Error::OutOfBound);
+            return Err(Error::AotLimitReachedMaximumTempRegisters);
         }
         let value = self.next;
         self.next += 1;

--- a/src/machine/aot/mod.rs
+++ b/src/machine/aot/mod.rs
@@ -107,10 +107,10 @@ impl LabelGatheringMachine {
             use goblin_v023::elf::{Header, SectionHeader};
 
             let header = program.pread::<Header>(0)?;
-            let container = header.container().map_err(|_e| Error::InvalidElfBits)?;
-            let endianness = header.endianness().map_err(|_e| Error::InvalidElfBits)?;
+            let container = header.container().map_err(|_e| Error::ElfBits)?;
+            let endianness = header.endianness().map_err(|_e| Error::ElfBits)?;
             if <Self as CoreMachine>::REG::BITS != if container.is_big() { 64 } else { 32 } {
-                return Err(Error::InvalidElfBits);
+                return Err(Error::ElfBits);
             }
             let ctx = Ctx::new(container, endianness);
             SectionHeader::parse(
@@ -127,10 +127,10 @@ impl LabelGatheringMachine {
             use goblin_v040::elf::{Header, SectionHeader};
 
             let header = program.pread::<Header>(0)?;
-            let container = header.container().map_err(|_e| Error::InvalidElfBits)?;
-            let endianness = header.endianness().map_err(|_e| Error::InvalidElfBits)?;
+            let container = header.container().map_err(|_e| Error::ElfBits)?;
+            let endianness = header.endianness().map_err(|_e| Error::ElfBits)?;
             if <Self as CoreMachine>::REG::BITS != if container.is_big() { 64 } else { 32 } {
-                return Err(Error::InvalidElfBits);
+                return Err(Error::ElfBits);
             }
             let ctx = Ctx::new(container, endianness);
             SectionHeader::parse(

--- a/src/machine/aot/mod.rs
+++ b/src/machine/aot/mod.rs
@@ -193,7 +193,7 @@ impl LabelGatheringMachine {
     fn read_pc(&self) -> Result<u64, Error> {
         match &self.pc {
             Value::Imm(pc) => Ok(*pc),
-            _ => Err(Error::Unexpected),
+            _ => Err(Error::Unexpected(String::from("Unexpected value type"))),
         }
     }
 
@@ -476,7 +476,7 @@ impl AotCompilingMachine {
     fn read_pc(&self) -> Result<u64, Error> {
         match &self.pc {
             Value::Imm(pc) => Ok(*pc),
-            _ => Err(Error::Unexpected),
+            _ => Err(Error::Unexpected(String::from("Unexpected value type"))),
         }
     }
 

--- a/src/machine/aot/mod.rs
+++ b/src/machine/aot/mod.rs
@@ -106,7 +106,7 @@ impl LabelGatheringMachine {
             use goblin_v023::container::Ctx;
             use goblin_v023::elf::{Header, SectionHeader};
 
-            let header = program.pread::<Header>(0).map_err(|_e| Error::ParseError)?;
+            let header = program.pread::<Header>(0)?;
             let container = header.container().map_err(|_e| Error::InvalidElfBits)?;
             let endianness = header.endianness().map_err(|_e| Error::InvalidElfBits)?;
             if <Self as CoreMachine>::REG::BITS != if container.is_big() { 64 } else { 32 } {
@@ -118,8 +118,7 @@ impl LabelGatheringMachine {
                 header.e_shoff as usize,
                 header.e_shnum as usize,
                 ctx,
-            )
-            .map_err(|_e| Error::ParseError)?
+            )?
             .iter()
             .map(elf_adaptor::SectionHeader::from_v0)
             .collect()
@@ -127,7 +126,7 @@ impl LabelGatheringMachine {
             use goblin_v040::container::Ctx;
             use goblin_v040::elf::{Header, SectionHeader};
 
-            let header = program.pread::<Header>(0).map_err(|_e| Error::ParseError)?;
+            let header = program.pread::<Header>(0)?;
             let container = header.container().map_err(|_e| Error::InvalidElfBits)?;
             let endianness = header.endianness().map_err(|_e| Error::InvalidElfBits)?;
             if <Self as CoreMachine>::REG::BITS != if container.is_big() { 64 } else { 32 } {
@@ -139,8 +138,7 @@ impl LabelGatheringMachine {
                 header.e_shoff as usize,
                 header.e_shnum as usize,
                 ctx,
-            )
-            .map_err(|_e| Error::ParseError)?
+            )?
             .iter()
             .map(elf_adaptor::SectionHeader::from_v1)
             .collect()

--- a/src/machine/aot/mod.rs
+++ b/src/machine/aot/mod.rs
@@ -146,7 +146,7 @@ impl LabelGatheringMachine {
             .collect()
         };
         if section_headers.len() > MAXIMUM_SECTIONS {
-            return Err(Error::LimitReached);
+            return Err(Error::AotLimitReachedMaximumSections);
         }
         let mut sections: Vec<(u64, u64)> = section_headers
             .iter()
@@ -222,7 +222,7 @@ impl LabelGatheringMachine {
                             }
                         }
                         if self.labels.len() > MAXIMUM_LABELS {
-                            return Err(Error::LimitReached);
+                            return Err(Error::AotLimitReachedMaximumLabels);
                         }
                         self.pc = Value::from_u64(next_pc);
                     }
@@ -260,7 +260,7 @@ impl LabelGatheringMachine {
                         // sections won't overlap with each other as well.
                         self.dummy_sections.insert(pc, dummy_end);
                         if self.dummy_sections.len() > MAXIMUM_DUMMY_SECTIONS {
-                            return Err(Error::LimitReached);
+                            return Err(Error::AotLimitReachedMaximumDummySections);
                         }
                         self.pc = Value::from_u64(dummy_end);
                     }

--- a/src/machine/asm/mod.rs
+++ b/src/machine/asm/mod.rs
@@ -525,7 +525,7 @@ impl<'a> AsmMachine<'a> {
                 RET_ECALL => self.machine.ecall()?,
                 RET_EBREAK => self.machine.ebreak()?,
                 RET_DYNAMIC_JUMP => (),
-                RET_MAX_CYCLES_EXCEEDED => return Err(Error::InvalidCycles),
+                RET_MAX_CYCLES_EXCEEDED => return Err(Error::CyclesExceeded),
                 RET_CYCLES_OVERFLOW => return Err(Error::CyclesOverflow),
                 RET_OUT_OF_BOUND => return Err(Error::OutOfBound),
                 RET_INVALID_PERMISSION => return Err(Error::InvalidPermission),
@@ -573,7 +573,7 @@ impl<'a> AsmMachine<'a> {
             RET_DECODE_TRACE => (),
             RET_ECALL => self.machine.ecall()?,
             RET_EBREAK => self.machine.ebreak()?,
-            RET_MAX_CYCLES_EXCEEDED => return Err(Error::InvalidCycles),
+            RET_MAX_CYCLES_EXCEEDED => return Err(Error::CyclesExceeded),
             RET_OUT_OF_BOUND => return Err(Error::OutOfBound),
             RET_INVALID_PERMISSION => return Err(Error::InvalidPermission),
             RET_SLOWPATH => {

--- a/src/machine/asm/mod.rs
+++ b/src/machine/asm/mod.rs
@@ -206,7 +206,7 @@ impl Memory for Box<AsmCoreMachine> {
         offset_from_addr: u64,
     ) -> Result<(), Error> {
         if round_page_down(addr) != addr || round_page_up(size) != size {
-            return Err(Error::Unaligned);
+            return Err(Error::MemPageUnalignedAccess);
         }
         if addr > RISCV_MAX_MEMORY as u64
             || size > RISCV_MAX_MEMORY as u64

--- a/src/machine/asm/mod.rs
+++ b/src/machine/asm/mod.rs
@@ -118,7 +118,7 @@ fn check_memory_writable(
     debug_assert!(size == 1 || size == 2 || size == 4 || size == 8);
     let page = addr >> RISCV_PAGE_SHIFTS;
     if page as usize >= RISCV_PAGES {
-        return Err(Error::OutOfBound);
+        return Err(Error::MemOutOfBound);
     }
     check_permission(machine, page, FLAG_WRITABLE)?;
     check_memory(machine, page);
@@ -129,7 +129,7 @@ fn check_memory_writable(
     if page_offset + size > RISCV_PAGESIZE {
         let page = page + 1;
         if page as usize >= RISCV_PAGES {
-            return Err(Error::OutOfBound);
+            return Err(Error::MemOutOfBound);
         } else {
             check_permission(machine, page, FLAG_WRITABLE)?;
             check_memory(machine, page);
@@ -149,7 +149,7 @@ fn check_memory_executable(
 
     let page = addr >> RISCV_PAGE_SHIFTS;
     if page as usize >= RISCV_PAGES {
-        return Err(Error::OutOfBound);
+        return Err(Error::MemOutOfBound);
     }
     check_permission(machine, page, FLAG_EXECUTABLE)?;
     check_memory(machine, page);
@@ -159,7 +159,7 @@ fn check_memory_executable(
     if page_offset + size > RISCV_PAGESIZE {
         let page = page + 1;
         if page as usize >= RISCV_PAGES {
-            return Err(Error::OutOfBound);
+            return Err(Error::MemOutOfBound);
         } else {
             check_permission(machine, page, FLAG_EXECUTABLE)?;
             check_memory(machine, page);
@@ -177,7 +177,7 @@ fn check_memory_inited(
     debug_assert!(size == 1 || size == 2 || size == 4 || size == 8);
     let page = addr >> RISCV_PAGE_SHIFTS;
     if page as usize >= RISCV_PAGES {
-        return Err(Error::OutOfBound);
+        return Err(Error::MemOutOfBound);
     }
     check_memory(machine, page);
 
@@ -186,7 +186,7 @@ fn check_memory_inited(
     if page_offset + size > RISCV_PAGESIZE {
         let page = page + 1;
         if page as usize >= RISCV_PAGES {
-            return Err(Error::OutOfBound);
+            return Err(Error::MemOutOfBound);
         } else {
             check_memory(machine, page);
         }
@@ -213,7 +213,7 @@ impl Memory for Box<AsmCoreMachine> {
             || addr + size > RISCV_MAX_MEMORY as u64
             || offset_from_addr > size
         {
-            return Err(Error::OutOfBound);
+            return Err(Error::MemOutOfBound);
         }
         // We benchmarked the code piece here, using while loop this way is
         // actually faster than a for..in solution. The difference is roughly
@@ -240,7 +240,7 @@ impl Memory for Box<AsmCoreMachine> {
         if page < RISCV_PAGES as u64 {
             Ok(self.flags[page as usize])
         } else {
-            Err(Error::OutOfBound)
+            Err(Error::MemOutOfBound)
         }
     }
 
@@ -249,7 +249,7 @@ impl Memory for Box<AsmCoreMachine> {
             self.flags[page as usize] |= flag;
             Ok(())
         } else {
-            Err(Error::OutOfBound)
+            Err(Error::MemOutOfBound)
         }
     }
 
@@ -258,7 +258,7 @@ impl Memory for Box<AsmCoreMachine> {
             self.flags[page as usize] &= !flag;
             Ok(())
         } else {
-            Err(Error::OutOfBound)
+            Err(Error::MemOutOfBound)
         }
     }
 
@@ -527,7 +527,7 @@ impl<'a> AsmMachine<'a> {
                 RET_DYNAMIC_JUMP => (),
                 RET_MAX_CYCLES_EXCEEDED => return Err(Error::CyclesExceeded),
                 RET_CYCLES_OVERFLOW => return Err(Error::CyclesOverflow),
-                RET_OUT_OF_BOUND => return Err(Error::OutOfBound),
+                RET_OUT_OF_BOUND => return Err(Error::MemOutOfBound),
                 RET_INVALID_PERMISSION => return Err(Error::MemWriteOnExecutablePage),
                 RET_SLOWPATH => {
                     let pc = *self.machine.pc() - 4;
@@ -574,7 +574,7 @@ impl<'a> AsmMachine<'a> {
             RET_ECALL => self.machine.ecall()?,
             RET_EBREAK => self.machine.ebreak()?,
             RET_MAX_CYCLES_EXCEEDED => return Err(Error::CyclesExceeded),
-            RET_OUT_OF_BOUND => return Err(Error::OutOfBound),
+            RET_OUT_OF_BOUND => return Err(Error::MemOutOfBound),
             RET_INVALID_PERMISSION => return Err(Error::MemWriteOnExecutablePage),
             RET_SLOWPATH => {
                 let pc = *self.machine.pc() - 4;

--- a/src/machine/elf_adaptor.rs
+++ b/src/machine/elf_adaptor.rs
@@ -12,8 +12,11 @@ pub fn convert_flags(p_flags: u32, allow_freeze_writable: bool) -> Result<u8, Er
     let readable = p_flags & PF_R != 0;
     let writable = p_flags & PF_W != 0;
     let executable = p_flags & PF_X != 0;
-    if (!readable) || (writable && executable) {
-        return Err(Error::InvalidPermission);
+    if !readable {
+        return Err(Error::ElfSegmentUnreadable);
+    }
+    if writable && executable {
+        return Err(Error::ElfSegmentWritableAndExecutable);
     }
     if executable {
         Ok(FLAG_EXECUTABLE | FLAG_FREEZED)

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -155,7 +155,7 @@ pub trait SupportMachine: CoreMachine {
                     .p_offset
                     .wrapping_add(program_header.p_filesz);
                 if slice_start > slice_end || slice_end > program.len() as u64 {
-                    return Err(Error::OutOfBound);
+                    return Err(Error::ElfSegmentAddrOrSizeError);
                 }
                 self.memory_mut().init_pages(
                     aligned_start,
@@ -258,7 +258,7 @@ pub trait SupportMachine: CoreMachine {
         }
         if self.registers()[SP].to_u64() < stack_start {
             // args exceed stack size
-            return Err(Error::OutOfBound);
+            return Err(Error::MemOutOfStack);
         }
         Ok(stack_start + stack_size - self.registers()[SP].to_u64())
     }

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -106,7 +106,7 @@ pub trait SupportMachine: CoreMachine {
             if version < VERSION1 {
                 use goblin_v023::container::Ctx;
                 use goblin_v023::elf::{program_header::ProgramHeader, Header};
-                let header = program.pread::<Header>(0).map_err(|_e| Error::ParseError)?;
+                let header = program.pread::<Header>(0)?;
                 let container = header.container().map_err(|_e| Error::InvalidElfBits)?;
                 let endianness = header.endianness().map_err(|_e| Error::InvalidElfBits)?;
                 if Self::REG::BITS != if container.is_big() { 64 } else { 32 } {
@@ -118,8 +118,7 @@ pub trait SupportMachine: CoreMachine {
                     header.e_phoff as usize,
                     header.e_phnum as usize,
                     ctx,
-                )
-                .map_err(|_e| Error::ParseError)?
+                )?
                 .iter()
                 .map(elf_adaptor::ProgramHeader::from_v0)
                 .collect();
@@ -127,7 +126,7 @@ pub trait SupportMachine: CoreMachine {
             } else {
                 use goblin_v040::container::Ctx;
                 use goblin_v040::elf::{program_header::ProgramHeader, Header};
-                let header = program.pread::<Header>(0).map_err(|_e| Error::ParseError)?;
+                let header = program.pread::<Header>(0)?;
                 let container = header.container().map_err(|_e| Error::InvalidElfBits)?;
                 let endianness = header.endianness().map_err(|_e| Error::InvalidElfBits)?;
                 if Self::REG::BITS != if container.is_big() { 64 } else { 32 } {
@@ -139,8 +138,7 @@ pub trait SupportMachine: CoreMachine {
                     header.e_phoff as usize,
                     header.e_phnum as usize,
                     ctx,
-                )
-                .map_err(|_e| Error::ParseError)?
+                )?
                 .iter()
                 .map(elf_adaptor::ProgramHeader::from_v1)
                 .collect();

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -107,10 +107,10 @@ pub trait SupportMachine: CoreMachine {
                 use goblin_v023::container::Ctx;
                 use goblin_v023::elf::{program_header::ProgramHeader, Header};
                 let header = program.pread::<Header>(0)?;
-                let container = header.container().map_err(|_e| Error::InvalidElfBits)?;
-                let endianness = header.endianness().map_err(|_e| Error::InvalidElfBits)?;
+                let container = header.container().map_err(|_e| Error::ElfBits)?;
+                let endianness = header.endianness().map_err(|_e| Error::ElfBits)?;
                 if Self::REG::BITS != if container.is_big() { 64 } else { 32 } {
-                    return Err(Error::InvalidElfBits);
+                    return Err(Error::ElfBits);
                 }
                 let ctx = Ctx::new(container, endianness);
                 let program_headers = ProgramHeader::parse(
@@ -127,10 +127,10 @@ pub trait SupportMachine: CoreMachine {
                 use goblin_v040::container::Ctx;
                 use goblin_v040::elf::{program_header::ProgramHeader, Header};
                 let header = program.pread::<Header>(0)?;
-                let container = header.container().map_err(|_e| Error::InvalidElfBits)?;
-                let endianness = header.endianness().map_err(|_e| Error::InvalidElfBits)?;
+                let container = header.container().map_err(|_e| Error::ElfBits)?;
+                let endianness = header.endianness().map_err(|_e| Error::ElfBits)?;
                 if Self::REG::BITS != if container.is_big() { 64 } else { 32 } {
-                    return Err(Error::InvalidElfBits);
+                    return Err(Error::ElfBits);
                 }
                 let ctx = Ctx::new(container, endianness);
                 let program_headers = ProgramHeader::parse(

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -83,7 +83,7 @@ pub trait SupportMachine: CoreMachine {
             .checked_add(cycles)
             .ok_or(Error::CyclesOverflow)?;
         if new_cycles > self.max_cycles() {
-            return Err(Error::InvalidCycles);
+            return Err(Error::CyclesExceeded);
         }
         self.set_cycles(new_cycles);
         Ok(())
@@ -476,7 +476,7 @@ impl<Inner: SupportMachine> Machine for DefaultMachine<'_, Inner> {
                     let processed = syscall.ecall(&mut self.inner)?;
                     if processed {
                         if self.cycles() > self.max_cycles() {
-                            return Err(Error::InvalidCycles);
+                            return Err(Error::CyclesExceeded);
                         }
                         return Ok(());
                     }

--- a/src/memory/flat.rs
+++ b/src/memory/flat.rs
@@ -57,7 +57,7 @@ impl<R: Register> Memory for FlatMemory<R> {
         if page < RISCV_PAGES as u64 {
             Ok(self.flags[page as usize])
         } else {
-            Err(Error::OutOfBound)
+            Err(Error::MemOutOfBound)
         }
     }
 
@@ -66,7 +66,7 @@ impl<R: Register> Memory for FlatMemory<R> {
             self.flags[page as usize] |= flag;
             Ok(())
         } else {
-            Err(Error::OutOfBound)
+            Err(Error::MemOutOfBound)
         }
     }
 
@@ -75,7 +75,7 @@ impl<R: Register> Memory for FlatMemory<R> {
             self.flags[page as usize] &= !flag;
             Ok(())
         } else {
-            Err(Error::OutOfBound)
+            Err(Error::MemOutOfBound)
         }
     }
 
@@ -89,8 +89,8 @@ impl<R: Register> Memory for FlatMemory<R> {
 
     fn load8(&mut self, addr: &Self::REG) -> Result<Self::REG, Error> {
         let addr = addr.to_u64();
-        if addr.checked_add(1).ok_or(Error::OutOfBound)? > self.len() as u64 {
-            return Err(Error::OutOfBound);
+        if addr.checked_add(1).ok_or(Error::MemOutOfBound)? > self.len() as u64 {
+            return Err(Error::MemOutOfBound);
         }
         let mut reader = Cursor::new(&self.data);
         reader.seek(SeekFrom::Start(addr as u64))?;
@@ -100,8 +100,8 @@ impl<R: Register> Memory for FlatMemory<R> {
 
     fn load16(&mut self, addr: &Self::REG) -> Result<Self::REG, Error> {
         let addr = addr.to_u64();
-        if addr.checked_add(2).ok_or(Error::OutOfBound)? > self.len() as u64 {
-            return Err(Error::OutOfBound);
+        if addr.checked_add(2).ok_or(Error::MemOutOfBound)? > self.len() as u64 {
+            return Err(Error::MemOutOfBound);
         }
         let mut reader = Cursor::new(&self.data);
         reader.seek(SeekFrom::Start(addr as u64))?;
@@ -112,8 +112,8 @@ impl<R: Register> Memory for FlatMemory<R> {
 
     fn load32(&mut self, addr: &Self::REG) -> Result<Self::REG, Error> {
         let addr = addr.to_u64();
-        if addr.checked_add(4).ok_or(Error::OutOfBound)? > self.len() as u64 {
-            return Err(Error::OutOfBound);
+        if addr.checked_add(4).ok_or(Error::MemOutOfBound)? > self.len() as u64 {
+            return Err(Error::MemOutOfBound);
         }
         let mut reader = Cursor::new(&self.data);
         reader.seek(SeekFrom::Start(addr as u64))?;
@@ -124,8 +124,8 @@ impl<R: Register> Memory for FlatMemory<R> {
 
     fn load64(&mut self, addr: &Self::REG) -> Result<Self::REG, Error> {
         let addr = addr.to_u64();
-        if addr.checked_add(8).ok_or(Error::OutOfBound)? > self.len() as u64 {
-            return Err(Error::OutOfBound);
+        if addr.checked_add(8).ok_or(Error::MemOutOfBound)? > self.len() as u64 {
+            return Err(Error::MemOutOfBound);
         }
         let mut reader = Cursor::new(&self.data);
         reader.seek(SeekFrom::Start(addr as u64))?;

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -93,10 +93,10 @@ pub(crate) fn fill_page_data<M: Memory>(
 pub fn get_page_indices(addr: u64, size: u64) -> Result<(u64, u64), Error> {
     let (addr_end, overflowed) = addr.overflowing_add(size);
     if overflowed {
-        return Err(Error::OutOfBound);
+        return Err(Error::MemOutOfBound);
     }
     if addr_end > RISCV_MAX_MEMORY as u64 {
-        return Err(Error::OutOfBound);
+        return Err(Error::MemOutOfBound);
     }
     let page = addr >> RISCV_PAGE_SHIFTS;
     let page_end = (addr_end - 1) >> RISCV_PAGE_SHIFTS;

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -111,7 +111,7 @@ pub fn check_permission<M: Memory>(
     for page in page_indices.0..=page_indices.1 {
         let page_flag = memory.fetch_flag(page)?;
         if (page_flag & FLAG_WXORX_BIT) != (flag & FLAG_WXORX_BIT) {
-            return Err(Error::InvalidPermission);
+            return Err(Error::MemWriteOnExecutablePage);
         }
     }
     Ok(())

--- a/src/memory/sparse.rs
+++ b/src/memory/sparse.rs
@@ -34,7 +34,7 @@ impl<R> SparseMemory<R> {
     fn fetch_page(&mut self, aligned_addr: u64) -> Result<&mut Page, Error> {
         let page = aligned_addr / RISCV_PAGESIZE as u64;
         if page >= RISCV_PAGES as u64 {
-            return Err(Error::OutOfBound);
+            return Err(Error::MemOutOfBound);
         }
         let mut index = self.indices[page as usize];
         if index == INVALID_PAGE_INDEX {
@@ -92,7 +92,7 @@ impl<R: Register> Memory for SparseMemory<R> {
         if page < RISCV_PAGES as u64 {
             Ok(self.flags[page as usize])
         } else {
-            Err(Error::OutOfBound)
+            Err(Error::MemOutOfBound)
         }
     }
 
@@ -101,7 +101,7 @@ impl<R: Register> Memory for SparseMemory<R> {
             self.flags[page as usize] |= flag;
             Ok(())
         } else {
-            Err(Error::OutOfBound)
+            Err(Error::MemOutOfBound)
         }
     }
 
@@ -110,7 +110,7 @@ impl<R: Register> Memory for SparseMemory<R> {
             self.flags[page as usize] &= !flag;
             Ok(())
         } else {
-            Err(Error::OutOfBound)
+            Err(Error::MemOutOfBound)
         }
     }
 

--- a/src/memory/wxorx.rs
+++ b/src/memory/wxorx.rs
@@ -43,7 +43,7 @@ impl<M: Memory> Memory for WXorXMemory<M> {
             || addr + size > RISCV_MAX_MEMORY as u64
             || offset_from_addr > size
         {
-            return Err(Error::OutOfBound);
+            return Err(Error::MemOutOfBound);
         }
         for page_addr in (addr..addr + size).step_by(RISCV_PAGESIZE) {
             let page = page_addr / RISCV_PAGESIZE as u64;

--- a/src/memory/wxorx.rs
+++ b/src/memory/wxorx.rs
@@ -48,7 +48,7 @@ impl<M: Memory> Memory for WXorXMemory<M> {
         for page_addr in (addr..addr + size).step_by(RISCV_PAGESIZE) {
             let page = page_addr / RISCV_PAGESIZE as u64;
             if self.fetch_flag(page)? & FLAG_FREEZED != 0 {
-                return Err(Error::InvalidPermission);
+                return Err(Error::MemWriteOnExecutablePage);
             }
             self.set_flag(page, flags)?;
         }

--- a/src/memory/wxorx.rs
+++ b/src/memory/wxorx.rs
@@ -36,7 +36,7 @@ impl<M: Memory> Memory for WXorXMemory<M> {
         offset_from_addr: u64,
     ) -> Result<(), Error> {
         if round_page_down(addr) != addr || round_page_up(size) != size {
-            return Err(Error::Unaligned);
+            return Err(Error::MemPageUnalignedAccess);
         }
         if addr > RISCV_MAX_MEMORY as u64
             || size > RISCV_MAX_MEMORY as u64

--- a/tests/test_aot.rs
+++ b/tests/test_aot.rs
@@ -170,7 +170,7 @@ pub fn test_aot_trace() {
         .unwrap();
     let result = machine.run();
     assert!(result.is_err());
-    assert_eq!(result.err(), Some(Error::InvalidPermission));
+    assert_eq!(result.err(), Some(Error::MemWriteOnExecutablePage));
 }
 
 #[test]
@@ -186,7 +186,7 @@ pub fn test_aot_jump0() {
         .unwrap();
     let result = machine.run();
     assert!(result.is_err());
-    assert_eq!(result.err(), Some(Error::InvalidPermission));
+    assert_eq!(result.err(), Some(Error::MemWriteOnExecutablePage));
 }
 
 #[test]
@@ -266,7 +266,7 @@ pub fn test_aot_load_elf_crash_64() {
         .load_program(&buffer, &vec!["load_elf_crash_64".into()])
         .unwrap();
     let result = machine.run();
-    assert_eq!(result.err(), Some(Error::InvalidPermission));
+    assert_eq!(result.err(), Some(Error::MemWriteOnExecutablePage));
 }
 
 #[test]

--- a/tests/test_aot.rs
+++ b/tests/test_aot.rs
@@ -154,7 +154,7 @@ pub fn test_aot_simple_max_cycles_reached() {
         .unwrap();
     let result = machine.run();
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err(), Error::InvalidCycles);
+    assert_eq!(result.unwrap_err(), Error::CyclesExceeded);
 }
 
 #[test]
@@ -417,7 +417,7 @@ pub fn test_aot_outofcycles_in_syscall() {
         .unwrap();
     let result = machine.run();
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err(), Error::InvalidCycles);
+    assert_eq!(result.unwrap_err(), Error::CyclesExceeded);
     assert_eq!(machine.machine.cycles(), 108);
     assert_eq!(machine.machine.registers()[A0], 39);
 }

--- a/tests/test_aot.rs
+++ b/tests/test_aot.rs
@@ -204,7 +204,7 @@ pub fn test_aot_write_large_address() {
         .unwrap();
     let result = machine.run();
     assert!(result.is_err());
-    assert_eq!(result.err(), Some(Error::OutOfBound));
+    assert_eq!(result.err(), Some(Error::MemOutOfBound));
 }
 
 #[test]
@@ -251,7 +251,7 @@ pub fn test_aot_invalid_read64() {
         .unwrap();
     let result = machine.run();
     assert!(result.is_err());
-    assert_eq!(result.err(), Some(Error::OutOfBound));
+    assert_eq!(result.err(), Some(Error::MemOutOfBound));
 }
 
 #[test]
@@ -281,7 +281,7 @@ pub fn test_aot_wxorx_crash_64() {
         .load_program(&buffer, &vec!["wxorx_crash_64".into()])
         .unwrap();
     let result = machine.run();
-    assert_eq!(result.err(), Some(Error::OutOfBound));
+    assert_eq!(result.err(), Some(Error::MemOutOfBound));
 }
 
 #[test]
@@ -290,7 +290,7 @@ pub fn test_aot_load_elf_section_crash_64() {
         .unwrap()
         .into();
     let result = AotCompilingMachine::load(&buffer, None, ISA_IMC, VERSION0);
-    assert_eq!(result.err(), Some(Error::OutOfBound));
+    assert_eq!(result.err(), Some(Error::AotSectionIsEmpty));
 }
 
 #[test]
@@ -306,7 +306,7 @@ pub fn test_aot_load_malformed_elf_crash_64() {
 pub fn test_aot_flat_crash_64() {
     let buffer = fs::read("tests/programs/flat_crash_64").unwrap().into();
     let result = AotCompilingMachine::load(&buffer, None, ISA_IMC, VERSION0);
-    assert_eq!(result.err(), Some(Error::OutOfBound));
+    assert_eq!(result.err(), Some(Error::MemOutOfBound));
 }
 
 #[test]

--- a/tests/test_aot.rs
+++ b/tests/test_aot.rs
@@ -299,7 +299,7 @@ pub fn test_aot_load_malformed_elf_crash_64() {
         .unwrap()
         .into();
     let result = AotCompilingMachine::load(&buffer, None, ISA_IMC, VERSION0);
-    assert_eq!(result.err(), Some(Error::ParseError));
+    assert!(matches!(result.err(), Some(Error::ElfParseError(_))));
 }
 
 #[test]

--- a/tests/test_asm.rs
+++ b/tests/test_asm.rs
@@ -155,7 +155,7 @@ pub fn test_asm_trace() {
         .unwrap();
     let result = machine.run();
     assert!(result.is_err());
-    assert_eq!(result.err(), Some(Error::InvalidPermission));
+    assert_eq!(result.err(), Some(Error::MemWriteOnExecutablePage));
 }
 
 #[test]
@@ -169,7 +169,7 @@ pub fn test_asm_jump0() {
         .unwrap();
     let result = machine.run();
     assert!(result.is_err());
-    assert_eq!(result.err(), Some(Error::InvalidPermission));
+    assert_eq!(result.err(), Some(Error::MemWriteOnExecutablePage));
 }
 
 #[test]
@@ -239,7 +239,7 @@ pub fn test_asm_load_elf_crash_64() {
         .load_program(&buffer, &vec!["load_elf_crash_64".into()])
         .unwrap();
     let result = machine.run();
-    assert_eq!(result.err(), Some(Error::InvalidPermission));
+    assert_eq!(result.err(), Some(Error::MemWriteOnExecutablePage));
 }
 
 #[test]

--- a/tests/test_asm.rs
+++ b/tests/test_asm.rs
@@ -185,7 +185,7 @@ pub fn test_asm_write_large_address() {
         .unwrap();
     let result = machine.run();
     assert!(result.is_err());
-    assert_eq!(result.err(), Some(Error::OutOfBound));
+    assert_eq!(result.err(), Some(Error::MemOutOfBound));
 }
 
 #[test]
@@ -226,7 +226,7 @@ pub fn test_invalid_read64() {
         .unwrap();
     let result = machine.run();
     assert!(result.is_err());
-    assert_eq!(result.err(), Some(Error::OutOfBound));
+    assert_eq!(result.err(), Some(Error::MemOutOfBound));
 }
 
 #[test]
@@ -252,7 +252,7 @@ pub fn test_asm_wxorx_crash_64() {
         .load_program(&buffer, &vec!["wxorx_crash_64".into()])
         .unwrap();
     let result = machine.run();
-    assert_eq!(result.err(), Some(Error::OutOfBound));
+    assert_eq!(result.err(), Some(Error::MemOutOfBound));
 }
 
 #[test]
@@ -389,7 +389,7 @@ pub fn test_decoder_instructions_cache_pc_out_of_bound_timeout() {
         .unwrap();
     let result = machine.run();
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err(), Error::OutOfBound);
+    assert_eq!(result.unwrap_err(), Error::MemOutOfBound);
 }
 
 pub fn test_asm_step() {

--- a/tests/test_asm.rs
+++ b/tests/test_asm.rs
@@ -141,7 +141,7 @@ pub fn test_asm_simple_max_cycles_reached() {
         .unwrap();
     let result = machine.run();
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err(), Error::InvalidCycles);
+    assert_eq!(result.unwrap_err(), Error::CyclesExceeded);
 }
 
 #[test]
@@ -351,7 +351,7 @@ pub fn test_asm_outofcycles_in_syscall() {
         .unwrap();
     let result = machine.run();
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err(), Error::InvalidCycles);
+    assert_eq!(result.unwrap_err(), Error::CyclesExceeded);
     assert_eq!(machine.machine.cycles(), 108);
     assert_eq!(machine.machine.registers()[A0], 39);
 }

--- a/tests/test_misc.rs
+++ b/tests/test_misc.rs
@@ -304,7 +304,7 @@ pub fn test_outofcycles_in_syscall() {
         .unwrap();
     let result = machine.run();
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err(), Error::InvalidCycles);
+    assert_eq!(result.unwrap_err(), Error::CyclesExceeded);
     assert_eq!(machine.cycles(), 108);
     assert_eq!(machine.registers()[A0], 39);
 }

--- a/tests/test_misc.rs
+++ b/tests/test_misc.rs
@@ -139,7 +139,7 @@ pub fn test_invalid_file_offset64() {
         .unwrap()
         .into();
     let result = run::<u64, SparseMemory<u64>>(&buffer, &vec!["invalid_file_offset64".into()]);
-    assert_eq!(result.err(), Some(Error::OutOfBound));
+    assert_eq!(result.err(), Some(Error::ElfSegmentAddrOrSizeError));
 }
 
 #[test]
@@ -183,7 +183,7 @@ pub fn test_load_elf_crash_64() {
 pub fn test_wxorx_crash_64() {
     let buffer = fs::read("tests/programs/wxorx_crash_64").unwrap().into();
     let result = run::<u64, SparseMemory<u64>>(&buffer, &vec!["wxorx_crash_64".into()]);
-    assert_eq!(result.err(), Some(Error::OutOfBound));
+    assert_eq!(result.err(), Some(Error::MemOutOfBound));
 }
 
 #[test]
@@ -193,7 +193,7 @@ pub fn test_flat_crash_64() {
         DefaultCoreMachine::<u64, FlatMemory<u64>>::new(ISA_IMC, VERSION0, u64::max_value());
     let mut machine = DefaultMachineBuilder::new(core_machine).build();
     let result = machine.load_program(&buffer, &vec!["flat_crash_64".into()]);
-    assert_eq!(result.err(), Some(Error::OutOfBound));
+    assert_eq!(result.err(), Some(Error::MemOutOfBound));
 }
 
 #[test]

--- a/tests/test_misc.rs
+++ b/tests/test_misc.rs
@@ -108,7 +108,7 @@ pub fn test_trace() {
     let buffer = fs::read("tests/programs/trace64").unwrap().into();
     let result = run::<u64, SparseMemory<u64>>(&buffer, &vec!["trace64".into()]);
     assert!(result.is_err());
-    assert_eq!(result.err(), Some(Error::InvalidPermission));
+    assert_eq!(result.err(), Some(Error::MemWriteOnExecutablePage));
 }
 
 #[test]
@@ -116,7 +116,7 @@ pub fn test_jump0() {
     let buffer = fs::read("tests/programs/jump0_64").unwrap().into();
     let result = run::<u64, SparseMemory<u64>>(&buffer, &vec!["jump0_64".into()]);
     assert!(result.is_err());
-    assert_eq!(result.err(), Some(Error::InvalidPermission));
+    assert_eq!(result.err(), Some(Error::MemWriteOnExecutablePage));
 }
 
 #[test]
@@ -149,7 +149,7 @@ pub fn test_op_rvc_srli_crash_32() {
         .unwrap()
         .into();
     let result = run::<u32, SparseMemory<u32>>(&buffer, &vec!["op_rvc_srli_crash_32".into()]);
-    assert_eq!(result.err(), Some(Error::InvalidPermission));
+    assert_eq!(result.err(), Some(Error::MemWriteOnExecutablePage));
 }
 
 #[test]
@@ -176,7 +176,7 @@ pub fn test_op_rvc_slli_crash_32() {
 pub fn test_load_elf_crash_64() {
     let buffer = fs::read("tests/programs/load_elf_crash_64").unwrap().into();
     let result = run::<u64, SparseMemory<u64>>(&buffer, &vec!["load_elf_crash_64".into()]);
-    assert_eq!(result.err(), Some(Error::InvalidPermission));
+    assert_eq!(result.err(), Some(Error::MemWriteOnExecutablePage));
 }
 
 #[test]

--- a/tests/test_resume.rs
+++ b/tests/test_resume.rs
@@ -82,7 +82,7 @@ pub fn resume_asm_2_asm(version: u32, except_cycles: u64) {
     let result1 = machine1.run();
     let cycles1 = machine1.cycles();
     assert!(result1.is_err());
-    assert_eq!(result1.unwrap_err(), Error::InvalidCycles);
+    assert_eq!(result1.unwrap_err(), Error::CyclesExceeded);
     let snapshot = machine1.snapshot().unwrap();
 
     let mut machine2 = MachineTy::Asm.build(version, 40);
@@ -104,7 +104,7 @@ pub fn resume_asm_2_asm_2_asm(version: u32, except_cycles: u64) {
     let result1 = machine1.run();
     let cycles1 = machine1.cycles();
     assert!(result1.is_err());
-    assert_eq!(result1.unwrap_err(), Error::InvalidCycles);
+    assert_eq!(result1.unwrap_err(), Error::CyclesExceeded);
     let snapshot1 = machine1.snapshot().unwrap();
 
     let mut machine2 = MachineTy::Asm.build(version, 4000000);
@@ -112,7 +112,7 @@ pub fn resume_asm_2_asm_2_asm(version: u32, except_cycles: u64) {
     let result2 = machine2.run();
     let cycles2 = machine2.cycles();
     assert!(result2.is_err());
-    assert_eq!(result2.unwrap_err(), Error::InvalidCycles);
+    assert_eq!(result2.unwrap_err(), Error::CyclesExceeded);
     let snapshot2 = machine2.snapshot().unwrap();
 
     let mut machine3 = MachineTy::Asm.build(version, 4000000);
@@ -134,7 +134,7 @@ pub fn resume_asm_2_interpreter(version: u32, except_cycles: u64) {
     let result1 = machine1.run();
     let cycles1 = machine1.cycles();
     assert!(result1.is_err());
-    assert_eq!(result1.unwrap_err(), Error::InvalidCycles);
+    assert_eq!(result1.unwrap_err(), Error::CyclesExceeded);
     let snapshot = machine1.snapshot().unwrap();
 
     let mut machine2 = MachineTy::Interpreter.build(version, 40);
@@ -157,7 +157,7 @@ pub fn resume_interpreter_2_interpreter(version: u32, except_cycles: u64) {
     let result1 = machine1.run();
     let cycles1 = machine1.cycles();
     assert!(result1.is_err());
-    assert_eq!(result1.unwrap_err(), Error::InvalidCycles);
+    assert_eq!(result1.unwrap_err(), Error::CyclesExceeded);
     let snapshot = machine1.snapshot().unwrap();
 
     let mut machine2 = MachineTy::Interpreter.build(version, 30);
@@ -179,7 +179,7 @@ pub fn resume_interpreter_2_asm(version: u32, except_cycles: u64) {
     let result1 = machine1.run();
     let cycles1 = machine1.cycles();
     assert!(result1.is_err());
-    assert_eq!(result1.unwrap_err(), Error::InvalidCycles);
+    assert_eq!(result1.unwrap_err(), Error::CyclesExceeded);
     let snapshot = machine1.snapshot().unwrap();
 
     let mut machine2 = MachineTy::Asm.build(version, 30);
@@ -206,7 +206,7 @@ pub fn resume_aot_2_asm(version: u32, except_cycles: u64) {
     let result1 = machine1.run();
     let cycles1 = machine1.cycles();
     assert!(result1.is_err());
-    assert_eq!(result1.unwrap_err(), Error::InvalidCycles);
+    assert_eq!(result1.unwrap_err(), Error::CyclesExceeded);
     let snapshot = machine1.snapshot().unwrap();
 
     let mut machine2 = MachineTy::Asm.build(version, 40);
@@ -229,7 +229,7 @@ pub fn resume_asm_2_aot(version: u32, except_cycles: u64) {
     let result1 = machine1.run();
     let cycles1 = machine1.cycles();
     assert!(result1.is_err());
-    assert_eq!(result1.unwrap_err(), Error::InvalidCycles);
+    assert_eq!(result1.unwrap_err(), Error::CyclesExceeded);
     let snapshot = machine1.snapshot().unwrap();
 
     let mut aot_machine =
@@ -255,7 +255,7 @@ pub fn resume_interpreter_with_trace_2_asm_inner(version: u32, except_cycles: u6
     let result1 = machine1.run();
     let cycles1 = machine1.cycles();
     assert!(result1.is_err());
-    assert_eq!(result1.unwrap_err(), Error::InvalidCycles);
+    assert_eq!(result1.unwrap_err(), Error::CyclesExceeded);
     let snapshot = machine1.snapshot().unwrap();
 
     let mut machine2 = MachineTy::Asm.build(version, 30);

--- a/tests/test_simple.rs
+++ b/tests/test_simple.rs
@@ -73,7 +73,7 @@ pub fn test_simple_invalid_bits() {
     let buffer = fs::read("tests/programs/simple").unwrap().into();
     let result = run::<u64, SparseMemory<u64>>(&buffer, &vec!["simple".into()]);
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err(), Error::InvalidElfBits);
+    assert_eq!(result.unwrap_err(), Error::ElfBits);
 }
 
 #[test]

--- a/tests/test_simple.rs
+++ b/tests/test_simple.rs
@@ -65,7 +65,7 @@ pub fn test_simple_max_cycles_reached() {
         .unwrap();
     let result = machine.run();
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err(), Error::InvalidCycles);
+    assert_eq!(result.unwrap_err(), Error::CyclesExceeded);
 }
 
 #[test]

--- a/tests/test_versions.rs
+++ b/tests/test_versions.rs
@@ -101,7 +101,7 @@ pub fn test_rust_version0_read_at_boundary() {
     let mut machine = create_rust_machine("read_at_boundary64".to_string(), VERSION0);
     let result = machine.run();
     assert!(result.is_err());
-    assert_eq!(result.err(), Some(Error::OutOfBound));
+    assert_eq!(result.err(), Some(Error::MemOutOfBound));
 }
 
 #[test]
@@ -197,7 +197,7 @@ pub fn test_asm_version0_read_at_boundary() {
     let mut machine = create_asm_machine("read_at_boundary64".to_string(), VERSION0);
     let result = machine.run();
     assert!(result.is_err());
-    assert_eq!(result.err(), Some(Error::OutOfBound));
+    assert_eq!(result.err(), Some(Error::MemOutOfBound));
 }
 
 #[test]
@@ -303,7 +303,7 @@ pub fn test_aot_version0_read_at_boundary() {
     let mut machine = create_aot_machine("read_at_boundary64".to_string(), &code, VERSION0);
     let result = machine.run();
     assert!(result.is_err());
-    assert_eq!(result.err(), Some(Error::OutOfBound));
+    assert_eq!(result.err(), Some(Error::MemOutOfBound));
 }
 
 #[test]

--- a/tests/test_versions.rs
+++ b/tests/test_versions.rs
@@ -387,7 +387,7 @@ pub fn test_rust_version0_unaligned64() {
         DefaultMachineBuilder::<DefaultCoreMachine<u64, Mem>>::new(core_machine).build();
     let result = machine.load_program(&buffer, &vec![program.into()]);
     assert!(result.is_err());
-    assert_eq!(result.err(), Some(Error::InvalidPermission));
+    assert_eq!(result.err(), Some(Error::MemWriteOnExecutablePage));
 }
 
 #[test]
@@ -409,7 +409,7 @@ pub fn test_asm_version0_unaligned64() {
     let mut machine = AsmMachine::new(core, None);
     let result = machine.load_program(&buffer, &vec![program.into()]);
     assert!(result.is_err());
-    assert_eq!(result.err(), Some(Error::InvalidPermission));
+    assert_eq!(result.err(), Some(Error::MemWriteOnExecutablePage));
 }
 
 #[test]
@@ -433,7 +433,7 @@ pub fn test_aot_version0_unaligned64() {
     let mut machine = AsmMachine::new(core, Some(&code));
     let result = machine.load_program(&buffer, &vec![program.into()]);
     assert!(result.is_err());
-    assert_eq!(result.err(), Some(Error::InvalidPermission));
+    assert_eq!(result.err(), Some(Error::MemWriteOnExecutablePage));
 }
 
 #[test]


### PR DESCRIPTION

- Optimize error's fmt output, making it easier for users to debug.

- Distinguish between 
    - `AotLimitReachedMaximumTempRegisters`, 
    - `AotLimitReachedMaximumSections`, 
    - `AotLimitReachedMaximumLabels`, 
    - `AotLimitReachedMaximumDummySections`, 
    - `AotSectionIsEmpty`, 
    - `AotSectionOverlaps`, 
    - `AotOutOfBoundDueToNotStartOfBasicBlock`, 
    - `ElfSegmentAddrOrSizeError`, 
    - `MemOutOfBound`, 
    - `MemOutOfStack` 
    from `OutOfBound`

- Distinguish between 
    - `MemWriteOnExecutablePage`, 
    - `MemWriteOnFreezedPage`, 
    - `ElfSegmentUnreadable`, 
    - `ElfSegmentWritableAndExecutable`
    from `InvalidPermission`

- Rename `InvalidCycles` to `CyclesExceeded`
- Rename `Unaligned` to `MemPageUnalignedAccess`
- Rename `Dynasm` to `AotDynasm`
- Rename `InvalidElfBits` to `ElfBits`