### PR TITLE
chore: remove unnecessary instructions in trace_end

### DIFF
--- a/src/machine/asm/execute_aarch64.S
+++ b/src/machine/asm/execute_aarch64.S
@@ -266,8 +266,6 @@ ckb_vm_x64_execute:
   cmp TEMP4, TEMP3
   bne .exit_trace
   ldrb TEMP3w, [TRACE, CKB_VM_ASM_TRACE_OFFSET_LENGTH]
-  cmp TEMP3w, 0
-  beq .exit_trace
   ldr TEMP2, [MACHINE, CKB_VM_ASM_ASM_CORE_MACHINE_OFFSET_CYCLES]
   ldr TEMP1, [TRACE, CKB_VM_ASM_TRACE_OFFSET_CYCLES]
   add TEMP2, TEMP2, TEMP1

--- a/src/machine/asm/execute_x64.S
+++ b/src/machine/asm/execute_x64.S
@@ -368,8 +368,6 @@ ckb_vm_x64_execute:
   cmp %rcx, %rdx
   jne .exit_trace
   movzbl CKB_VM_ASM_TRACE_OFFSET_LENGTH(TRACE), %edx
-  cmp $0, %rdx
-  je .exit_trace
   movq CKB_VM_ASM_ASM_CORE_MACHINE_OFFSET_CYCLES(MACHINE), %rax
   addq CKB_VM_ASM_TRACE_OFFSET_CYCLES(TRACE), %rax
   jc .exit_cycles_overflow


### PR DESCRIPTION
In the previous code before https://github.com/nervosnetwork/ckb-vm/pull/298 , `CKB_VM_ASM_LABEL_OP_CUSTOM_TRACE_END` and `prepare_trace` were sharing the same code block. 

Now the `CKB_VM_ASM_LABEL_OP_CUSTOM_TRACE_END` will only be triggered when the next trace is executed sequentially, it does not run at address 0, so we can remove the unnecessary length checking here.

