### PR TITLE
Bump version to v0.24.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ckb-vm"
 description = "CKB's Virtual machine"
-version = "0.24.0-beta"
+version = "0.24.0"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2021"
@@ -29,7 +29,7 @@ goblin_v023 = { package = "goblin", version = "=0.2.3" }
 goblin_v040 = { package = "goblin", version = "=0.4.0" }
 scroll = "0.10"
 serde = { version = "1.0", features = ["derive"] }
-ckb-vm-definitions = { path = "definitions", version = "=0.24.0-beta" }
+ckb-vm-definitions = { path = "definitions", version = "=0.24.0" }
 derive_more = "0.99.2"
 rand = "0.7.3"
 

--- a/definitions/Cargo.toml
+++ b/definitions/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ckb-vm-definitions"
 description = "Common definition files for CKB VM"
-version = "0.24.0-beta"
+version = "0.24.0"
 license = "MIT"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2021"


### PR DESCRIPTION
v0.24.0-beta has been around for a while, it is recommended to upgrade to v0.24.0