### PR TITLE
Add probes for syscalls and functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ enable-chaos-mode-by-default = ["ckb-vm-definitions/enable-chaos-mode-by-default
 # Disable slow tests to run miri on CI
 miri-ci = []
 pprof = []
+probes = ["dep:probe"]
 
 [dependencies]
 byteorder = "1"
@@ -32,7 +33,7 @@ serde = { version = "1.0", features = ["derive"] }
 ckb-vm-definitions = { path = "definitions", version = "=0.24.0-beta" }
 derive_more = "0.99.2"
 rand = "0.7.3"
-probe = { version = "0.5.0" }
+probe = { version = "0.5.0", optional = true }
 
 [build-dependencies]
 cc = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ serde = { version = "1.0", features = ["derive"] }
 ckb-vm-definitions = { path = "definitions", version = "=0.24.0-beta" }
 derive_more = "0.99.2"
 rand = "0.7.3"
+probe = { version = "0.5.0" }
 
 [build-dependencies]
 cc = "1.0"

--- a/src/instructions/common.rs
+++ b/src/instructions/common.rs
@@ -5,6 +5,9 @@ use super::register::Register;
 use super::utils::update_register;
 use super::{Error, RegisterIndex, SImmediate, UImmediate};
 
+#[cfg(feature = "probes")]
+use crate::probe::probe_jump;
+
 // Other instruction set functions common with RVC
 
 // ======================
@@ -380,6 +383,9 @@ pub fn sraiw<Mac: Machine>(
 // =======================
 pub fn jal<Mac: Machine>(machine: &mut Mac, rd: RegisterIndex, imm: SImmediate, xbytes: u8) {
     let link = machine.pc().overflowing_add(&Mac::REG::from_u8(xbytes));
-    update_register(machine, rd, link);
-    machine.update_pc(machine.pc().overflowing_add(&Mac::REG::from_i32(imm)));
+    update_register(machine, rd, link.clone());
+    let next_pc = machine.pc().overflowing_add(&Mac::REG::from_i32(imm));
+    #[cfg(feature = "probes")]
+    probe_jump(machine, link.clone(), next_pc.clone());
+    machine.update_pc(next_pc);
 }

--- a/src/instructions/execute.rs
+++ b/src/instructions/execute.rs
@@ -7,6 +7,9 @@ use super::{
 use crate::memory::Memory;
 use ckb_vm_definitions::{instructions as insts, registers::RA};
 
+#[cfg(feature = "probes")]
+use crate::probe::probe_jump;
+
 pub fn execute_instruction<Mac: Machine>(
     inst: Instruction,
     machine: &mut Mac,
@@ -417,6 +420,8 @@ pub fn execute_instruction<Mac: Machine>(
             let mut next_pc =
                 machine.registers()[i.rs1()].overflowing_add(&Mac::REG::from_i32(i.immediate_s()));
             next_pc = next_pc & (!Mac::REG::one());
+            #[cfg(feature = "probes")]
+            probe_jump(machine, link.clone(), next_pc.clone());
             update_register(machine, i.rd(), link);
             machine.update_pc(next_pc);
         }
@@ -1037,6 +1042,8 @@ pub fn execute_instruction<Mac: Machine>(
                 .pc()
                 .overflowing_add(&Mac::REG::from_i32(i.immediate_s()))
                 & (!Mac::REG::one());
+            #[cfg(feature = "probes")]
+            probe_jump(machine, link.clone(), next_pc.clone());
             update_register(machine, RA, link);
             machine.update_pc(next_pc);
         }
@@ -1045,6 +1052,8 @@ pub fn execute_instruction<Mac: Machine>(
             let size = instruction_length(inst);
             let link = machine.pc().overflowing_add(&Mac::REG::from_u8(size));
             let next_pc = Mac::REG::from_i32(i.immediate_s()) & (!Mac::REG::one());
+            #[cfg(feature = "probes")]
+            probe_jump(machine, link.clone(), next_pc.clone());
             update_register(machine, RA, link);
             machine.update_pc(next_pc);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,9 @@ pub fn run<R: Register, M: Memory<REG = R>>(
     machine.run()
 }
 
+#[cfg(feature = "probes")]
+pub mod probe;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -14,9 +14,12 @@ use super::instructions::{execute, Instruction, Register};
 use super::memory::{round_page_down, round_page_up, Memory};
 use super::syscalls::Syscalls;
 use super::{
-    registers::{A0, A1, A2, A3, A4, A5, A7, REGISTER_ABI_NAMES, SP},
+    registers::{A0, A7, REGISTER_ABI_NAMES, SP},
     Error, ISA_MOP, RISCV_GENERAL_REGISTER_NUMBER, RISCV_MAX_MEMORY,
 };
+
+#[cfg(feature = "probes")]
+use crate::probe::{probe_syscall, probe_syscall_return};
 
 // Version 0 is the initial launched CKB VM, it is used in CKB Lina mainnet
 pub const VERSION0: u32 = 0;
@@ -48,6 +51,16 @@ pub trait CoreMachine {
     // in case of bug fixes.
     fn version(&self) -> u32;
     fn isa(&self) -> u8;
+
+    #[cfg(feature = "probes")]
+    fn registers_ptr(&self) -> *const Self::REG {
+        self.registers().as_ptr()
+    }
+
+    #[cfg(feature = "probes")]
+    fn memory_ptr(&self) -> *const Self::REG {
+        self.memory().ptr()
+    }
 }
 
 /// This is the core trait describing a full RISC-V machine. Instruction
@@ -512,14 +525,10 @@ impl<Inner: SupportMachine> SupportMachine for DefaultMachine<Inner> {
 impl<Inner: SupportMachine> Machine for DefaultMachine<Inner> {
     fn ecall(&mut self) -> Result<(), Error> {
         let code = self.registers()[A7].to_u64();
-        let arg0 = self.registers()[A0].to_u64();
-        let arg1 = self.registers()[A1].to_u64();
-        let arg2 = self.registers()[A2].to_u64();
-        let arg3 = self.registers()[A3].to_u64();
-        let arg4 = self.registers()[A4].to_u64();
-        let arg5 = self.registers()[A5].to_u64();
-        dbg!(code, arg0, arg1, arg2, arg3);
-        probe::probe!(ckb_vm, syscall, code, arg0, arg1, arg2, arg3, arg4, arg5);
+        #[cfg(feature = "probes")]
+        let syscall_number = code.clone().to_u64();
+        #[cfg(feature = "probes")]
+        probe_syscall(self, syscall_number);
         match code {
             93 => {
                 // exit
@@ -531,10 +540,8 @@ impl<Inner: SupportMachine> Machine for DefaultMachine<Inner> {
                 for syscall in &mut self.syscalls {
                     let processed = syscall.ecall(&mut self.inner)?;
                     if processed {
-                        let ret_code = self.registers()[A0].to_u64();
-                        let ret_code2 = self.registers()[A2].to_u64();
-                        dbg!(code, ret_code, ret_code2);
-                        probe::probe!(ckb_vm, syscall_ret, code, ret_code, ret_code2);
+                        #[cfg(feature = "probes")]
+                        probe_syscall_return(self, syscall_number);
                         if self.cycles() > self.max_cycles() {
                             return Err(Error::CyclesExceeded);
                         }

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -14,7 +14,7 @@ use super::instructions::{execute, Instruction, Register};
 use super::memory::{round_page_down, round_page_up, Memory};
 use super::syscalls::Syscalls;
 use super::{
-    registers::{A0, A7, REGISTER_ABI_NAMES, SP},
+    registers::{A0, A1, A2, A3, A4, A5, A7, REGISTER_ABI_NAMES, SP},
     Error, ISA_MOP, RISCV_GENERAL_REGISTER_NUMBER, RISCV_MAX_MEMORY,
 };
 
@@ -512,6 +512,14 @@ impl<Inner: SupportMachine> SupportMachine for DefaultMachine<Inner> {
 impl<Inner: SupportMachine> Machine for DefaultMachine<Inner> {
     fn ecall(&mut self) -> Result<(), Error> {
         let code = self.registers()[A7].to_u64();
+        let arg0 = self.registers()[A0].to_u64();
+        let arg1 = self.registers()[A1].to_u64();
+        let arg2 = self.registers()[A2].to_u64();
+        let arg3 = self.registers()[A3].to_u64();
+        let arg4 = self.registers()[A4].to_u64();
+        let arg5 = self.registers()[A5].to_u64();
+        dbg!(code, arg0, arg1, arg2, arg3);
+        probe::probe!(ckb_vm, syscall, code, arg0, arg1, arg2, arg3, arg4, arg5);
         match code {
             93 => {
                 // exit
@@ -523,6 +531,10 @@ impl<Inner: SupportMachine> Machine for DefaultMachine<Inner> {
                 for syscall in &mut self.syscalls {
                     let processed = syscall.ecall(&mut self.inner)?;
                     if processed {
+                        let ret_code = self.registers()[A0].to_u64();
+                        let ret_code2 = self.registers()[A2].to_u64();
+                        dbg!(code, ret_code, ret_code2);
+                        probe::probe!(ckb_vm, syscall_ret, code, ret_code, ret_code2);
                         if self.cycles() > self.max_cycles() {
                             return Err(Error::CyclesExceeded);
                         }

--- a/src/memory/flat.rs
+++ b/src/memory/flat.rs
@@ -229,4 +229,9 @@ impl<R: Register> Memory for FlatMemory<R> {
     fn set_lr(&mut self, value: &Self::REG) {
         self.load_reservation_address = value.clone();
     }
+
+    #[cfg(feature = "probes")]
+    fn ptr(&self) -> *const Self::REG {
+        self.data.as_ptr() as *const Self::REG
+    }
 }

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -68,6 +68,11 @@ pub trait Memory {
     // Load reservation address for atomic extension.
     fn lr(&self) -> &Self::REG;
     fn set_lr(&mut self, value: &Self::REG);
+
+    #[cfg(feature = "probes")]
+    fn ptr(&self) -> *const Self::REG {
+        unimplemented!("memory ptr not implemented")
+    }
 }
 
 #[inline(always)]

--- a/src/memory/wxorx.rs
+++ b/src/memory/wxorx.rs
@@ -157,4 +157,9 @@ impl<M: Memory> Memory for WXorXMemory<M> {
     fn set_lr(&mut self, value: &Self::REG) {
         self.inner.set_lr(value);
     }
+
+    #[cfg(feature = "probes")]
+    fn ptr(&self) -> *const Self::REG {
+        self.inner.ptr()
+    }
 }

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -1,0 +1,25 @@
+use crate::instructions::Register;
+use crate::machine::Machine;
+use crate::registers::{A0, A1, A2, A3, A4, A5};
+
+pub fn probe_jump<Mac: Machine>(machine: &mut Mac, link: Mac::REG, next_pc: Mac::REG) {
+    let regs = machine.registers_ptr();
+    let memory = machine.memory_ptr();
+    probe::probe!(ckb_vm, jump, link.to_u64(), next_pc.to_u64(), regs, memory);
+}
+
+pub fn probe_syscall<Mac: Machine>(machine: &mut Mac, code: u64) {
+    let arg0 = machine.registers()[A0].to_u64();
+    let arg1 = machine.registers()[A1].to_u64();
+    let arg2 = machine.registers()[A2].to_u64();
+    let arg3 = machine.registers()[A3].to_u64();
+    let arg4 = machine.registers()[A4].to_u64();
+    let arg5 = machine.registers()[A5].to_u64();
+    probe::probe!(ckb_vm, syscall, code, arg0, arg1, arg2, arg3, arg4, arg5);
+}
+
+pub fn probe_syscall_return<Mac: Machine>(machine: &mut Mac, code: u64) {
+    let ret_code = machine.registers()[A0].to_u64();
+    let ret_code2 = machine.registers()[A1].to_u64();
+    probe::probe!(ckb_vm, syscall_ret, code, ret_code, ret_code2);
+}


### PR DESCRIPTION
There are two probes added here. One is used to track syscall parameters and return values. One is used to track function calls and returns. The functionality of the code here has been manually verified with https://github.com/contrun/ckb-vm-bpf-toolkit/blob/731ce2095eb4074e57616dad538ed51bf598f255/tools/uretprobe.py. I used https://github.com/contrun/ckb-standalone-debugger/tree/use-ckb-vm-with-probe-support (which requires https://github.com/contrun/ckb-vm/tree/add-probes-for-syscalls-and-functions that have the same code change to this commit except that is based on v0.22.2) to show the usage of these probes. For example, below is a sample output of running `sudo env RUST_LOG=debug ./tools/memdump.py --bin ../ckb-lua/build/lua-loader.debug -- -e 'print(42)' --bpf-func "^test_func$" --bpf-regs a0 --bpf-debugger ../ckb-standalone-debugger/target/release/ckb-debugger`

```
Func test_func has been jumped to/from 2 times!
Func test_func has been called 1 times!
Func test_func has returned 1 times!
Dumping return value counts for func test_func
return value: 000000000005d020, count: 1
Dumping meomry addresses for func test_func
memory addr: 00007f1474126010, content: 0000000000000001
Dumping meomry content for func test_func
memory addr: 000000000005d020, content: 31302f2e2d2c2b2a
```