### PR TITLE
chore: use Arc instead of lifetime parameter

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ trigger:
 
 variables:
   RUST_BACKTRACE: full
-  TEST_SUITE_COMMIT: ff49a1dfb3c12be9dc18073133d660f0dd176662
+  TEST_SUITE_COMMIT: 7d4bc62021e24758c01c70a9a6ce3a93666269ec
 
 jobs:
   - job: WinCI

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,7 @@ trigger:
 
 variables:
   RUST_BACKTRACE: full
-  TEST_SUITE_COMMIT: 7d4bc62021e24758c01c70a9a6ce3a93666269ec
+  TEST_SUITE_COMMIT: a1fb578bf802ce1155565d509402e7e00a1c280b
 
 jobs:
   - job: WinCI

--- a/benches/vm_benchmark.rs
+++ b/benches/vm_benchmark.rs
@@ -58,7 +58,7 @@ fn aot_benchmark(c: &mut Criterion) {
                                       "foo",
                                       "bar"].into_iter().map(|a| a.into()).collect();
         let mut aot_machine = AotCompilingMachine::load(&buffer.clone(), None, ISA_IMC, VERSION0).unwrap();
-        let result = Rc::new(aot_machine.compile().unwrap());
+        let result = std::sync::Arc::new(aot_machine.compile().unwrap());
 
         b.iter(|| {
             let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::max_value());

--- a/benches/vm_benchmark.rs
+++ b/benches/vm_benchmark.rs
@@ -58,12 +58,12 @@ fn aot_benchmark(c: &mut Criterion) {
                                       "foo",
                                       "bar"].into_iter().map(|a| a.into()).collect();
         let mut aot_machine = AotCompilingMachine::load(&buffer.clone(), None, ISA_IMC, VERSION0).unwrap();
-        let result = aot_machine.compile().unwrap();
+        let result = Rc::new(aot_machine.compile().unwrap());
 
         b.iter(|| {
             let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::max_value());
             let core = DefaultMachineBuilder::new(asm_core).build();
-            let mut machine = AsmMachine::new(core, Some(&result));
+            let mut machine = AsmMachine::new(core, Some(result.clone()));
             machine.load_program(&buffer, &args[..]).unwrap();
             machine.run().unwrap()
         });

--- a/examples/ckb-vm-runner.rs
+++ b/examples/ckb-vm-runner.rs
@@ -105,7 +105,8 @@ fn main_aot(code: Bytes, args: Vec<Bytes>) -> Result<(), Box<dyn std::error::Err
             .instruction_cycle_func(Box::new(instruction_cycles))
             .syscall(Box::new(DebugSyscall {}))
             .build();
-    let mut machine = ckb_vm::machine::asm::AsmMachine::new(core, Some(std::rc::Rc::new(aot_code)));
+    let mut machine =
+        ckb_vm::machine::asm::AsmMachine::new(core, Some(std::sync::Arc::new(aot_code)));
     machine.load_program(&code, &args)?;
     let exit = machine.run();
     let cycles = machine.machine.cycles();

--- a/examples/ckb-vm-runner.rs
+++ b/examples/ckb-vm-runner.rs
@@ -105,7 +105,7 @@ fn main_aot(code: Bytes, args: Vec<Bytes>) -> Result<(), Box<dyn std::error::Err
             .instruction_cycle_func(Box::new(instruction_cycles))
             .syscall(Box::new(DebugSyscall {}))
             .build();
-    let mut machine = ckb_vm::machine::asm::AsmMachine::new(core, Some(&aot_code));
+    let mut machine = ckb_vm::machine::asm::AsmMachine::new(core, Some(std::rc::Rc::new(aot_code)));
     machine.load_program(&code, &args)?;
     let exit = machine.run();
     let cycles = machine.machine.cycles();

--- a/src/machine/asm/mod.rs
+++ b/src/machine/asm/mod.rs
@@ -1,5 +1,17 @@
-use std::mem::transmute;
-
+use crate::{
+    decoder::{build_decoder, Decoder},
+    instructions::{
+        blank_instruction, execute_instruction, extract_opcode, instruction_length,
+        is_basic_block_end_instruction,
+    },
+    machine::VERSION0,
+    memory::{
+        fill_page_data, get_page_indices, memset, round_page_down, round_page_up, FLAG_DIRTY,
+        FLAG_EXECUTABLE, FLAG_FREEZED, FLAG_WRITABLE, FLAG_WXORX_BIT,
+    },
+    CoreMachine, DefaultMachine, Error, Machine, Memory, SupportMachine, MEMORY_FRAME_SHIFTS,
+    RISCV_MAX_MEMORY, RISCV_PAGES, RISCV_PAGESIZE,
+};
 use byteorder::{ByteOrder, LittleEndian};
 use bytes::Bytes;
 pub use ckb_vm_definitions::asm::AsmCoreMachine;
@@ -17,21 +29,8 @@ use libc::c_uchar;
 use memmap::Mmap;
 use rand::{prelude::RngCore, SeedableRng};
 use std::collections::HashMap;
-
-use crate::{
-    decoder::{build_decoder, Decoder},
-    instructions::{
-        blank_instruction, execute_instruction, extract_opcode, instruction_length,
-        is_basic_block_end_instruction,
-    },
-    machine::VERSION0,
-    memory::{
-        fill_page_data, get_page_indices, memset, round_page_down, round_page_up, FLAG_DIRTY,
-        FLAG_EXECUTABLE, FLAG_FREEZED, FLAG_WRITABLE, FLAG_WXORX_BIT,
-    },
-    CoreMachine, DefaultMachine, Error, Machine, Memory, SupportMachine, MEMORY_FRAME_SHIFTS,
-    RISCV_MAX_MEMORY, RISCV_PAGES, RISCV_PAGESIZE,
-};
+use std::mem::transmute;
+use std::rc::Rc;
 
 impl CoreMachine for Box<AsmCoreMachine> {
     type REG = u64;
@@ -433,9 +432,9 @@ impl AotCode {
     }
 }
 
-pub struct AsmMachine<'a> {
-    pub machine: DefaultMachine<'a, Box<AsmCoreMachine>>,
-    pub aot_code: Option<&'a AotCode>,
+pub struct AsmMachine {
+    pub machine: DefaultMachine<Box<AsmCoreMachine>>,
+    pub aot_code: Option<Rc<AotCode>>,
 }
 
 extern "C" {
@@ -445,10 +444,10 @@ extern "C" {
     fn ckb_vm_asm_labels();
 }
 
-impl<'a> AsmMachine<'a> {
+impl AsmMachine {
     pub fn new(
-        machine: DefaultMachine<'a, Box<AsmCoreMachine>>,
-        aot_code: Option<&'a AotCode>,
+        machine: DefaultMachine<Box<AsmCoreMachine>>,
+        aot_code: Option<Rc<AotCode>>,
     ) -> Self {
         Self { machine, aot_code }
     }

--- a/src/machine/asm/mod.rs
+++ b/src/machine/asm/mod.rs
@@ -30,7 +30,7 @@ use memmap::Mmap;
 use rand::{prelude::RngCore, SeedableRng};
 use std::collections::HashMap;
 use std::mem::transmute;
-use std::rc::Rc;
+use std::sync::Arc;
 
 impl CoreMachine for Box<AsmCoreMachine> {
     type REG = u64;
@@ -434,7 +434,7 @@ impl AotCode {
 
 pub struct AsmMachine {
     pub machine: DefaultMachine<Box<AsmCoreMachine>>,
-    pub aot_code: Option<Rc<AotCode>>,
+    pub aot_code: Option<Arc<AotCode>>,
 }
 
 extern "C" {
@@ -447,7 +447,7 @@ extern "C" {
 impl AsmMachine {
     pub fn new(
         machine: DefaultMachine<Box<AsmCoreMachine>>,
-        aot_code: Option<Rc<AotCode>>,
+        aot_code: Option<Arc<AotCode>>,
     ) -> Self {
         Self { machine, aot_code }
     }

--- a/src/machine/trace.rs
+++ b/src/machine/trace.rs
@@ -32,13 +32,13 @@ fn calculate_slot(addr: u64) -> usize {
     (addr as usize >> TRACE_ADDRESS_SHIFTS) & TRACE_MASK
 }
 
-pub struct TraceMachine<'a, Inner> {
-    pub machine: DefaultMachine<'a, Inner>,
+pub struct TraceMachine<Inner> {
+    pub machine: DefaultMachine<Inner>,
 
     traces: Vec<Trace>,
 }
 
-impl<Inner: SupportMachine> CoreMachine for TraceMachine<'_, Inner> {
+impl<Inner: SupportMachine> CoreMachine for TraceMachine<Inner> {
     type REG = <Inner as CoreMachine>::REG;
     type MEM = <Inner as CoreMachine>::MEM;
 
@@ -79,7 +79,7 @@ impl<Inner: SupportMachine> CoreMachine for TraceMachine<'_, Inner> {
     }
 }
 
-impl<Inner: SupportMachine> Machine for TraceMachine<'_, Inner> {
+impl<Inner: SupportMachine> Machine for TraceMachine<Inner> {
     fn ecall(&mut self) -> Result<(), Error> {
         self.machine.ecall()
     }
@@ -89,8 +89,8 @@ impl<Inner: SupportMachine> Machine for TraceMachine<'_, Inner> {
     }
 }
 
-impl<'a, Inner: SupportMachine> TraceMachine<'a, Inner> {
-    pub fn new(machine: DefaultMachine<'a, Inner>) -> Self {
+impl<Inner: SupportMachine> TraceMachine<Inner> {
+    pub fn new(machine: DefaultMachine<Inner>) -> Self {
         Self {
             machine,
             traces: vec![],

--- a/tests/machine_build.rs
+++ b/tests/machine_build.rs
@@ -7,7 +7,6 @@ use bytes::Bytes;
 use ckb_vm::machine::{trace::TraceMachine, DefaultCoreMachine, VERSION1};
 use ckb_vm::{DefaultMachineBuilder, ISA_B, ISA_IMC, ISA_MOP};
 use ckb_vm::{Instruction, SparseMemory, WXorXMemory};
-use std::rc::Rc;
 
 pub fn instruction_cycle_func(_: Instruction) -> u64 {
     1
@@ -43,7 +42,7 @@ pub fn aot_v1_imcb(path: &str, code: AotCode) -> AsmMachine {
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
         .instruction_cycle_func(Box::new(instruction_cycle_func))
         .build();
-    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
+    let mut machine = AsmMachine::new(core, Some(std::sync::Arc::new(code)));
     machine
         .load_program(&buffer, &vec![Bytes::from("main")])
         .unwrap();
@@ -102,7 +101,7 @@ pub fn aot_v1_mop(path: &str, args: Vec<Bytes>, code: AotCode) -> AsmMachine {
         .build();
     let mut argv = vec![Bytes::from("main")];
     argv.extend_from_slice(&args);
-    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
+    let mut machine = AsmMachine::new(core, Some(std::sync::Arc::new(code)));
     machine.load_program(&buffer, &argv).unwrap();
     machine
 }

--- a/tests/machine_build.rs
+++ b/tests/machine_build.rs
@@ -3,18 +3,18 @@ use ckb_vm::machine::asm::{AsmCoreMachine, AsmMachine};
 #[cfg(has_aot)]
 use ckb_vm::machine::{aot::AotCompilingMachine, asm::AotCode};
 
+use bytes::Bytes;
 use ckb_vm::machine::{trace::TraceMachine, DefaultCoreMachine, VERSION1};
 use ckb_vm::{DefaultMachineBuilder, ISA_B, ISA_IMC, ISA_MOP};
 use ckb_vm::{Instruction, SparseMemory, WXorXMemory};
-
-use bytes::Bytes;
+use std::rc::Rc;
 
 pub fn instruction_cycle_func(_: Instruction) -> u64 {
     1
 }
 
 #[cfg(has_asm)]
-pub fn asm_v1_imcb<'a>(path: &str) -> AsmMachine<'a> {
+pub fn asm_v1_imcb(path: &str) -> AsmMachine {
     let buffer: Bytes = std::fs::read(path).unwrap().into();
     let asm_core = AsmCoreMachine::new(ISA_IMC | ISA_B, VERSION1, u64::max_value());
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
@@ -36,14 +36,14 @@ pub fn aot_v1_imcb_code(path: &str) -> AotCode {
 }
 
 #[cfg(has_aot)]
-pub fn aot_v1_imcb<'a>(path: &str, code: &'a AotCode) -> AsmMachine<'a> {
+pub fn aot_v1_imcb(path: &str, code: AotCode) -> AsmMachine {
     let buffer: Bytes = std::fs::read(path).unwrap().into();
 
     let asm_core = AsmCoreMachine::new(ISA_IMC | ISA_B, VERSION1, u64::max_value());
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
         .instruction_cycle_func(Box::new(instruction_cycle_func))
         .build();
-    let mut machine = AsmMachine::new(core, Some(code));
+    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
     machine
         .load_program(&buffer, &vec![Bytes::from("main")])
         .unwrap();
@@ -71,7 +71,7 @@ pub fn int_v1_imcb(
 }
 
 #[cfg(has_asm)]
-pub fn asm_v1_mop<'a>(path: &str, args: Vec<Bytes>) -> AsmMachine<'a> {
+pub fn asm_v1_mop(path: &str, args: Vec<Bytes>) -> AsmMachine {
     let buffer: Bytes = std::fs::read(path).unwrap().into();
     let asm_core = AsmCoreMachine::new(ISA_IMC | ISA_B | ISA_MOP, VERSION1, u64::max_value());
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
@@ -93,7 +93,7 @@ pub fn aot_v1_mop_code(path: &str) -> AotCode {
 }
 
 #[cfg(has_aot)]
-pub fn aot_v1_mop<'a>(path: &str, args: Vec<Bytes>, code: &'a AotCode) -> AsmMachine<'a> {
+pub fn aot_v1_mop(path: &str, args: Vec<Bytes>, code: AotCode) -> AsmMachine {
     let buffer: Bytes = std::fs::read(path).unwrap().into();
 
     let asm_core = AsmCoreMachine::new(ISA_IMC | ISA_B | ISA_MOP, VERSION1, u64::max_value());
@@ -102,7 +102,7 @@ pub fn aot_v1_mop<'a>(path: &str, args: Vec<Bytes>, code: &'a AotCode) -> AsmMac
         .build();
     let mut argv = vec![Bytes::from("main")];
     argv.extend_from_slice(&args);
-    let mut machine = AsmMachine::new(core, Some(code));
+    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
     machine.load_program(&buffer, &argv).unwrap();
     machine
 }

--- a/tests/test_aot.rs
+++ b/tests/test_aot.rs
@@ -11,7 +11,6 @@ use ckb_vm::{
     Debugger, DefaultMachineBuilder, Error, Instruction, Register, SupportMachine, Syscalls,
     ISA_IMC,
 };
-use std::rc::Rc;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
 use std::{fs, u64};
@@ -23,7 +22,7 @@ pub fn test_aot_simple64() {
     let code = aot_machine.compile().unwrap();
     let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::max_value());
     let core = DefaultMachineBuilder::new(asm_core).build();
-    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
+    let mut machine = AsmMachine::new(core, Some(Arc::new(code)));
     machine
         .load_program(&buffer, &vec!["simple".into()])
         .unwrap();
@@ -64,7 +63,7 @@ pub fn test_aot_with_custom_syscall() {
     let core = DefaultMachineBuilder::new(asm_core)
         .syscall(Box::new(CustomSyscall {}))
         .build();
-    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
+    let mut machine = AsmMachine::new(core, Some(Arc::new(code)));
     machine
         .load_program(&buffer, &vec!["syscall".into()])
         .unwrap();
@@ -101,7 +100,7 @@ pub fn test_aot_ebreak() {
             value: Arc::clone(&value),
         }))
         .build();
-    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
+    let mut machine = AsmMachine::new(core, Some(Arc::new(code)));
     machine
         .load_program(&buffer, &vec!["ebreak".into()])
         .unwrap();
@@ -126,7 +125,7 @@ pub fn test_aot_simple_cycles() {
         AotCompilingMachine::load(&buffer, Some(Box::new(dummy_cycle_func)), ISA_IMC, VERSION0)
             .unwrap();
     let code = aot_machine.compile().unwrap();
-    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
+    let mut machine = AsmMachine::new(core, Some(Arc::new(code)));
     machine
         .load_program(&buffer, &vec!["syscall".into()])
         .unwrap();
@@ -149,7 +148,7 @@ pub fn test_aot_simple_max_cycles_reached() {
         AotCompilingMachine::load(&buffer, Some(Box::new(dummy_cycle_func)), ISA_IMC, VERSION0)
             .unwrap();
     let code = aot_machine.compile().unwrap();
-    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
+    let mut machine = AsmMachine::new(core, Some(Arc::new(code)));
     machine
         .load_program(&buffer, &vec!["syscall".into()])
         .unwrap();
@@ -165,7 +164,7 @@ pub fn test_aot_trace() {
     let code = aot_machine.compile().unwrap();
     let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::max_value());
     let core = DefaultMachineBuilder::new(asm_core).build();
-    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
+    let mut machine = AsmMachine::new(core, Some(Arc::new(code)));
     machine
         .load_program(&buffer, &vec!["simple".into()])
         .unwrap();
@@ -181,7 +180,7 @@ pub fn test_aot_jump0() {
     let code = aot_machine.compile().unwrap();
     let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::max_value());
     let core = DefaultMachineBuilder::new(asm_core).build();
-    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
+    let mut machine = AsmMachine::new(core, Some(Arc::new(code)));
     machine
         .load_program(&buffer, &vec!["jump0_64".into()])
         .unwrap();
@@ -199,7 +198,7 @@ pub fn test_aot_write_large_address() {
     let code = aot_machine.compile().unwrap();
     let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::max_value());
     let core = DefaultMachineBuilder::new(asm_core).build();
-    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
+    let mut machine = AsmMachine::new(core, Some(Arc::new(code)));
     machine
         .load_program(&buffer, &vec!["write_large_address64".into()])
         .unwrap();
@@ -215,7 +214,7 @@ pub fn test_aot_misaligned_jump64() {
     let code = aot_machine.compile().unwrap();
     let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::max_value());
     let core = DefaultMachineBuilder::new(asm_core).build();
-    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
+    let mut machine = AsmMachine::new(core, Some(Arc::new(code)));
     machine
         .load_program(&buffer, &vec!["write_large_address64".into()])
         .unwrap();
@@ -230,7 +229,7 @@ pub fn test_aot_mulw64() {
     let code = aot_machine.compile().unwrap();
     let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::max_value());
     let core = DefaultMachineBuilder::new(asm_core).build();
-    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
+    let mut machine = AsmMachine::new(core, Some(Arc::new(code)));
     machine
         .load_program(&buffer, &vec!["mulw64".into()])
         .unwrap();
@@ -246,7 +245,7 @@ pub fn test_aot_invalid_read64() {
     let code = aot_machine.compile().unwrap();
     let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::max_value());
     let core = DefaultMachineBuilder::new(asm_core).build();
-    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
+    let mut machine = AsmMachine::new(core, Some(Arc::new(code)));
     machine
         .load_program(&buffer, &vec!["invalid_read64".into()])
         .unwrap();
@@ -262,7 +261,7 @@ pub fn test_aot_load_elf_crash_64() {
     let code = aot_machine.compile().unwrap();
     let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::max_value());
     let core = DefaultMachineBuilder::new(asm_core).build();
-    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
+    let mut machine = AsmMachine::new(core, Some(Arc::new(code)));
     machine
         .load_program(&buffer, &vec!["load_elf_crash_64".into()])
         .unwrap();
@@ -277,7 +276,7 @@ pub fn test_aot_wxorx_crash_64() {
     let code = aot_machine.compile().unwrap();
     let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::max_value());
     let core = DefaultMachineBuilder::new(asm_core).build();
-    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
+    let mut machine = AsmMachine::new(core, Some(Arc::new(code)));
     machine
         .load_program(&buffer, &vec!["wxorx_crash_64".into()])
         .unwrap();
@@ -317,7 +316,7 @@ pub fn test_aot_alloc_many() {
     let code = aot_machine.compile().unwrap();
     let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::max_value());
     let core = DefaultMachineBuilder::new(asm_core).build();
-    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
+    let mut machine = AsmMachine::new(core, Some(Arc::new(code)));
     machine
         .load_program(&buffer, &vec!["alloc_many".into()])
         .unwrap();
@@ -335,7 +334,7 @@ pub fn test_aot_chaos_seed() {
     asm_core1.chaos_mode = 1;
     asm_core1.chaos_seed = 100;
     let core1 = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core1).build();
-    let mut machine1 = AsmMachine::new(core1, Some(Rc::new(code1)));
+    let mut machine1 = AsmMachine::new(core1, Some(Arc::new(code1)));
     machine1
         .load_program(&buffer, &vec!["read_memory".into()])
         .unwrap();
@@ -348,7 +347,7 @@ pub fn test_aot_chaos_seed() {
     asm_core2.chaos_mode = 1;
     asm_core2.chaos_seed = 100;
     let core2 = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core2).build();
-    let mut machine2 = AsmMachine::new(core2, Some(Rc::new(code2)));
+    let mut machine2 = AsmMachine::new(core2, Some(Arc::new(code2)));
     machine2
         .load_program(&buffer, &vec!["read_memory".into()])
         .unwrap();
@@ -368,7 +367,7 @@ pub fn test_aot_rvc_pageend() {
     let code = aot_machine.compile().unwrap();
     let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::max_value());
     let core = DefaultMachineBuilder::new(asm_core).build();
-    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
+    let mut machine = AsmMachine::new(core, Some(Arc::new(code)));
     machine
         .load_program(&buffer, &vec!["rvc_pageend".into()])
         .unwrap();
@@ -412,7 +411,7 @@ pub fn test_aot_outofcycles_in_syscall() {
         .instruction_cycle_func(Box::new(|_| 1))
         .syscall(Box::new(OutOfCyclesSyscall {}))
         .build();
-    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
+    let mut machine = AsmMachine::new(core, Some(Arc::new(code)));
     machine
         .load_program(&buffer, &vec!["syscall".into()])
         .unwrap();
@@ -435,7 +434,7 @@ pub fn test_aot_cycles_overflow() {
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
         .instruction_cycle_func(Box::new(|_| 1))
         .build();
-    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
+    let mut machine = AsmMachine::new(core, Some(Arc::new(code)));
     machine
         .load_program(&buffer, &vec!["simple64".into()])
         .unwrap();

--- a/tests/test_aot.rs
+++ b/tests/test_aot.rs
@@ -11,6 +11,7 @@ use ckb_vm::{
     Debugger, DefaultMachineBuilder, Error, Instruction, Register, SupportMachine, Syscalls,
     ISA_IMC,
 };
+use std::rc::Rc;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
 use std::{fs, u64};
@@ -22,7 +23,7 @@ pub fn test_aot_simple64() {
     let code = aot_machine.compile().unwrap();
     let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::max_value());
     let core = DefaultMachineBuilder::new(asm_core).build();
-    let mut machine = AsmMachine::new(core, Some(&code));
+    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
     machine
         .load_program(&buffer, &vec!["simple".into()])
         .unwrap();
@@ -63,7 +64,7 @@ pub fn test_aot_with_custom_syscall() {
     let core = DefaultMachineBuilder::new(asm_core)
         .syscall(Box::new(CustomSyscall {}))
         .build();
-    let mut machine = AsmMachine::new(core, Some(&code));
+    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
     machine
         .load_program(&buffer, &vec!["syscall".into()])
         .unwrap();
@@ -100,7 +101,7 @@ pub fn test_aot_ebreak() {
             value: Arc::clone(&value),
         }))
         .build();
-    let mut machine = AsmMachine::new(core, Some(&code));
+    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
     machine
         .load_program(&buffer, &vec!["ebreak".into()])
         .unwrap();
@@ -125,7 +126,7 @@ pub fn test_aot_simple_cycles() {
         AotCompilingMachine::load(&buffer, Some(Box::new(dummy_cycle_func)), ISA_IMC, VERSION0)
             .unwrap();
     let code = aot_machine.compile().unwrap();
-    let mut machine = AsmMachine::new(core, Some(&code));
+    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
     machine
         .load_program(&buffer, &vec!["syscall".into()])
         .unwrap();
@@ -148,7 +149,7 @@ pub fn test_aot_simple_max_cycles_reached() {
         AotCompilingMachine::load(&buffer, Some(Box::new(dummy_cycle_func)), ISA_IMC, VERSION0)
             .unwrap();
     let code = aot_machine.compile().unwrap();
-    let mut machine = AsmMachine::new(core, Some(&code));
+    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
     machine
         .load_program(&buffer, &vec!["syscall".into()])
         .unwrap();
@@ -164,7 +165,7 @@ pub fn test_aot_trace() {
     let code = aot_machine.compile().unwrap();
     let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::max_value());
     let core = DefaultMachineBuilder::new(asm_core).build();
-    let mut machine = AsmMachine::new(core, Some(&code));
+    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
     machine
         .load_program(&buffer, &vec!["simple".into()])
         .unwrap();
@@ -180,7 +181,7 @@ pub fn test_aot_jump0() {
     let code = aot_machine.compile().unwrap();
     let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::max_value());
     let core = DefaultMachineBuilder::new(asm_core).build();
-    let mut machine = AsmMachine::new(core, Some(&code));
+    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
     machine
         .load_program(&buffer, &vec!["jump0_64".into()])
         .unwrap();
@@ -198,7 +199,7 @@ pub fn test_aot_write_large_address() {
     let code = aot_machine.compile().unwrap();
     let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::max_value());
     let core = DefaultMachineBuilder::new(asm_core).build();
-    let mut machine = AsmMachine::new(core, Some(&code));
+    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
     machine
         .load_program(&buffer, &vec!["write_large_address64".into()])
         .unwrap();
@@ -214,7 +215,7 @@ pub fn test_aot_misaligned_jump64() {
     let code = aot_machine.compile().unwrap();
     let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::max_value());
     let core = DefaultMachineBuilder::new(asm_core).build();
-    let mut machine = AsmMachine::new(core, Some(&code));
+    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
     machine
         .load_program(&buffer, &vec!["write_large_address64".into()])
         .unwrap();
@@ -229,7 +230,7 @@ pub fn test_aot_mulw64() {
     let code = aot_machine.compile().unwrap();
     let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::max_value());
     let core = DefaultMachineBuilder::new(asm_core).build();
-    let mut machine = AsmMachine::new(core, Some(&code));
+    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
     machine
         .load_program(&buffer, &vec!["mulw64".into()])
         .unwrap();
@@ -245,7 +246,7 @@ pub fn test_aot_invalid_read64() {
     let code = aot_machine.compile().unwrap();
     let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::max_value());
     let core = DefaultMachineBuilder::new(asm_core).build();
-    let mut machine = AsmMachine::new(core, Some(&code));
+    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
     machine
         .load_program(&buffer, &vec!["invalid_read64".into()])
         .unwrap();
@@ -261,7 +262,7 @@ pub fn test_aot_load_elf_crash_64() {
     let code = aot_machine.compile().unwrap();
     let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::max_value());
     let core = DefaultMachineBuilder::new(asm_core).build();
-    let mut machine = AsmMachine::new(core, Some(&code));
+    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
     machine
         .load_program(&buffer, &vec!["load_elf_crash_64".into()])
         .unwrap();
@@ -276,7 +277,7 @@ pub fn test_aot_wxorx_crash_64() {
     let code = aot_machine.compile().unwrap();
     let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::max_value());
     let core = DefaultMachineBuilder::new(asm_core).build();
-    let mut machine = AsmMachine::new(core, Some(&code));
+    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
     machine
         .load_program(&buffer, &vec!["wxorx_crash_64".into()])
         .unwrap();
@@ -316,7 +317,7 @@ pub fn test_aot_alloc_many() {
     let code = aot_machine.compile().unwrap();
     let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::max_value());
     let core = DefaultMachineBuilder::new(asm_core).build();
-    let mut machine = AsmMachine::new(core, Some(&code));
+    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
     machine
         .load_program(&buffer, &vec!["alloc_many".into()])
         .unwrap();
@@ -334,7 +335,7 @@ pub fn test_aot_chaos_seed() {
     asm_core1.chaos_mode = 1;
     asm_core1.chaos_seed = 100;
     let core1 = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core1).build();
-    let mut machine1 = AsmMachine::new(core1, Some(&code1));
+    let mut machine1 = AsmMachine::new(core1, Some(Rc::new(code1)));
     machine1
         .load_program(&buffer, &vec!["read_memory".into()])
         .unwrap();
@@ -347,7 +348,7 @@ pub fn test_aot_chaos_seed() {
     asm_core2.chaos_mode = 1;
     asm_core2.chaos_seed = 100;
     let core2 = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core2).build();
-    let mut machine2 = AsmMachine::new(core2, Some(&code2));
+    let mut machine2 = AsmMachine::new(core2, Some(Rc::new(code2)));
     machine2
         .load_program(&buffer, &vec!["read_memory".into()])
         .unwrap();
@@ -367,7 +368,7 @@ pub fn test_aot_rvc_pageend() {
     let code = aot_machine.compile().unwrap();
     let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::max_value());
     let core = DefaultMachineBuilder::new(asm_core).build();
-    let mut machine = AsmMachine::new(core, Some(&code));
+    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
     machine
         .load_program(&buffer, &vec!["rvc_pageend".into()])
         .unwrap();
@@ -411,7 +412,7 @@ pub fn test_aot_outofcycles_in_syscall() {
         .instruction_cycle_func(Box::new(|_| 1))
         .syscall(Box::new(OutOfCyclesSyscall {}))
         .build();
-    let mut machine = AsmMachine::new(core, Some(&code));
+    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
     machine
         .load_program(&buffer, &vec!["syscall".into()])
         .unwrap();
@@ -434,7 +435,7 @@ pub fn test_aot_cycles_overflow() {
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
         .instruction_cycle_func(Box::new(|_| 1))
         .build();
-    let mut machine = AsmMachine::new(core, Some(&code));
+    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
     machine
         .load_program(&buffer, &vec!["simple64".into()])
         .unwrap();

--- a/tests/test_b_extension.rs
+++ b/tests/test_b_extension.rs
@@ -18,7 +18,7 @@ pub fn test_clzw_bug() {
     #[cfg(has_aot)]
     {
         let code = machine_build::aot_v1_imcb_code("tests/programs/clzw_bug");
-        let mut machine_aot = machine_build::aot_v1_imcb("tests/programs/clzw_bug", &code);
+        let mut machine_aot = machine_build::aot_v1_imcb("tests/programs/clzw_bug", code);
         let ret_aot = machine_aot.run();
         assert!(ret_aot.is_ok());
         assert_eq!(ret_aot.unwrap(), 0);
@@ -44,7 +44,7 @@ pub fn test_sbinvi_aot_load_imm_bug() {
     {
         let code = machine_build::aot_v1_imcb_code("tests/programs/sbinvi_aot_load_imm_bug");
         let mut machine_aot =
-            machine_build::aot_v1_imcb("tests/programs/sbinvi_aot_load_imm_bug", &code);
+            machine_build::aot_v1_imcb("tests/programs/sbinvi_aot_load_imm_bug", code);
         let ret_aot = machine_aot.run();
         assert!(ret_aot.is_ok());
         assert_eq!(ret_aot.unwrap(), 0);
@@ -71,7 +71,7 @@ pub fn test_rorw_in_end_of_aot_block() {
     {
         let code = machine_build::aot_v1_imcb_code("tests/programs/rorw_in_end_of_aot_block");
         let mut machine_aot =
-            machine_build::aot_v1_imcb("tests/programs/rorw_in_end_of_aot_block", &code);
+            machine_build::aot_v1_imcb("tests/programs/rorw_in_end_of_aot_block", code);
         let ret_aot = machine_aot.run();
         assert!(ret_aot.is_ok());
         assert_eq!(ret_aot.unwrap(), 0);
@@ -96,7 +96,7 @@ pub fn test_pcnt() {
     #[cfg(has_aot)]
     {
         let code = machine_build::aot_v1_imcb_code("tests/programs/pcnt");
-        let mut machine_aot = machine_build::aot_v1_imcb("tests/programs/pcnt", &code);
+        let mut machine_aot = machine_build::aot_v1_imcb("tests/programs/pcnt", code);
         let ret_aot = machine_aot.run();
         assert!(ret_aot.is_ok());
         assert_eq!(ret_aot.unwrap(), 0);
@@ -121,7 +121,7 @@ pub fn test_clmul_bug() {
     #[cfg(has_aot)]
     {
         let code = machine_build::aot_v1_imcb_code("tests/programs/clmul_bug");
-        let mut machine_aot = machine_build::aot_v1_imcb("tests/programs/clmul_bug", &code);
+        let mut machine_aot = machine_build::aot_v1_imcb("tests/programs/clmul_bug", code);
         let ret_aot = machine_aot.run();
         assert!(ret_aot.is_ok());
         assert_eq!(ret_aot.unwrap(), 0);
@@ -146,7 +146,7 @@ pub fn test_orc_bug() {
     #[cfg(has_aot)]
     {
         let code = machine_build::aot_v1_imcb_code("tests/programs/orc_bug");
-        let mut machine_aot = machine_build::aot_v1_imcb("tests/programs/orc_bug", &code);
+        let mut machine_aot = machine_build::aot_v1_imcb("tests/programs/orc_bug", code);
         let ret_aot = machine_aot.run();
         assert!(ret_aot.is_ok());
         assert_eq!(ret_aot.unwrap(), 0);

--- a/tests/test_mop.rs
+++ b/tests/test_mop.rs
@@ -31,7 +31,7 @@ pub fn test_mop_wide_multiply() {
     {
         let code = machine_build::aot_v1_mop_code("tests/programs/mop_wide_multiply");
         let mut machine_aot =
-            machine_build::aot_v1_mop("tests/programs/mop_wide_multiply", vec![], &code);
+            machine_build::aot_v1_mop("tests/programs/mop_wide_multiply", vec![], code);
         let ret_aot = machine_aot.run();
         assert!(ret_aot.is_ok());
         assert_eq!(ret_aot.unwrap(), 0);
@@ -66,7 +66,7 @@ pub fn test_mop_wide_divide() {
     {
         let code = machine_build::aot_v1_mop_code("tests/programs/mop_wide_divide");
         let mut machine_aot =
-            machine_build::aot_v1_mop("tests/programs/mop_wide_divide", vec![], &code);
+            machine_build::aot_v1_mop("tests/programs/mop_wide_divide", vec![], code);
         let ret_aot = machine_aot.run();
         assert!(ret_aot.is_ok());
         assert_eq!(ret_aot.unwrap(), 0);
@@ -100,7 +100,7 @@ pub fn test_mop_far_jump() {
     {
         let code = machine_build::aot_v1_mop_code("tests/programs/mop_far_jump");
         let mut machine_aot =
-            machine_build::aot_v1_mop("tests/programs/mop_far_jump", vec![], &code);
+            machine_build::aot_v1_mop("tests/programs/mop_far_jump", vec![], code);
         let ret_aot = machine_aot.run();
         assert!(ret_aot.is_ok());
         assert_eq!(ret_aot.unwrap(), 0);
@@ -134,7 +134,7 @@ pub fn test_mop_ld_32_constants() {
     {
         let code = machine_build::aot_v1_mop_code("tests/programs/mop_ld_signextend_32");
         let mut machine_aot =
-            machine_build::aot_v1_mop("tests/programs/mop_ld_signextend_32", vec![], &code);
+            machine_build::aot_v1_mop("tests/programs/mop_ld_signextend_32", vec![], code);
         let ret_aot = machine_aot.run();
         assert!(ret_aot.is_ok());
         assert_eq!(ret_aot.unwrap(), 0);
@@ -171,7 +171,7 @@ pub fn test_mop_secp256k1() {
     {
         let code = machine_build::aot_v1_mop_code("benches/data/secp256k1_bench");
         let mut machine_aot =
-            machine_build::aot_v1_mop("benches/data/secp256k1_bench", args.clone(), &code);
+            machine_build::aot_v1_mop("benches/data/secp256k1_bench", args.clone(), code);
         let ret_aot = machine_aot.run();
         assert!(ret_aot.is_ok());
         assert_eq!(ret_aot.unwrap(), 0);
@@ -205,7 +205,7 @@ pub fn test_mop_adc() {
     #[cfg(has_aot)]
     {
         let code = machine_build::aot_v1_mop_code("tests/programs/mop_adc");
-        let mut machine_aot = machine_build::aot_v1_mop("tests/programs/mop_adc", vec![], &code);
+        let mut machine_aot = machine_build::aot_v1_mop("tests/programs/mop_adc", vec![], code);
         let ret_aot = machine_aot.run();
         assert!(ret_aot.is_ok());
         assert_eq!(ret_aot.unwrap(), 0);
@@ -239,7 +239,7 @@ pub fn test_mop_sbb() {
     #[cfg(has_aot)]
     {
         let code = machine_build::aot_v1_mop_code("tests/programs/mop_sbb");
-        let mut machine_aot = machine_build::aot_v1_mop("tests/programs/mop_sbb", vec![], &code);
+        let mut machine_aot = machine_build::aot_v1_mop("tests/programs/mop_sbb", vec![], code);
         let ret_aot = machine_aot.run();
         assert!(ret_aot.is_ok());
         assert_eq!(ret_aot.unwrap(), 0);
@@ -275,7 +275,7 @@ pub fn test_mop_random_adc_sbb() {
     {
         let code = machine_build::aot_v1_mop_code("tests/programs/mop_random_adc_sbb");
         let mut machine_aot =
-            machine_build::aot_v1_mop("tests/programs/mop_random_adc_sbb", vec![], &code);
+            machine_build::aot_v1_mop("tests/programs/mop_random_adc_sbb", vec![], code);
         let ret_aot = machine_aot.run();
         assert!(ret_aot.is_ok());
         assert_eq!(ret_aot.unwrap(), 0);
@@ -307,7 +307,7 @@ pub fn test_mop_ld_signextend_32_overflow_bug() {
         let mut machine_aot = machine_build::aot_v1_mop(
             "tests/programs/mop_ld_signextend_32_overflow_bug",
             vec![],
-            &code,
+            code,
         );
         let ret_aot = machine_aot.run();
         assert!(ret_aot.is_ok());
@@ -334,7 +334,7 @@ pub fn test_mop_wide_mul_zero() {
     {
         let code = machine_build::aot_v1_mop_code("tests/programs/mop_wide_mul_zero");
         let mut machine_aot =
-            machine_build::aot_v1_mop("tests/programs/mop_wide_mul_zero", vec![], &code);
+            machine_build::aot_v1_mop("tests/programs/mop_wide_mul_zero", vec![], code);
         let ret_aot = machine_aot.run();
         assert!(ret_aot.is_ok());
         assert_eq!(ret_aot.unwrap(), 0);
@@ -360,7 +360,7 @@ pub fn test_mop_wide_div_zero() {
     {
         let code = machine_build::aot_v1_mop_code("tests/programs/mop_wide_div_zero");
         let mut machine_aot =
-            machine_build::aot_v1_mop("tests/programs/mop_wide_div_zero", vec![], &code);
+            machine_build::aot_v1_mop("tests/programs/mop_wide_div_zero", vec![], code);
         let ret_aot = machine_aot.run();
         assert!(ret_aot.is_ok());
         assert_eq!(ret_aot.unwrap(), 0);

--- a/tests/test_reset.rs
+++ b/tests/test_reset.rs
@@ -8,6 +8,7 @@ use ckb_vm::{
     registers::A7, Error, Register, SparseMemory, SupportMachine, Syscalls, TraceMachine,
     WXorXMemory, DEFAULT_STACK_SIZE, ISA_IMC, ISA_MOP, RISCV_MAX_MEMORY,
 };
+use std::rc::Rc;
 
 #[allow(dead_code)]
 mod machine_build;
@@ -128,7 +129,7 @@ pub fn test_reset_aot() {
         .instruction_cycle_func(Box::new(machine_build::instruction_cycle_func))
         .syscall(Box::new(CustomSyscall {}))
         .build();
-    let mut machine = AsmMachine::new(core, Some(&code));
+    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
     machine.load_program(&buffer, &vec![]).unwrap();
 
     let result = machine.run();

--- a/tests/test_reset.rs
+++ b/tests/test_reset.rs
@@ -8,7 +8,6 @@ use ckb_vm::{
     registers::A7, Error, Register, SparseMemory, SupportMachine, Syscalls, TraceMachine,
     WXorXMemory, DEFAULT_STACK_SIZE, ISA_IMC, ISA_MOP, RISCV_MAX_MEMORY,
 };
-use std::rc::Rc;
 
 #[allow(dead_code)]
 mod machine_build;
@@ -129,7 +128,7 @@ pub fn test_reset_aot() {
         .instruction_cycle_func(Box::new(machine_build::instruction_cycle_func))
         .syscall(Box::new(CustomSyscall {}))
         .build();
-    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
+    let mut machine = AsmMachine::new(core, Some(std::sync::Arc::new(code)));
     machine.load_program(&buffer, &vec![]).unwrap();
 
     let result = machine.run();

--- a/tests/test_resume.rs
+++ b/tests/test_resume.rs
@@ -16,7 +16,6 @@ use ckb_vm::{
 };
 use std::fs::File;
 use std::io::Read;
-use std::rc::Rc;
 
 #[test]
 fn test_resume_interpreter_with_trace_2_asm() {
@@ -200,7 +199,8 @@ pub fn resume_aot_2_asm(version: u32, except_cycles: u64) {
         AotCompilingMachine::load(&buffer, Some(Box::new(dummy_cycle_func)), ISA_IMC, VERSION1)
             .unwrap();
     let code = aot_machine.compile().unwrap();
-    let mut machine1 = AotMachine::build(version, except_cycles - 30, Some(Rc::new(code)));
+    let mut machine1 =
+        AotMachine::build(version, except_cycles - 30, Some(std::sync::Arc::new(code)));
     machine1
         .load_program(&buffer, &vec!["alloc_many".into()])
         .unwrap();
@@ -237,7 +237,7 @@ pub fn resume_asm_2_aot(version: u32, except_cycles: u64) {
         AotCompilingMachine::load(&buffer, Some(Box::new(dummy_cycle_func)), ISA_IMC, VERSION1)
             .unwrap();
     let code = aot_machine.compile().unwrap();
-    let mut machine2 = AotMachine::build(version, 40, Some(Rc::new(code)));
+    let mut machine2 = AotMachine::build(version, 40, Some(std::sync::Arc::new(code)));
     machine2.resume(&snapshot).unwrap();
     let result2 = machine2.run();
     let cycles2 = machine2.cycles();
@@ -384,7 +384,7 @@ struct AotMachine(AsmMachine);
 
 #[cfg(has_aot)]
 impl AotMachine {
-    fn build(version: u32, max_cycles: u64, program: Option<Rc<AotCode>>) -> AotMachine {
+    fn build(version: u32, max_cycles: u64, program: Option<std::sync::Arc<AotCode>>) -> AotMachine {
         let asm_core1 = AsmCoreMachine::new(ISA_IMC, version, max_cycles);
         let core1 = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core1)
             .instruction_cycle_func(Box::new(dummy_cycle_func))

--- a/tests/test_resume.rs
+++ b/tests/test_resume.rs
@@ -16,6 +16,7 @@ use ckb_vm::{
 };
 use std::fs::File;
 use std::io::Read;
+use std::rc::Rc;
 
 #[test]
 fn test_resume_interpreter_with_trace_2_asm() {
@@ -199,7 +200,7 @@ pub fn resume_aot_2_asm(version: u32, except_cycles: u64) {
         AotCompilingMachine::load(&buffer, Some(Box::new(dummy_cycle_func)), ISA_IMC, VERSION1)
             .unwrap();
     let code = aot_machine.compile().unwrap();
-    let mut machine1 = AotMachine::build(version, except_cycles - 30, Some(&code));
+    let mut machine1 = AotMachine::build(version, except_cycles - 30, Some(Rc::new(code)));
     machine1
         .load_program(&buffer, &vec!["alloc_many".into()])
         .unwrap();
@@ -236,7 +237,7 @@ pub fn resume_asm_2_aot(version: u32, except_cycles: u64) {
         AotCompilingMachine::load(&buffer, Some(Box::new(dummy_cycle_func)), ISA_IMC, VERSION1)
             .unwrap();
     let code = aot_machine.compile().unwrap();
-    let mut machine2 = AotMachine::build(version, 40, Some(&code));
+    let mut machine2 = AotMachine::build(version, 40, Some(Rc::new(code)));
     machine2.resume(&snapshot).unwrap();
     let result2 = machine2.run();
     let cycles2 = machine2.cycles();
@@ -281,7 +282,7 @@ enum MachineTy {
 }
 
 impl MachineTy {
-    fn build<'a>(self, version: u32, max_cycles: u64) -> Machine {
+    fn build(self, version: u32, max_cycles: u64) -> Machine {
         match self {
             MachineTy::Asm => {
                 let asm_core1 = AsmCoreMachine::new(ISA_IMC, version, max_cycles);
@@ -321,11 +322,9 @@ impl MachineTy {
 }
 
 enum Machine {
-    Asm(AsmMachine<'static>),
-    Interpreter(DefaultMachine<'static, DefaultCoreMachine<u64, WXorXMemory<SparseMemory<u64>>>>),
-    InterpreterWithTrace(
-        TraceMachine<'static, DefaultCoreMachine<u64, WXorXMemory<SparseMemory<u64>>>>,
-    ),
+    Asm(AsmMachine),
+    Interpreter(DefaultMachine<DefaultCoreMachine<u64, WXorXMemory<SparseMemory<u64>>>>),
+    InterpreterWithTrace(TraceMachine<DefaultCoreMachine<u64, WXorXMemory<SparseMemory<u64>>>>),
 }
 
 impl Machine {
@@ -381,11 +380,11 @@ impl Machine {
 }
 
 #[cfg(has_aot)]
-struct AotMachine<'a>(AsmMachine<'a>);
+struct AotMachine(AsmMachine);
 
 #[cfg(has_aot)]
-impl<'a> AotMachine<'a> {
-    fn build(version: u32, max_cycles: u64, program: Option<&'a AotCode>) -> AotMachine<'a> {
+impl AotMachine {
+    fn build(version: u32, max_cycles: u64, program: Option<Rc<AotCode>>) -> AotMachine {
         let asm_core1 = AsmCoreMachine::new(ISA_IMC, version, max_cycles);
         let core1 = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core1)
             .instruction_cycle_func(Box::new(dummy_cycle_func))

--- a/tests/test_resume.rs
+++ b/tests/test_resume.rs
@@ -384,7 +384,11 @@ struct AotMachine(AsmMachine);
 
 #[cfg(has_aot)]
 impl AotMachine {
-    fn build(version: u32, max_cycles: u64, program: Option<std::sync::Arc<AotCode>>) -> AotMachine {
+    fn build(
+        version: u32,
+        max_cycles: u64,
+        program: Option<std::sync::Arc<AotCode>>,
+    ) -> AotMachine {
         let asm_core1 = AsmCoreMachine::new(ISA_IMC, version, max_cycles);
         let core1 = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core1)
             .instruction_cycle_func(Box::new(dummy_cycle_func))

--- a/tests/test_versions.rs
+++ b/tests/test_versions.rs
@@ -13,7 +13,6 @@ use ckb_vm::{
     SparseMemory, WXorXMemory, ISA_IMC, RISCV_PAGESIZE,
 };
 use std::fs;
-use std::rc::Rc;
 
 type Mem = WXorXMemory<SparseMemory<u64>>;
 
@@ -58,7 +57,7 @@ fn create_aot_machine(program: String, code: AotCode, version: u32) -> AsmMachin
     let buffer = fs::read(path).unwrap().into();
     let asm_core = AsmCoreMachine::new(ISA_IMC, version, u64::max_value());
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core).build();
-    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
+    let mut machine = AsmMachine::new(core, Some(std::sync::Arc::new(code)));
     machine
         .load_program(&buffer, &vec![program.into()])
         .unwrap();
@@ -431,7 +430,7 @@ pub fn test_aot_version0_unaligned64() {
         .into();
     let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::max_value());
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core).build();
-    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
+    let mut machine = AsmMachine::new(core, Some(std::sync::Arc::new(code)));
     let result = machine.load_program(&buffer, &vec![program.into()]);
     assert!(result.is_err());
     assert_eq!(result.err(), Some(Error::MemWriteOnExecutablePage));

--- a/tests/test_versions.rs
+++ b/tests/test_versions.rs
@@ -13,13 +13,14 @@ use ckb_vm::{
     SparseMemory, WXorXMemory, ISA_IMC, RISCV_PAGESIZE,
 };
 use std::fs;
+use std::rc::Rc;
 
 type Mem = WXorXMemory<SparseMemory<u64>>;
 
-fn create_rust_machine<'a>(
+fn create_rust_machine(
     program: String,
     version: u32,
-) -> DefaultMachine<'a, DefaultCoreMachine<u64, Mem>> {
+) -> DefaultMachine<DefaultCoreMachine<u64, Mem>> {
     let path = format!("tests/programs/{}", program);
     let buffer = fs::read(path).unwrap().into();
     let core_machine = DefaultCoreMachine::<u64, Mem>::new(ISA_IMC, version, u64::max_value());
@@ -31,7 +32,7 @@ fn create_rust_machine<'a>(
     machine
 }
 
-fn create_asm_machine<'a>(program: String, version: u32) -> AsmMachine<'a> {
+fn create_asm_machine(program: String, version: u32) -> AsmMachine {
     let path = format!("tests/programs/{}", program);
     let buffer = fs::read(path).unwrap().into();
     let asm_core = AsmCoreMachine::new(ISA_IMC, version, u64::max_value());
@@ -52,12 +53,12 @@ fn compile_aot_code(program: String, version: u32) -> AotCode {
 }
 
 #[cfg(has_aot)]
-fn create_aot_machine<'a>(program: String, code: &'a AotCode, version: u32) -> AsmMachine<'a> {
+fn create_aot_machine(program: String, code: AotCode, version: u32) -> AsmMachine {
     let path = format!("tests/programs/{}", program);
     let buffer = fs::read(path).unwrap().into();
     let asm_core = AsmCoreMachine::new(ISA_IMC, version, u64::max_value());
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core).build();
-    let mut machine = AsmMachine::new(core, Some(code));
+    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
     machine
         .load_program(&buffer, &vec![program.into()])
         .unwrap();
@@ -260,7 +261,7 @@ pub fn test_asm_version1_write_at_boundary() {
 #[cfg(has_aot)]
 pub fn test_aot_version0_argv_null() {
     let code = compile_aot_code("argv_null_test".to_string(), VERSION0);
-    let mut machine = create_aot_machine("argv_null_test".to_string(), &code, VERSION0);
+    let mut machine = create_aot_machine("argv_null_test".to_string(), code, VERSION0);
     let result = machine.run();
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 1);
@@ -270,7 +271,7 @@ pub fn test_aot_version0_argv_null() {
 #[cfg(has_aot)]
 pub fn test_aot_version0_sp_alignment() {
     let code = compile_aot_code("sp_alignment_test".to_string(), VERSION0);
-    let mut machine = create_aot_machine("sp_alignment_test".to_string(), &code, VERSION0);
+    let mut machine = create_aot_machine("sp_alignment_test".to_string(), code, VERSION0);
     let result = machine.run();
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 1);
@@ -280,7 +281,7 @@ pub fn test_aot_version0_sp_alignment() {
 #[cfg(has_aot)]
 pub fn test_aot_version0_jalr_bug() {
     let code = compile_aot_code("jalr_bug".to_string(), VERSION0);
-    let mut machine = create_aot_machine("jalr_bug".to_string(), &code, VERSION0);
+    let mut machine = create_aot_machine("jalr_bug".to_string(), code, VERSION0);
     let result = machine.run();
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), -1);
@@ -290,7 +291,7 @@ pub fn test_aot_version0_jalr_bug() {
 #[cfg(has_aot)]
 pub fn test_aot_version0_jalr_bug_noc() {
     let code = compile_aot_code("jalr_bug_noc".to_string(), VERSION0);
-    let mut machine = create_aot_machine("jalr_bug_noc".to_string(), &code, VERSION0);
+    let mut machine = create_aot_machine("jalr_bug_noc".to_string(), code, VERSION0);
     let result = machine.run();
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), -1);
@@ -300,7 +301,7 @@ pub fn test_aot_version0_jalr_bug_noc() {
 #[cfg(has_aot)]
 pub fn test_aot_version0_read_at_boundary() {
     let code = compile_aot_code("read_at_boundary64".to_string(), VERSION0);
-    let mut machine = create_aot_machine("read_at_boundary64".to_string(), &code, VERSION0);
+    let mut machine = create_aot_machine("read_at_boundary64".to_string(), code, VERSION0);
     let result = machine.run();
     assert!(result.is_err());
     assert_eq!(result.err(), Some(Error::MemOutOfBound));
@@ -310,7 +311,7 @@ pub fn test_aot_version0_read_at_boundary() {
 #[cfg(has_aot)]
 pub fn test_aot_version0_write_at_boundary() {
     let code = compile_aot_code("write_at_boundary64".to_string(), VERSION0);
-    let mut machine = create_aot_machine("write_at_boundary64".to_string(), &code, VERSION0);
+    let mut machine = create_aot_machine("write_at_boundary64".to_string(), code, VERSION0);
     let result = machine.run();
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);
@@ -320,7 +321,7 @@ pub fn test_aot_version0_write_at_boundary() {
 #[cfg(has_aot)]
 pub fn test_aot_version1_argv_null() {
     let code = compile_aot_code("argv_null_test".to_string(), VERSION1);
-    let mut machine = create_aot_machine("argv_null_test".to_string(), &code, VERSION1);
+    let mut machine = create_aot_machine("argv_null_test".to_string(), code, VERSION1);
     let result = machine.run();
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);
@@ -330,7 +331,7 @@ pub fn test_aot_version1_argv_null() {
 #[cfg(has_aot)]
 pub fn test_aot_version1_sp_alignment() {
     let code = compile_aot_code("sp_alignment_test".to_string(), VERSION1);
-    let mut machine = create_aot_machine("sp_alignment_test".to_string(), &code, VERSION1);
+    let mut machine = create_aot_machine("sp_alignment_test".to_string(), code, VERSION1);
     let result = machine.run();
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);
@@ -340,7 +341,7 @@ pub fn test_aot_version1_sp_alignment() {
 #[cfg(has_aot)]
 pub fn test_aot_version1_jalr_bug() {
     let code = compile_aot_code("jalr_bug".to_string(), VERSION1);
-    let mut machine = create_aot_machine("jalr_bug".to_string(), &code, VERSION1);
+    let mut machine = create_aot_machine("jalr_bug".to_string(), code, VERSION1);
     let result = machine.run();
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);
@@ -350,7 +351,7 @@ pub fn test_aot_version1_jalr_bug() {
 #[cfg(has_aot)]
 pub fn test_aot_version1_jalr_bug_noc() {
     let code = compile_aot_code("jalr_bug_noc".to_string(), VERSION1);
-    let mut machine = create_aot_machine("jalr_bug_noc".to_string(), &code, VERSION1);
+    let mut machine = create_aot_machine("jalr_bug_noc".to_string(), code, VERSION1);
     let result = machine.run();
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);
@@ -360,7 +361,7 @@ pub fn test_aot_version1_jalr_bug_noc() {
 #[cfg(has_aot)]
 pub fn test_aot_version1_read_at_boundary() {
     let code = compile_aot_code("read_at_boundary64".to_string(), VERSION1);
-    let mut machine = create_aot_machine("read_at_boundary64".to_string(), &code, VERSION1);
+    let mut machine = create_aot_machine("read_at_boundary64".to_string(), code, VERSION1);
     let result = machine.run();
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);
@@ -370,7 +371,7 @@ pub fn test_aot_version1_read_at_boundary() {
 #[cfg(has_aot)]
 pub fn test_aot_version1_write_at_boundary() {
     let code = compile_aot_code("write_at_boundary64".to_string(), VERSION1);
-    let mut machine = create_aot_machine("write_at_boundary64".to_string(), &code, VERSION1);
+    let mut machine = create_aot_machine("write_at_boundary64".to_string(), code, VERSION1);
     let result = machine.run();
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);
@@ -430,7 +431,7 @@ pub fn test_aot_version0_unaligned64() {
         .into();
     let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::max_value());
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core).build();
-    let mut machine = AsmMachine::new(core, Some(&code));
+    let mut machine = AsmMachine::new(core, Some(Rc::new(code)));
     let result = machine.load_program(&buffer, &vec![program.into()]);
     assert!(result.is_err());
     assert_eq!(result.err(), Some(Error::MemWriteOnExecutablePage));
@@ -440,7 +441,7 @@ pub fn test_aot_version0_unaligned64() {
 #[cfg(has_aot)]
 pub fn test_aot_version1_unaligned64() {
     let code = compile_aot_code("unaligned64".to_string(), VERSION1);
-    let mut machine = create_aot_machine("unaligned64".to_string(), &code, VERSION1);
+    let mut machine = create_aot_machine("unaligned64".to_string(), code, VERSION1);
     let result = machine.run();
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);


### PR DESCRIPTION
This PR modified the definition of AsmMachine:

```
// Before
pub struct AsmMachine<'a> {
    pub machine: DefaultMachine<'a, Box<AsmCoreMachine>>,
    pub aot_code: Option<&'a AotCode>,
}

// After
pub struct AsmMachine {
    pub machine: DefaultMachine<Box<AsmCoreMachine>>,
    pub aot_code: Option<Arc<AotCode>>,
}
```

This allows us to completely remove any lifetime parameter in ckb-vm.