### PR TITLE
chore: Re-export used crates for ease of dependency management.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,9 @@ pub mod memory;
 pub mod snapshot;
 pub mod syscalls;
 
+pub use bytes;
+pub use ckb_vm_definitions;
+
 pub use crate::{
     debugger::Debugger,
     instructions::{Instruction, Register},


### PR DESCRIPTION
Frequently, we will have to specify both ckb-vm as well as its dependencies, such as this:

https://github.com/xxuejie/ckb-vm-contrib/blob/90d0303f35349aa9c9e4ef2006bcd049ef134092/Cargo.toml#L23-L24

One has to manually pay more attention to make sure versions for depended crates match those versions used in CKB-VM, which is a quite troublesome process.

By re-exporting commonly used crates, one only needs to import ckb-vm once, saving the trouble of updating each individual crates.