### PR TITLE
Fix vssubu.vx, unsigned should be used here

### DIFF
--- a/src/instructions/execute.rs
+++ b/src/instructions/execute.rs
@@ -1578,7 +1578,7 @@ pub fn execute_instruction<Mac: Machine>(
             v_vv_loop_u!(inst, machine, alu::ssubu);
         }
         insts::OP_VSSUBU_VX => {
-            v_vx_loop_s!(inst, machine, alu::ssubu);
+            v_vx_loop_u!(inst, machine, alu::ssubu);
         }
         insts::OP_VSSUB_VV => {
             v_vv_loop_s!(inst, machine, alu::ssub);


### PR DESCRIPTION
Unsigned should be used here.

[The testcase](https://github.com/joii2020/rvv-testcases/commit/4d5c2fa96f585538da4edea7129cad1460c07c38#diff-52e671029b8745c3d65259d39ba168a40012fd40a7bd82d9cd827e8ec84cccbfR544)
