### PR TITLE
Save program bytes in DefaultCoreMachine

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ aot = ["asm"]
 enable-chaos-mode-by-default = ["ckb-vm-definitions/enable-chaos-mode-by-default"]
 # Disable slow tests to run miri on CI
 miri-ci = []
+pprof = []
 
 [dependencies]
 byteorder = "1"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -209,7 +209,9 @@ jobs:
       - script: |
           sudo apt-get install -y qemu binfmt-support qemu-user-static
           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-          docker run --rm -v `pwd`:/code -t arm64v8/rust bash -c "cd /code && cargo test --features=asm"
+          echo "Comment: updating crates.io cause oom in arm docker, use -v /usr/local/cargo/registry/:/usr/local/cargo/registry/ to skip this problem"
+          cargo update
+          docker run --rm -v `pwd`:/code -v /home/vsts/.cargo/registry/:/usr/local/cargo/registry/ -t arm64v8/rust bash -c "cd /code && cargo test --features=asm"
         displayName: Run ci-asm on arm64 machines
 
   - job: LinuxArm64TestSuite

--- a/src/machine/asm/mod.rs
+++ b/src/machine/asm/mod.rs
@@ -412,6 +412,11 @@ impl SupportMachine for Box<AsmCoreMachine> {
     fn set_running(&mut self, running: bool) {
         self.running = if running { 1 } else { 0 }
     }
+
+    #[cfg(feature = "pprof")]
+    fn code(&self) -> &Bytes {
+        unreachable!()
+    }
 }
 
 pub struct AotCode {


### PR DESCRIPTION
The caller now has a chance to get the code loaded via the exec syscall.