### PR TITLE
feat: Support detect-aot feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ asm = []
 # Detect if requirements are met, and enable asm feature when we can.
 detect-asm = []
 aot = ["asm"]
+# Detect if requirements are met, and enable aot feature when we can.
+detect-aot = ["detect-asm"]
 enable-chaos-mode-by-default = ["ckb-vm-definitions/enable-chaos-mode-by-default"]
 # Disable slow tests to run miri on CI
 miri-ci = []

--- a/build.rs
+++ b/build.rs
@@ -36,7 +36,7 @@ fn main() {
         use std::path::Path;
         use std::process::Command;
 
-        let enable_aot = cfg!(feature = "aot");
+        let enable_aot = cfg!(any(feature = "aot", feature = "detect-aot")) && can_enable_aot;
 
         fn run_command(mut c: Command) {
             println!("Running Command[{:?}]", c);


### PR DESCRIPTION
To support compiling on Mac m1, we want to enable the `aot` feature depend on the compiling environment. Unforturnately, rust doesn't allow us to turn on a feature in `build.rs`.

This PR adds `detect-aot` feature, just like the `detect-asm` - the AOT is enabled when it is possible.