### PR TITLE
chore: refactor build_decoder

### DIFF
--- a/src/machine/asm/mod.rs
+++ b/src/machine/asm/mod.rs
@@ -8,8 +8,7 @@ use ckb_vm_definitions::{
         TRACE_ITEM_LENGTH, TRACE_SIZE,
     },
     instructions::OP_CUSTOM_TRACE_END,
-    ISA_MOP, MEMORY_FRAMES, MEMORY_FRAME_PAGE_SHIFTS, RISCV_GENERAL_REGISTER_NUMBER,
-    RISCV_PAGE_SHIFTS,
+    MEMORY_FRAMES, MEMORY_FRAME_PAGE_SHIFTS, RISCV_GENERAL_REGISTER_NUMBER, RISCV_PAGE_SHIFTS,
 };
 use rand::{prelude::RngCore, SeedableRng};
 use std::os::raw::c_uchar;
@@ -20,7 +19,6 @@ use crate::{
         blank_instruction, execute_instruction, extract_opcode, instruction_length,
         is_basic_block_end_instruction,
     },
-    machine::VERSION0,
     memory::{
         fill_page_data, get_page_indices, memset, round_page_down, round_page_up, FLAG_DIRTY,
         FLAG_EXECUTABLE, FLAG_FREEZED, FLAG_WRITABLE, FLAG_WXORX_BIT,
@@ -461,10 +459,7 @@ impl AsmMachine {
     }
 
     pub fn run(&mut self) -> Result<i8, Error> {
-        if self.machine.isa() & ISA_MOP != 0 && self.machine.version() == VERSION0 {
-            return Err(Error::InvalidVersion);
-        }
-        let mut decoder = build_decoder::<u64>(self.machine.isa(), self.machine.version());
+        let mut decoder = build_decoder::<u64>(self.machine.isa(), self.machine.version())?;
         self.machine.set_running(true);
         while self.machine.running() {
             if self.machine.reset_signal() {

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -15,7 +15,7 @@ use super::memory::{round_page_down, round_page_up, Memory};
 use super::syscalls::Syscalls;
 use super::{
     registers::{A0, A7, REGISTER_ABI_NAMES, SP},
-    Error, ISA_MOP, RISCV_GENERAL_REGISTER_NUMBER,
+    Error, RISCV_GENERAL_REGISTER_NUMBER,
 };
 
 // Version 0 is the initial launched CKB VM, it is used in CKB Lina mainnet
@@ -600,10 +600,7 @@ impl<Inner: SupportMachine> DefaultMachine<Inner> {
     // not be practical in production, but it serves as a baseline and
     // reference implementation
     pub fn run(&mut self) -> Result<i8, Error> {
-        if self.isa() & ISA_MOP != 0 && self.version() == VERSION0 {
-            return Err(Error::InvalidVersion);
-        }
-        let mut decoder = build_decoder::<Inner::REG>(self.isa(), self.version());
+        let mut decoder = build_decoder::<Inner::REG>(self.isa(), self.version())?;
         self.set_running(true);
         while self.running() {
             if self.reset_signal() {

--- a/src/machine/trace.rs
+++ b/src/machine/trace.rs
@@ -102,7 +102,7 @@ impl<Inner: SupportMachine> TraceMachine<Inner> {
     }
 
     pub fn run(&mut self) -> Result<i8, Error> {
-        let mut decoder = build_decoder::<Inner::REG>(self.isa(), self.version());
+        let mut decoder = build_decoder::<Inner::REG>(self.isa(), self.version())?;
         self.machine.set_running(true);
         // For current trace size this is acceptable, however we might want
         // to tweak the code here if we choose to use a larger trace size or

--- a/tests/test_asm.rs
+++ b/tests/test_asm.rs
@@ -400,7 +400,7 @@ pub fn test_asm_step() {
         .unwrap();
 
     let result = || -> Result<i8, Error> {
-        let mut decoder = build_decoder::<u64>(ISA_IMC, VERSION0);
+        let mut decoder = build_decoder::<u64>(ISA_IMC, VERSION0)?;
         machine.machine.set_running(true);
         while machine.machine.running() {
             machine.step(&mut decoder)?;

--- a/tests/test_auipc_fusion.rs
+++ b/tests/test_auipc_fusion.rs
@@ -67,7 +67,8 @@ pub fn test_rust_auipc_fusion() {
         .load_program(&buffer, &vec!["auipc_no_sign_extend".into()])
         .unwrap();
 
-    let mut decoder = AuxDecoder::new(build_decoder::<u64>(machine.isa(), machine.version()));
+    let mut decoder =
+        AuxDecoder::new(build_decoder::<u64>(machine.isa(), machine.version()).unwrap());
     machine.set_running(true);
     while machine.running() {
         let pc = *machine.pc();
@@ -98,10 +99,9 @@ pub fn test_asm_auipc_fusion() {
         .load_program(&buffer, &vec!["auipc_no_sign_extend".into()])
         .unwrap();
 
-    let mut decoder = AuxDecoder::new(build_decoder::<u64>(
-        machine.machine.isa(),
-        machine.machine.version(),
-    ));
+    let mut decoder = AuxDecoder::new(
+        build_decoder::<u64>(machine.machine.isa(), machine.machine.version()).unwrap(),
+    );
 
     let pc = *machine.machine.pc();
     let slot = calculate_slot(pc);


### PR DESCRIPTION
move the isa and version checking to fn `build_decoder`, avoid duplicate code on different machine building fn, rvv extensions and version checking can also be handled centrally in `build_decoder`