### PR TITLE
Make ckb-vm thread-safety

### DIFF
--- a/examples/ckb-vm-runner.rs
+++ b/examples/ckb-vm-runner.rs
@@ -94,7 +94,7 @@ fn main_asm(code: Bytes, args: Vec<Bytes>) -> Result<(), Box<dyn std::error::Err
         u64::MAX,
     );
     let core = ckb_vm::DefaultMachineBuilder::new(asm_core)
-        .instruction_cycle_func(&instruction_cycles)
+        .instruction_cycle_func(Box::new(instruction_cycles))
         .syscall(Box::new(DebugSyscall {}))
         .build();
     let mut machine = ckb_vm::machine::asm::AsmMachine::new(core);
@@ -118,7 +118,7 @@ fn main_int(code: Bytes, args: Vec<Bytes>) -> Result<(), Box<dyn std::error::Err
         u64::MAX,
     );
     let machine_builder = ckb_vm::DefaultMachineBuilder::new(core_machine)
-        .instruction_cycle_func(&instruction_cycles);
+        .instruction_cycle_func(Box::new(instruction_cycles));
     let mut machine = machine_builder.syscall(Box::new(DebugSyscall {})).build();
     machine.load_program(&code, &args)?;
     let exit = machine.run();

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -1,6 +1,6 @@
 use crate::{machine::SupportMachine, Error};
 
-pub trait Debugger<Mac: SupportMachine> {
+pub trait Debugger<Mac: SupportMachine>: Send + Sync {
     fn initialize(&mut self, machine: &mut Mac) -> Result<(), Error>;
     fn ebreak(&mut self, machine: &mut Mac) -> Result<(), Error>;
 }

--- a/src/machine/asm/mod.rs
+++ b/src/machine/asm/mod.rs
@@ -422,12 +422,12 @@ extern "C" {
     pub fn ckb_vm_asm_labels();
 }
 
-pub struct AsmMachine<'a> {
-    pub machine: DefaultMachine<'a, Box<AsmCoreMachine>>,
+pub struct AsmMachine {
+    pub machine: DefaultMachine<Box<AsmCoreMachine>>,
 }
 
-impl<'a> AsmMachine<'a> {
-    pub fn new(machine: DefaultMachine<'a, Box<AsmCoreMachine>>) -> Self {
+impl AsmMachine {
+    pub fn new(machine: DefaultMachine<Box<AsmCoreMachine>>) -> Self {
         Self { machine }
     }
 

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -406,20 +406,20 @@ impl<R: Register, M: Memory + Default> DefaultCoreMachine<R, M> {
 
 pub type InstructionCycleFunc = dyn Fn(Instruction) -> u64;
 
-pub struct DefaultMachine<'a, Inner> {
+pub struct DefaultMachine<Inner> {
     inner: Inner,
 
     // We have run benchmarks on secp256k1 verification, the performance
     // cost of the Box wrapper here is neglectable, hence we are sticking
     // with Box solution for simplicity now. Later if this becomes an issue,
     // we can change to static dispatch.
-    instruction_cycle_func: &'a InstructionCycleFunc,
-    debugger: Option<Box<dyn Debugger<Inner> + 'a>>,
-    syscalls: Vec<Box<dyn Syscalls<Inner> + 'a>>,
+    instruction_cycle_func: Box<InstructionCycleFunc>,
+    debugger: Option<Box<dyn Debugger<Inner>>>,
+    syscalls: Vec<Box<dyn Syscalls<Inner>>>,
     exit_code: i8,
 }
 
-impl<Inner: CoreMachine> CoreMachine for DefaultMachine<'_, Inner> {
+impl<Inner: CoreMachine> CoreMachine for DefaultMachine<Inner> {
     type REG = <Inner as CoreMachine>::REG;
     type MEM = <Inner as CoreMachine>::MEM;
 
@@ -460,7 +460,7 @@ impl<Inner: CoreMachine> CoreMachine for DefaultMachine<'_, Inner> {
     }
 }
 
-impl<Inner: SupportMachine> SupportMachine for DefaultMachine<'_, Inner> {
+impl<Inner: SupportMachine> SupportMachine for DefaultMachine<Inner> {
     fn cycles(&self) -> u64 {
         self.inner.cycles()
     }
@@ -495,7 +495,7 @@ impl<Inner: SupportMachine> SupportMachine for DefaultMachine<'_, Inner> {
     }
 }
 
-impl<Inner: SupportMachine> Machine for DefaultMachine<'_, Inner> {
+impl<Inner: SupportMachine> Machine for DefaultMachine<Inner> {
     fn ecall(&mut self) -> Result<(), Error> {
         let code = self.registers()[A7].to_u64();
         match code {
@@ -531,7 +531,7 @@ impl<Inner: SupportMachine> Machine for DefaultMachine<'_, Inner> {
     }
 }
 
-impl<Inner: CoreMachine> Display for DefaultMachine<'_, Inner> {
+impl<Inner: CoreMachine> Display for DefaultMachine<Inner> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "pc  : 0x{:16X}", self.pc().to_u64())?;
         for (i, name) in REGISTER_ABI_NAMES.iter().enumerate() {
@@ -546,7 +546,7 @@ impl<Inner: CoreMachine> Display for DefaultMachine<'_, Inner> {
     }
 }
 
-impl<'a, Inner: SupportMachine> DefaultMachine<'a, Inner> {
+impl<Inner: SupportMachine> DefaultMachine<Inner> {
     pub fn load_program(&mut self, program: &Bytes, args: &[Bytes]) -> Result<u64, Error> {
         let elf_bytes = self.load_elf(program, true)?;
         for syscall in &mut self.syscalls {
@@ -580,8 +580,8 @@ impl<'a, Inner: SupportMachine> DefaultMachine<'a, Inner> {
         self.exit_code
     }
 
-    pub fn instruction_cycle_func(&self) -> &'a InstructionCycleFunc {
-        self.instruction_cycle_func
+    pub fn instruction_cycle_func(&self) -> &Box<InstructionCycleFunc> {
+        &self.instruction_cycle_func
     }
 
     pub fn inner_mut(&mut self) -> &mut Inner {
@@ -619,18 +619,18 @@ impl<'a, Inner: SupportMachine> DefaultMachine<'a, Inner> {
     }
 }
 
-pub struct DefaultMachineBuilder<'a, Inner> {
+pub struct DefaultMachineBuilder<Inner> {
     inner: Inner,
-    instruction_cycle_func: &'a InstructionCycleFunc,
-    debugger: Option<Box<dyn Debugger<Inner> + 'a>>,
-    syscalls: Vec<Box<dyn Syscalls<Inner> + 'a>>,
+    instruction_cycle_func: Box<InstructionCycleFunc>,
+    debugger: Option<Box<dyn Debugger<Inner>>>,
+    syscalls: Vec<Box<dyn Syscalls<Inner>>>,
 }
 
-impl<'a, Inner> DefaultMachineBuilder<'a, Inner> {
+impl<Inner> DefaultMachineBuilder<Inner> {
     pub fn new(inner: Inner) -> Self {
         Self {
             inner,
-            instruction_cycle_func: &|_| 0,
+            instruction_cycle_func: Box::new(|_| 0),
             debugger: None,
             syscalls: vec![],
         }
@@ -638,23 +638,23 @@ impl<'a, Inner> DefaultMachineBuilder<'a, Inner> {
 
     pub fn instruction_cycle_func(
         mut self,
-        instruction_cycle_func: &'a InstructionCycleFunc,
+        instruction_cycle_func: Box<InstructionCycleFunc>,
     ) -> Self {
         self.instruction_cycle_func = instruction_cycle_func;
         self
     }
 
-    pub fn syscall(mut self, syscall: Box<dyn Syscalls<Inner> + 'a>) -> Self {
+    pub fn syscall(mut self, syscall: Box<dyn Syscalls<Inner>>) -> Self {
         self.syscalls.push(syscall);
         self
     }
 
-    pub fn debugger(mut self, debugger: Box<dyn Debugger<Inner> + 'a>) -> Self {
+    pub fn debugger(mut self, debugger: Box<dyn Debugger<Inner>>) -> Self {
         self.debugger = Some(debugger);
         self
     }
 
-    pub fn build(self) -> DefaultMachine<'a, Inner> {
+    pub fn build(self) -> DefaultMachine<Inner> {
         DefaultMachine {
             inner: self.inner,
             instruction_cycle_func: self.instruction_cycle_func,

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -404,7 +404,7 @@ impl<R: Register, M: Memory + Default> DefaultCoreMachine<R, M> {
     }
 }
 
-pub type InstructionCycleFunc = dyn Fn(Instruction) -> u64;
+pub type InstructionCycleFunc = dyn Fn(Instruction) -> u64 + Send + Sync;
 
 pub struct DefaultMachine<Inner> {
     inner: Inner,

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -580,7 +580,7 @@ impl<Inner: SupportMachine> DefaultMachine<Inner> {
         self.exit_code
     }
 
-    pub fn instruction_cycle_func(&self) -> &Box<InstructionCycleFunc> {
+    pub fn instruction_cycle_func(&self) -> &InstructionCycleFunc {
         &self.instruction_cycle_func
     }
 

--- a/src/machine/trace.rs
+++ b/src/machine/trace.rs
@@ -32,13 +32,13 @@ fn calculate_slot(addr: u64) -> usize {
     (addr as usize >> TRACE_ADDRESS_SHIFTS) & TRACE_MASK
 }
 
-pub struct TraceMachine<'a, Inner> {
-    pub machine: DefaultMachine<'a, Inner>,
+pub struct TraceMachine<Inner> {
+    pub machine: DefaultMachine<Inner>,
 
     traces: Vec<Trace>,
 }
 
-impl<Inner: SupportMachine> CoreMachine for TraceMachine<'_, Inner> {
+impl<Inner: SupportMachine> CoreMachine for TraceMachine<Inner> {
     type REG = <Inner as CoreMachine>::REG;
     type MEM = <Inner as CoreMachine>::MEM;
 
@@ -79,7 +79,7 @@ impl<Inner: SupportMachine> CoreMachine for TraceMachine<'_, Inner> {
     }
 }
 
-impl<Inner: SupportMachine> Machine for TraceMachine<'_, Inner> {
+impl<Inner: SupportMachine> Machine for TraceMachine<Inner> {
     fn ecall(&mut self) -> Result<(), Error> {
         self.machine.ecall()
     }
@@ -89,8 +89,8 @@ impl<Inner: SupportMachine> Machine for TraceMachine<'_, Inner> {
     }
 }
 
-impl<'a, Inner: SupportMachine> TraceMachine<'a, Inner> {
-    pub fn new(machine: DefaultMachine<'a, Inner>) -> Self {
+impl<Inner: SupportMachine> TraceMachine<Inner> {
+    pub fn new(machine: DefaultMachine<Inner>) -> Self {
         Self {
             machine,
             traces: vec![],

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -1,7 +1,7 @@
 use super::Error;
 use crate::machine::SupportMachine;
 
-pub trait Syscalls<Mac: SupportMachine> {
+pub trait Syscalls<Mac: SupportMachine>: Send + Sync {
     fn initialize(&mut self, machine: &mut Mac) -> Result<(), Error>;
     // Returned bool means if the syscall has been processed, if
     // a module returns false, Machine would continue to leverage

--- a/tests/machine_build.rs
+++ b/tests/machine_build.rs
@@ -12,11 +12,11 @@ pub fn instruction_cycle_func(_: Instruction) -> u64 {
 }
 
 #[cfg(has_asm)]
-pub fn asm_v1_imcb<'a>(path: &str) -> AsmMachine<'a> {
+pub fn asm_v1_imcb(path: &str) -> AsmMachine {
     let buffer: Bytes = std::fs::read(path).unwrap().into();
     let asm_core = AsmCoreMachine::new(ISA_IMC | ISA_B, VERSION1, u64::max_value());
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
-        .instruction_cycle_func(&instruction_cycle_func)
+        .instruction_cycle_func(Box::new(instruction_cycle_func))
         .build();
     let mut machine = AsmMachine::new(core);
     machine
@@ -36,7 +36,7 @@ pub fn int_v1_imcb(
     );
     let mut machine = TraceMachine::new(
         DefaultMachineBuilder::new(core_machine)
-            .instruction_cycle_func(&instruction_cycle_func)
+            .instruction_cycle_func(Box::new(instruction_cycle_func))
             .build(),
     );
     machine
@@ -46,11 +46,11 @@ pub fn int_v1_imcb(
 }
 
 #[cfg(has_asm)]
-pub fn asm_v1_mop<'a>(path: &str, args: Vec<Bytes>) -> AsmMachine<'a> {
+pub fn asm_v1_mop(path: &str, args: Vec<Bytes>) -> AsmMachine {
     let buffer: Bytes = std::fs::read(path).unwrap().into();
     let asm_core = AsmCoreMachine::new(ISA_IMC | ISA_B | ISA_MOP, VERSION1, u64::max_value());
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
-        .instruction_cycle_func(&instruction_cycle_func)
+        .instruction_cycle_func(Box::new(instruction_cycle_func))
         .build();
     let mut machine = AsmMachine::new(core);
     let mut argv = vec![Bytes::from("main")];
@@ -71,7 +71,7 @@ pub fn int_v1_mop(
     );
     let mut machine = TraceMachine::new(
         DefaultMachineBuilder::new(core_machine)
-            .instruction_cycle_func(&instruction_cycle_func)
+            .instruction_cycle_func(Box::new(instruction_cycle_func))
             .build(),
     );
     let mut argv = vec![Bytes::from("main")];

--- a/tests/test_misc.rs
+++ b/tests/test_misc.rs
@@ -296,7 +296,7 @@ pub fn test_outofcycles_in_syscall() {
     let buffer = fs::read("tests/programs/syscall64").unwrap().into();
     let core_machine = DefaultCoreMachine::<u64, SparseMemory<u64>>::new(ISA_IMC, VERSION0, 20);
     let mut machine = DefaultMachineBuilder::new(core_machine)
-        .instruction_cycle_func(&|_| 1)
+        .instruction_cycle_func(Box::new(|_| 1))
         .syscall(Box::new(OutOfCyclesSyscall {}))
         .build();
     machine

--- a/tests/test_reset.rs
+++ b/tests/test_reset.rs
@@ -48,7 +48,7 @@ fn test_reset_int() {
         u64::max_value(),
     );
     let mut machine = DefaultMachineBuilder::new(core_machine)
-        .instruction_cycle_func(&machine_build::instruction_cycle_func)
+        .instruction_cycle_func(Box::new(machine_build::instruction_cycle_func))
         .syscall(Box::new(CustomSyscall {}))
         .build();
     machine.load_program(&code, &vec![]).unwrap();
@@ -71,7 +71,7 @@ fn test_reset_int_with_trace() {
     );
     let mut machine = TraceMachine::new(
         DefaultMachineBuilder::new(core_machine)
-            .instruction_cycle_func(&machine_build::instruction_cycle_func)
+            .instruction_cycle_func(Box::new(machine_build::instruction_cycle_func))
             .syscall(Box::new(CustomSyscall {}))
             .build(),
     );
@@ -91,7 +91,7 @@ fn test_reset_asm() {
 
     let asm_core = AsmCoreMachine::new(ISA_IMC | ISA_MOP, VERSION1, u64::max_value());
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
-        .instruction_cycle_func(&machine_build::instruction_cycle_func)
+        .instruction_cycle_func(Box::new(machine_build::instruction_cycle_func))
         .syscall(Box::new(CustomSyscall {}))
         .build();
     let mut machine = AsmMachine::new(core);

--- a/tests/test_simple.rs
+++ b/tests/test_simple.rs
@@ -39,7 +39,7 @@ pub fn test_simple_cycles() {
     let core_machine = DefaultCoreMachine::<u64, SparseMemory<u64>>::new(ISA_IMC, VERSION0, 708);
     let mut machine =
         DefaultMachineBuilder::<DefaultCoreMachine<u64, SparseMemory<u64>>>::new(core_machine)
-            .instruction_cycle_func(&dummy_cycle_func)
+            .instruction_cycle_func(Box::new(dummy_cycle_func))
             .build();
     machine
         .load_program(&buffer, &vec!["simple".into()])
@@ -58,7 +58,7 @@ pub fn test_simple_max_cycles_reached() {
     let core_machine = DefaultCoreMachine::<u64, SparseMemory<u64>>::new(ISA_IMC, VERSION0, 700);
     let mut machine =
         DefaultMachineBuilder::<DefaultCoreMachine<u64, SparseMemory<u64>>>::new(core_machine)
-            .instruction_cycle_func(&dummy_cycle_func)
+            .instruction_cycle_func(Box::new(dummy_cycle_func))
             .build();
     machine
         .load_program(&buffer, &vec!["simple".into()])
@@ -95,7 +95,7 @@ pub fn test_simple_cycles_overflow() {
         DefaultCoreMachine::<u64, SparseMemory<u64>>::new(ISA_IMC, VERSION0, u64::MAX);
     let mut machine =
         DefaultMachineBuilder::<DefaultCoreMachine<u64, SparseMemory<u64>>>::new(core_machine)
-            .instruction_cycle_func(&dummy_cycle_func)
+            .instruction_cycle_func(Box::new(dummy_cycle_func))
             .build();
     machine.set_cycles(u64::MAX - 10);
     machine

--- a/tests/test_versions.rs
+++ b/tests/test_versions.rs
@@ -13,10 +13,10 @@ use std::fs;
 
 type Mem = WXorXMemory<SparseMemory<u64>>;
 
-fn create_rust_machine<'a>(
+fn create_rust_machine(
     program: String,
     version: u32,
-) -> DefaultMachine<'a, DefaultCoreMachine<u64, Mem>> {
+) -> DefaultMachine<DefaultCoreMachine<u64, Mem>> {
     let path = format!("tests/programs/{}", program);
     let buffer = fs::read(path).unwrap().into();
     let core_machine = DefaultCoreMachine::<u64, Mem>::new(ISA_IMC, version, u64::max_value());
@@ -28,7 +28,7 @@ fn create_rust_machine<'a>(
     machine
 }
 
-fn create_asm_machine<'a>(program: String, version: u32) -> AsmMachine<'a> {
+fn create_asm_machine(program: String, version: u32) -> AsmMachine {
     let path = format!("tests/programs/{}", program);
     let buffer = fs::read(path).unwrap().into();
     let asm_core = AsmCoreMachine::new(ISA_IMC, version, u64::max_value());


### PR DESCRIPTION
Changed the following structures

```
pub type InstructionCycleFunc = dyn Fn(Instruction) -> u64 + Send + Sync;

pub trait Debugger<Mac: SupportMachine>: Send + Sync;

pub trait Syscalls<Mac: SupportMachine>: Send + Sync ;

pub struct DefaultMachine<Inner> {
    ... ...
    instruction_cycle_func: Box<InstructionCycleFunc>,
    debugger: Option<Box<dyn Debugger<Inner>>>,
    syscalls: Vec<Box<dyn Syscalls<Inner>>>,
    exit_code: i8,
}
```

The ownership of the machine instance can be moved safely between threads now:

```
#[test]
fn test_asm_thread_safe() {
    let buffer = fs::read("tests/programs/mulw64").unwrap().into();
    let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::max_value());
    let core = DefaultMachineBuilder::new(asm_core).build();
    let mut machine = AsmMachine::new(core);
    machine
        .load_program(&buffer, &vec!["mulw64".into()])
        .unwrap();
    let thread_join_handle = thread::spawn(move || {
        let result = machine.run();
        assert!(result.is_ok());
        assert_eq!(result.unwrap(), 0);
    });
    thread_join_handle.join().unwrap();
}
```