### PR TITLE
Fix vrgather.vv, when sew more than 64

### DIFF
--- a/src/instructions/execute.rs
+++ b/src/instructions/execute.rs
@@ -2137,17 +2137,11 @@ pub fn execute_instruction<Mac: Machine>(
                 let index = {
                     let mut data = machine.element_ref(i.vs1(), sew, j).to_vec();
                     data.resize(128, 0);
-                    let val = E1024::get(&data);
-
-                    if val > E1024::from(u64::MAX) {
-                        u64::MAX
-                    } else {
-                        E64::get(&data[0..8]).u64()
-                    }
+                    E1024::get(&data)
                 };
 
-                if index < machine.vlmax() {
-                    let data = machine.element_ref(i.vs2(), sew, index as usize).to_vec();
+                if index < E1024::from(machine.vlmax()) {
+                    let data = machine.element_ref(i.vs2(), sew, index.u64() as usize).to_vec();
                     machine.element_mut(i.vd(), sew, j).copy_from_slice(&data);
                 } else {
                     let data = vec![0; sew as usize >> 3];

--- a/src/instructions/execute.rs
+++ b/src/instructions/execute.rs
@@ -2134,18 +2134,18 @@ pub fn execute_instruction<Mac: Machine>(
                 if i.vm() == 0 && machine.get_bit(0, j) {
                     continue;
                 }
-                let mut data = machine.element_ref(i.vs1(), sew, j).to_vec();
-                if data.len() > 8 {
-                    for i in 8..data.len() {
-                        if data[i] != 0 {
-                            data = Vec::from([0xFF; 8]);
-                            break;
-                        }
+                let index = {
+                    let mut data = machine.element_ref(i.vs1(), sew, j).to_vec();
+                    data.resize(128, 0);
+                    let val = E1024::get(&data);
+
+                    if val > E1024::from(u64::MAX) {
+                        u64::MAX
+                    } else {
+                        E64::get(&data[0..8]).u64()
                     }
-                } else {
-                    data.resize(8, 0);
-                }
-                let index = E64::get(&data).u64();
+                };
+
                 if index < machine.vlmax() {
                     let data = machine.element_ref(i.vs2(), sew, index as usize).to_vec();
                     machine.element_mut(i.vd(), sew, j).copy_from_slice(&data);

--- a/src/instructions/execute.rs
+++ b/src/instructions/execute.rs
@@ -2135,7 +2135,16 @@ pub fn execute_instruction<Mac: Machine>(
                     continue;
                 }
                 let mut data = machine.element_ref(i.vs1(), sew, j).to_vec();
-                data.resize(8, 0);
+                if data.len() > 8 {
+                    for i in 8..data.len() {
+                        if data[i] != 0 {
+                            data = Vec::from([0xFF; 8]);
+                            break;
+                        }
+                    }
+                } else {
+                    data.resize(8, 0);
+                }
                 let index = E64::get(&data).u64();
                 if index < machine.vlmax() {
                     let data = machine.element_ref(i.vs2(), sew, index as usize).to_vec();


### PR DESCRIPTION
When sew more than 64, high-order data may be lost.