### PR TITLE
chore: print on build command error

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -39,13 +39,24 @@ fn main() {
         let enable_aot = cfg!(feature = "aot");
 
         fn run_command(mut c: Command) {
-            let status = c.status().unwrap_or_else(|e| {
-                panic!("Error running command: {:?} error: {:?}", c, e);
+            println!("Running Command[{:?}]", c);
+
+            let output = c.output().unwrap_or_else(|e| {
+                panic!("Error running Command[{:?}], error: {:?}", c, e);
             });
-            if !status.success() {
+
+            if !output.status.success() {
+                use std::io::{self, Write};
+                io::stdout()
+                    .write_all(&output.stdout)
+                    .expect("stdout write");
+                io::stderr()
+                    .write_all(&output.stderr)
+                    .expect("stderr write");
+
                 panic!(
-                    "Command {:? }exits with non-success status: {:?}",
-                    c, status
+                    "Command[{:?}] exits with non-success status: {:?}",
+                    c, output.status
                 );
             }
         }


### PR DESCRIPTION
Print stdout and stderr on build command error.

By default, `std::process::Command` only prints stderr on error. Stdout may help to figure out why `yasm` failed in CI like in https://github.com/nervosnetwork/ckb/runs/5343852953?check_suite_focus=true