### PR TITLE
chore: remove the Option wrapper of the instruction_cycle_func

### DIFF
--- a/src/machine/asm/mod.rs
+++ b/src/machine/asm/mod.rs
@@ -497,12 +497,7 @@ impl AsmMachine {
                         let end_instruction = is_basic_block_end_instruction(instruction);
                         current_pc += u64::from(instruction_length(instruction));
                         trace.instructions[i] = instruction;
-                        trace.cycles += self
-                            .machine
-                            .instruction_cycle_func()
-                            .as_ref()
-                            .map(|f| f(instruction))
-                            .unwrap_or(0);
+                        trace.cycles += self.machine.instruction_cycle_func()(instruction);
                         let opcode = extract_opcode(instruction);
                         // Here we are calculating the absolute address used in direct threading
                         // from label offsets.
@@ -552,12 +547,7 @@ impl AsmMachine {
         let instruction = decoder.decode(self.machine.memory_mut(), pc)?;
         let len = instruction_length(instruction) as u8;
         trace.instructions[0] = instruction;
-        trace.cycles += self
-            .machine
-            .instruction_cycle_func()
-            .as_ref()
-            .map(|f| f(instruction))
-            .unwrap_or(0);
+        trace.cycles += self.machine.instruction_cycle_func()(instruction);
         let opcode = extract_opcode(instruction);
         trace.thread[0] = unsafe {
             u64::from(*(ckb_vm_asm_labels as *const u32).offset(opcode as isize))

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -582,7 +582,7 @@ impl<Inner: SupportMachine> DefaultMachine<Inner> {
         self.exit_code
     }
 
-    pub fn instruction_cycle_func(&self) -> &Box<InstructionCycleFunc> {
+    pub fn instruction_cycle_func(&self) -> &InstructionCycleFunc {
         &self.instruction_cycle_func
     }
 

--- a/src/machine/trace.rs
+++ b/src/machine/trace.rs
@@ -137,12 +137,7 @@ impl<Inner: SupportMachine> TraceMachine<Inner> {
             }
             for i in 0..self.traces[slot].instruction_count {
                 let i = self.traces[slot].instructions[i as usize];
-                let cycles = self
-                    .machine
-                    .instruction_cycle_func()
-                    .as_ref()
-                    .map(|f| f(i))
-                    .unwrap_or(0);
+                let cycles = self.machine.instruction_cycle_func()(i);
                 self.machine.add_cycles(cycles)?;
                 execute(i, self)?;
             }


### PR DESCRIPTION
Modify the definition of `instruction_cycle_func` from `Option<Box<InstructionCycleFunc>>` to `Box<InstructionCycleFunc>`.

This brings a slight performance improve, especially in interpreter mode.

```
// When instruction_cylce_func is Box::new(|_|, 1)

interpret secp256k1_bench                                                                            
                        time:   [20.673 ms 20.748 ms 20.850 ms] // Before

interpret secp256k1_bench
                        time:   [20.199 ms 20.285 ms 20.394 ms] // After
```

Note: To express `Option::None`, we can simply set the `instruction_cycle_func` to `Box::new(|_|, 0)`.

