### PR TITLE
feat(cost_model): add default instruction cycle func

### DIFF
--- a/src/cost_model.rs
+++ b/src/cost_model.rs
@@ -1,0 +1,70 @@
+use crate::{
+    instructions::{extract_opcode, insts},
+    Instruction,
+};
+
+// Returns the spent cycles to execute the secific instruction.
+// This function is usually used to write test cases, which can visually
+// display how many instructions are executed.
+pub fn constant_cycles(_: Instruction) -> u64 {
+    1
+}
+
+// Returns the spent cycles to execute the secific instruction.
+// These values come from estimates of hardware execution speed.
+pub fn estimate_cycles(i: Instruction) -> u64 {
+    match extract_opcode(i) {
+        // IMC
+        insts::OP_JALR_VERSION0 => 3,
+        insts::OP_JALR_VERSION1 => 3,
+        insts::OP_LD_VERSION0 => 2,
+        insts::OP_LD_VERSION1 => 2,
+        insts::OP_LW_VERSION0 => 3,
+        insts::OP_LW_VERSION1 => 3,
+        insts::OP_LH_VERSION0 => 3,
+        insts::OP_LH_VERSION1 => 3,
+        insts::OP_LB_VERSION0 => 3,
+        insts::OP_LB_VERSION1 => 3,
+        insts::OP_LWU_VERSION0 => 3,
+        insts::OP_LWU_VERSION1 => 3,
+        insts::OP_LHU_VERSION0 => 3,
+        insts::OP_LHU_VERSION1 => 3,
+        insts::OP_LBU_VERSION0 => 3,
+        insts::OP_LBU_VERSION1 => 3,
+        insts::OP_SB => 3,
+        insts::OP_SH => 3,
+        insts::OP_SW => 3,
+        insts::OP_SD => 2,
+        insts::OP_BEQ => 3,
+        insts::OP_BGE => 3,
+        insts::OP_BGEU => 3,
+        insts::OP_BLT => 3,
+        insts::OP_BLTU => 3,
+        insts::OP_BNE => 3,
+        insts::OP_EBREAK => 500,
+        insts::OP_ECALL => 500,
+        insts::OP_JAL => 3,
+        insts::OP_MUL => 5,
+        insts::OP_MULW => 5,
+        insts::OP_MULH => 5,
+        insts::OP_MULHU => 5,
+        insts::OP_MULHSU => 5,
+        insts::OP_DIV => 32,
+        insts::OP_DIVW => 32,
+        insts::OP_DIVU => 32,
+        insts::OP_DIVUW => 32,
+        insts::OP_REM => 32,
+        insts::OP_REMW => 32,
+        insts::OP_REMU => 32,
+        insts::OP_REMUW => 32,
+        // MOP
+        insts::OP_WIDE_MUL => 5,
+        insts::OP_WIDE_MULU => 5,
+        insts::OP_WIDE_MULSU => 5,
+        insts::OP_WIDE_DIV => 32,
+        insts::OP_WIDE_DIVU => 32,
+        insts::OP_FAR_JUMP_REL => 3,
+        insts::OP_FAR_JUMP_ABS => 3,
+        _ => 1,
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 extern crate derive_more;
 
 pub mod bits;
+pub mod cost_model;
 pub mod debugger;
 pub mod decoder;
 pub mod error;

--- a/tests/machine_build.rs
+++ b/tests/machine_build.rs
@@ -1,22 +1,17 @@
+use bytes::Bytes;
+use ckb_vm::cost_model::constant_cycles;
 #[cfg(has_asm)]
 use ckb_vm::machine::asm::{AsmCoreMachine, AsmMachine};
-
 use ckb_vm::machine::{trace::TraceMachine, DefaultCoreMachine, VERSION1};
 use ckb_vm::{DefaultMachineBuilder, ISA_B, ISA_IMC, ISA_MOP};
-use ckb_vm::{Instruction, SparseMemory, WXorXMemory};
-
-use bytes::Bytes;
-
-pub fn instruction_cycle_func(_: Instruction) -> u64 {
-    1
-}
+use ckb_vm::{SparseMemory, WXorXMemory};
 
 #[cfg(has_asm)]
 pub fn asm_v1_imcb(path: &str) -> AsmMachine {
     let buffer: Bytes = std::fs::read(path).unwrap().into();
     let asm_core = AsmCoreMachine::new(ISA_IMC | ISA_B, VERSION1, u64::max_value());
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
-        .instruction_cycle_func(Box::new(instruction_cycle_func))
+        .instruction_cycle_func(Box::new(constant_cycles))
         .build();
     let mut machine = AsmMachine::new(core);
     machine
@@ -36,7 +31,7 @@ pub fn int_v1_imcb(
     );
     let mut machine = TraceMachine::new(
         DefaultMachineBuilder::new(core_machine)
-            .instruction_cycle_func(Box::new(instruction_cycle_func))
+            .instruction_cycle_func(Box::new(constant_cycles))
             .build(),
     );
     machine
@@ -55,7 +50,7 @@ pub fn asm_mop(path: &str, args: Vec<Bytes>, version: u32) -> AsmMachine {
     let buffer: Bytes = std::fs::read(path).unwrap().into();
     let asm_core = AsmCoreMachine::new(ISA_IMC | ISA_B | ISA_MOP, version, u64::max_value());
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
-        .instruction_cycle_func(Box::new(instruction_cycle_func))
+        .instruction_cycle_func(Box::new(constant_cycles))
         .build();
     let mut machine = AsmMachine::new(core);
     let mut argv = vec![Bytes::from("main")];
@@ -84,7 +79,7 @@ pub fn int_mop(
     );
     let mut machine = TraceMachine::new(
         DefaultMachineBuilder::new(core_machine)
-            .instruction_cycle_func(Box::new(instruction_cycle_func))
+            .instruction_cycle_func(Box::new(constant_cycles))
             .build(),
     );
     let mut argv = vec![Bytes::from("main")];

--- a/tests/test_auipc_fusion.rs
+++ b/tests/test_auipc_fusion.rs
@@ -1,23 +1,21 @@
-use std::fs;
-
-use ckb_vm::{
-    decoder::{build_decoder, Decoder},
-    instructions::{
-        execute, extract_opcode, instruction_length, set_instruction_length_n, Instruction, Utype,
-    },
-    machine::VERSION1,
-    CoreMachine, DefaultCoreMachine, DefaultMachineBuilder, Error, Memory, SparseMemory,
-    SupportMachine, ISA_IMC,
+use ckb_vm::decoder::{build_decoder, Decoder};
+use ckb_vm::instructions::{
+    execute, extract_opcode, instruction_length, set_instruction_length_n, Instruction, Utype,
 };
-use ckb_vm_definitions::instructions as insts;
-
+use ckb_vm::machine::VERSION1;
 #[cfg(has_asm)]
 use ckb_vm::{
     instructions::{blank_instruction, is_basic_block_end_instruction},
     machine::asm::{AsmCoreMachine, AsmMachine},
 };
+use ckb_vm::{
+    CoreMachine, DefaultCoreMachine, DefaultMachineBuilder, Error, Memory, SparseMemory,
+    SupportMachine, ISA_IMC,
+};
 #[cfg(has_asm)]
 use ckb_vm_definitions::asm::{calculate_slot, Trace, TRACE_ITEM_LENGTH};
+use ckb_vm_definitions::instructions as insts;
+use std::fs;
 
 // This is simplified from https://github.com/xxuejie/ckb-vm-contrib/blob/main/src/decoder.rs
 pub struct AuxDecoder {

--- a/tests/test_dy_memory.rs
+++ b/tests/test_dy_memory.rs
@@ -1,6 +1,3 @@
-use ckb_vm::{run, FlatMemory, SparseMemory};
-use std::fs;
-
 #[cfg(has_asm)]
 use ckb_vm::{
     machine::{
@@ -9,6 +6,8 @@ use ckb_vm::{
     },
     ISA_IMC,
 };
+use ckb_vm::{run, FlatMemory, SparseMemory};
+use std::fs;
 
 fn run_memory_suc(memory_size: usize, bin_path: String, bin_name: String) {
     let buffer = fs::read(bin_path).unwrap().into();

--- a/tests/test_misc.rs
+++ b/tests/test_misc.rs
@@ -1,18 +1,17 @@
-use rand::{thread_rng, Rng};
-use std::fs;
-use std::sync::atomic::{AtomicU8, Ordering};
-use std::sync::Arc;
-
+use ckb_vm::cost_model::constant_cycles;
+use ckb_vm::machine::VERSION0;
+use ckb_vm::registers::{A0, A1, A2, A3, A4, A5, A7};
 use ckb_vm::{
-    machine::VERSION0,
-    registers::{A0, A1, A2, A3, A4, A5, A7},
     run, CoreMachine, Debugger, DefaultCoreMachine, DefaultMachineBuilder, Error, FlatMemory,
     Memory, Register, SparseMemory, SupportMachine, Syscalls, WXorXMemory, ISA_IMC,
     RISCV_MAX_MEMORY, RISCV_PAGESIZE,
 };
-
 #[cfg(has_asm)]
 use ckb_vm_definitions::asm::AsmCoreMachine;
+use rand::{thread_rng, Rng};
+use std::fs;
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::Arc;
 
 #[test]
 pub fn test_andi() {
@@ -414,7 +413,7 @@ pub fn test_outofcycles_in_syscall() {
     let buffer = fs::read("tests/programs/syscall64").unwrap().into();
     let core_machine = DefaultCoreMachine::<u64, SparseMemory<u64>>::new(ISA_IMC, VERSION0, 20);
     let mut machine = DefaultMachineBuilder::new(core_machine)
-        .instruction_cycle_func(Box::new(|_| 1))
+        .instruction_cycle_func(Box::new(constant_cycles))
         .syscall(Box::new(OutOfCyclesSyscall {}))
         .build();
     machine

--- a/tests/test_mop.rs
+++ b/tests/test_mop.rs
@@ -1,7 +1,5 @@
 pub mod machine_build;
-
 use bytes::Bytes;
-
 use ckb_vm::{registers::A0, CoreMachine, Error, SupportMachine};
 
 #[test]

--- a/tests/test_reset.rs
+++ b/tests/test_reset.rs
@@ -1,4 +1,5 @@
 use bytes::Bytes;
+use ckb_vm::cost_model::constant_cycles;
 #[cfg(has_asm)]
 use ckb_vm::machine::asm::{AsmCoreMachine, AsmMachine};
 use ckb_vm::machine::{DefaultCoreMachine, DefaultMachineBuilder, VERSION1};
@@ -48,7 +49,7 @@ fn test_reset_int() {
         u64::max_value(),
     );
     let mut machine = DefaultMachineBuilder::new(core_machine)
-        .instruction_cycle_func(Box::new(machine_build::instruction_cycle_func))
+        .instruction_cycle_func(Box::new(constant_cycles))
         .syscall(Box::new(CustomSyscall {}))
         .build();
     machine.load_program(&code, &vec![]).unwrap();
@@ -71,7 +72,7 @@ fn test_reset_int_with_trace() {
     );
     let mut machine = TraceMachine::new(
         DefaultMachineBuilder::new(core_machine)
-            .instruction_cycle_func(Box::new(machine_build::instruction_cycle_func))
+            .instruction_cycle_func(Box::new(constant_cycles))
             .syscall(Box::new(CustomSyscall {}))
             .build(),
     );
@@ -91,7 +92,7 @@ fn test_reset_asm() {
 
     let asm_core = AsmCoreMachine::new(ISA_IMC | ISA_MOP, VERSION1, u64::max_value());
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
-        .instruction_cycle_func(Box::new(machine_build::instruction_cycle_func))
+        .instruction_cycle_func(Box::new(constant_cycles))
         .syscall(Box::new(CustomSyscall {}))
         .build();
     let mut machine = AsmMachine::new(core);

--- a/tests/test_resume.rs
+++ b/tests/test_resume.rs
@@ -1,17 +1,13 @@
 #![cfg(has_asm)]
-
 pub mod machine_build;
 use bytes::Bytes;
-use ckb_vm::{
-    machine::{
-        asm::{AsmCoreMachine, AsmMachine},
-        trace::TraceMachine,
-        DefaultCoreMachine, DefaultMachine, SupportMachine, VERSION0, VERSION1,
-    },
-    memory::{sparse::SparseMemory, wxorx::WXorXMemory},
-    snapshot::{make_snapshot, resume, Snapshot},
-    DefaultMachineBuilder, Error, ISA_IMC,
-};
+use ckb_vm::cost_model::constant_cycles;
+use ckb_vm::machine::asm::{AsmCoreMachine, AsmMachine};
+use ckb_vm::machine::trace::TraceMachine;
+use ckb_vm::machine::{DefaultCoreMachine, DefaultMachine, SupportMachine, VERSION0, VERSION1};
+use ckb_vm::memory::{sparse::SparseMemory, wxorx::WXorXMemory};
+use ckb_vm::snapshot::{make_snapshot, resume, Snapshot};
+use ckb_vm::{DefaultMachineBuilder, Error, ISA_IMC};
 use std::fs::File;
 use std::io::Read;
 
@@ -212,7 +208,7 @@ impl MachineTy {
             MachineTy::Asm => {
                 let asm_core1 = AsmCoreMachine::new(ISA_IMC, version, max_cycles);
                 let core1 = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core1)
-                    .instruction_cycle_func(Box::new(machine_build::instruction_cycle_func))
+                    .instruction_cycle_func(Box::new(constant_cycles))
                     .build();
                 Machine::Asm(AsmMachine::new(core1))
             }
@@ -224,7 +220,7 @@ impl MachineTy {
                     DefaultMachineBuilder::<DefaultCoreMachine<u64, WXorXMemory<SparseMemory<u64>>>>::new(
                         core_machine1,
                     )
-                    .instruction_cycle_func(Box::new(machine_build::instruction_cycle_func))
+                    .instruction_cycle_func(Box::new(constant_cycles))
                     .build(),
                 )
             }
@@ -237,7 +233,7 @@ impl MachineTy {
                         DefaultMachineBuilder::<
                             DefaultCoreMachine<u64, WXorXMemory<SparseMemory<u64>>>,
                         >::new(core_machine1)
-                        .instruction_cycle_func(Box::new(machine_build::instruction_cycle_func))
+                        .instruction_cycle_func(Box::new(constant_cycles))
                         .build(),
                     ),
                 )

--- a/tests/test_versions.rs
+++ b/tests/test_versions.rs
@@ -1,11 +1,8 @@
 #![cfg(has_asm)]
-
+use ckb_vm::machine::asm::{AsmCoreMachine, AsmMachine};
+use ckb_vm::machine::{VERSION0, VERSION1};
+use ckb_vm::memory::{FLAG_DIRTY, FLAG_FREEZED};
 use ckb_vm::{
-    machine::{
-        asm::{AsmCoreMachine, AsmMachine},
-        VERSION0, VERSION1,
-    },
-    memory::{FLAG_DIRTY, FLAG_FREEZED},
     CoreMachine, DefaultCoreMachine, DefaultMachine, DefaultMachineBuilder, Error, Memory,
     SparseMemory, WXorXMemory, ISA_IMC, RISCV_PAGESIZE,
 };


### PR DESCRIPTION
ckb-vm will maintain a default `instruction_cycle_func`. This can simplify the development of some small tools based on ckb-vm.