### PR TITLE
feat: Add a new external node to Value AST

### DIFF
--- a/src/instructions/ast.rs
+++ b/src/instructions/ast.rs
@@ -52,6 +52,7 @@ pub enum Value {
     SignOp2(SignActionOp2, Rc<Value>, Rc<Value>, bool),
     Cond(Rc<Value>, Rc<Value>, Rc<Value>),
     Load(Rc<Value>, u8),
+    External(Rc<Value>, u64),
 }
 
 impl Default for Value {


### PR DESCRIPTION
While ckb-vm itself won't really use it, some external libraries might benefit from having an externally customizable node. A similar example might be found in `Error::External`.