### PR TITLE
chore: Make fill_page_data a public function

### DIFF
--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -63,7 +63,7 @@ pub trait Memory {
 }
 
 #[inline(always)]
-pub(crate) fn fill_page_data<M: Memory>(
+pub fn fill_page_data<M: Memory>(
     memory: &mut M,
     addr: u64,
     size: u64,


### PR DESCRIPTION
This utility function can be extra helpful when implementing Memory trait in an external project