### PR TITLE
refactor: Remove initializers from Memory trait

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ trigger:
     - '*'
 
 variables:
-  TEST_SUITE_COMMIT: 441e0f2149c097ccad133b040544dca13caeb01e
+  TEST_SUITE_COMMIT: 86480364649c9cb6ac01674fe51156e7cf50a31a
 
 jobs:
   - job: LinuxCIDeps

--- a/benches/vm_benchmark.rs
+++ b/benches/vm_benchmark.rs
@@ -10,7 +10,7 @@ use ckb_vm::{
     },
     ISA_B, ISA_IMC, ISA_MOP,
 };
-use ckb_vm::{run, SparseMemory, RISCV_MAX_MEMORY};
+use ckb_vm::{run, SparseMemory};
 use criterion::Criterion;
 use std::fs;
 
@@ -23,7 +23,7 @@ fn interpret_benchmark(c: &mut Criterion) {
                                       "foo",
                                       "bar"].into_iter().map(|a| a.into()).collect();
 
-        b.iter(|| run::<u64, SparseMemory<u64>>(&buffer, &args[..], RISCV_MAX_MEMORY).unwrap());
+        b.iter(|| run::<u64, SparseMemory<u64>>(&buffer, &args[..]).unwrap());
     });
 }
 

--- a/examples/check_real_memory.rs
+++ b/examples/check_real_memory.rs
@@ -1,7 +1,7 @@
 // This example is mainly to test whether there is memory overflow.
 // Under linux, we choose to use smem, which can monitor memory changes more accurately
 
-use ckb_vm::{run, Bytes, FlatMemory, SparseMemory};
+use ckb_vm::{run_with_memory, Bytes, FlatMemory, SparseMemory};
 use lazy_static::lazy_static;
 use std::process::{id, Command};
 
@@ -127,10 +127,10 @@ fn check_interpreter(memory_size: usize) -> Result<(), ()> {
     );
     println!("Base memory: {}", get_current_memory());
     for _ in 0..G_CHECK_LOOP {
-        let result = run::<u64, SparseMemory<u64>>(
+        let result = run_with_memory::<u64, SparseMemory<u64>>(
             &BIN_PATH_BUFFER,
             &vec![BIN_NAME.clone().into()],
-            memory_size,
+            SparseMemory::new_with_memory(memory_size),
         );
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), 0);
@@ -147,10 +147,10 @@ fn check_falt(memory_size: usize) -> Result<(), ()> {
     );
     println!("Base memory: {}", get_current_memory());
     for _ in 0..G_CHECK_LOOP {
-        let result = run::<u64, FlatMemory<u64>>(
+        let result = run_with_memory::<u64, FlatMemory<u64>>(
             &BIN_PATH_BUFFER,
             &vec![BIN_NAME.clone().into()],
-            memory_size,
+            FlatMemory::new_with_memory(memory_size),
         );
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), 0);

--- a/examples/is13.rs
+++ b/examples/is13.rs
@@ -26,7 +26,6 @@
 //  or $ cargo run --example is13 0xd
 //  or $ cargo run --example is13 HELLO
 use bytes::Bytes;
-use ckb_vm::RISCV_MAX_MEMORY;
 use std::io::Read;
 
 fn main() {
@@ -37,8 +36,7 @@ fn main() {
     file.read_to_end(&mut buffer).unwrap();
     let buffer = Bytes::from(buffer);
 
-    let r = ckb_vm::run::<u64, ckb_vm::SparseMemory<u64>>(&buffer, &args[..], RISCV_MAX_MEMORY)
-        .unwrap();
+    let r = ckb_vm::run::<u64, ckb_vm::SparseMemory<u64>>(&buffer, &args[..]).unwrap();
     match r {
         1 => println!("{:?} is not thirteen", args[1]),
         0 => println!("{:?} is thirteen", args[1]),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,11 +55,11 @@ pub fn run_with_memory<R: Register, M: Memory<REG = R>>(
     args: &[Bytes],
     memory: M,
 ) -> Result<i8, Error> {
-    let core_machine = DefaultCoreMachine::<R, M>::new_with_memory(
+    let core_machine = DefaultCoreMachine::<R, WXorXMemory<M>>::new_with_memory(
         ISA_IMC | ISA_A | ISA_B | ISA_MOP,
         machine::VERSION2,
         u64::max_value(),
-        memory,
+        WXorXMemory::new(memory),
     );
     let mut machine = TraceMachine::new(DefaultMachineBuilder::new(core_machine).build());
     machine.load_program(program, args)?;

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -30,14 +30,8 @@ pub type Page = [u8; RISCV_PAGESIZE];
 pub trait Memory {
     type REG: Register;
 
-    fn new() -> Self
-    where
-        Self: Sized,
-    {
-        Self::new_with_memory(RISCV_MAX_MEMORY)
-    }
+    fn reset_memory(&mut self) -> Result<(), Error>;
 
-    fn new_with_memory(memory_size: usize) -> Self;
     fn init_pages(
         &mut self,
         addr: u64,

--- a/src/memory/wxorx.rs
+++ b/src/memory/wxorx.rs
@@ -14,15 +14,23 @@ impl<M: Memory> WXorXMemory<M> {
     pub fn inner_mut(&mut self) -> &mut M {
         &mut self.inner
     }
+
+    pub fn new(inner: M) -> Self {
+        Self { inner }
+    }
+}
+
+impl<M: Memory + Default> Default for WXorXMemory<M> {
+    fn default() -> Self {
+        Self::new(M::default())
+    }
 }
 
 impl<M: Memory> Memory for WXorXMemory<M> {
     type REG = M::REG;
 
-    fn new_with_memory(memory_size: usize) -> Self {
-        Self {
-            inner: M::new_with_memory(memory_size),
-        }
+    fn reset_memory(&mut self) -> Result<(), Error> {
+        self.inner.reset_memory()
     }
 
     fn init_pages(

--- a/tests/test_dy_memory.rs
+++ b/tests/test_dy_memory.rs
@@ -6,17 +6,24 @@ use ckb_vm::{
     },
     ISA_IMC,
 };
-use ckb_vm::{run, FlatMemory, SparseMemory};
+use ckb_vm::{run_with_memory, FlatMemory, SparseMemory};
 use std::fs;
 
 fn run_memory_suc(memory_size: usize, bin_path: String, bin_name: String) {
     let buffer = fs::read(bin_path).unwrap().into();
-    let result =
-        run::<u64, SparseMemory<u64>>(&buffer, &vec![bin_name.clone().into()], memory_size);
+    let result = run_with_memory::<u64, SparseMemory<u64>>(
+        &buffer,
+        &vec![bin_name.clone().into()],
+        SparseMemory::new_with_memory(memory_size),
+    );
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);
 
-    let result = run::<u64, FlatMemory<u64>>(&buffer, &vec![bin_name.clone().into()], memory_size);
+    let result = run_with_memory::<u64, FlatMemory<u64>>(
+        &buffer,
+        &vec![bin_name.clone().into()],
+        FlatMemory::new_with_memory(memory_size),
+    );
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);
 
@@ -48,11 +55,19 @@ fn test_dy_memory() {
 fn test_memory_out_of_bounds() {
     let memory_size = 1024 * 256;
     let buffer = fs::read("tests/programs/alloc_many").unwrap().into();
-    let result = run::<u64, SparseMemory<u64>>(&buffer, &vec!["alloc_many".into()], memory_size);
+    let result = run_with_memory::<u64, SparseMemory<u64>>(
+        &buffer,
+        &vec!["alloc_many".into()],
+        SparseMemory::new_with_memory(memory_size),
+    );
     assert!(result.is_err());
     assert_eq!(ckb_vm::Error::MemOutOfBound, result.err().unwrap());
 
-    let result = run::<u64, FlatMemory<u64>>(&buffer, &vec!["alloc_many".into()], memory_size);
+    let result = run_with_memory::<u64, FlatMemory<u64>>(
+        &buffer,
+        &vec!["alloc_many".into()],
+        FlatMemory::new_with_memory(memory_size),
+    );
     assert!(result.is_err());
     assert_eq!(ckb_vm::Error::MemOutOfBound, result.err().unwrap());
 

--- a/tests/test_minimal.rs
+++ b/tests/test_minimal.rs
@@ -1,10 +1,10 @@
-use ckb_vm::{run, SparseMemory, RISCV_MAX_MEMORY};
+use ckb_vm::{run, SparseMemory};
 use std::fs;
 
 #[test]
 pub fn test_minimal_with_no_args() {
     let buffer = fs::read("tests/programs/minimal").unwrap().into();
-    let result = run::<u32, SparseMemory<u32>>(&buffer, &vec!["minimal".into()], RISCV_MAX_MEMORY);
+    let result = run::<u32, SparseMemory<u32>>(&buffer, &vec!["minimal".into()]);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 1);
 }
@@ -12,11 +12,7 @@ pub fn test_minimal_with_no_args() {
 #[test]
 pub fn test_minimal_with_a() {
     let buffer = fs::read("tests/programs/minimal").unwrap().into();
-    let result = run::<u32, SparseMemory<u32>>(
-        &buffer,
-        &vec!["minimal".into(), "a".into()],
-        RISCV_MAX_MEMORY,
-    );
+    let result = run::<u32, SparseMemory<u32>>(&buffer, &vec!["minimal".into(), "a".into()]);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 2);
 }
@@ -24,11 +20,7 @@ pub fn test_minimal_with_a() {
 #[test]
 pub fn test_minimal_with_b() {
     let buffer = fs::read("tests/programs/minimal").unwrap().into();
-    let result = run::<u32, SparseMemory<u32>>(
-        &buffer,
-        &vec!["minimal".into(), "".into()],
-        RISCV_MAX_MEMORY,
-    );
+    let result = run::<u32, SparseMemory<u32>>(&buffer, &vec!["minimal".into(), "".into()]);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);
 }

--- a/tests/test_misc.rs
+++ b/tests/test_misc.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 #[test]
 pub fn test_andi() {
     let buffer = fs::read("tests/programs/andi").unwrap().into();
-    let result = run::<u32, SparseMemory<u32>>(&buffer, &vec!["andi".into()], RISCV_MAX_MEMORY);
+    let result = run::<u32, SparseMemory<u32>>(&buffer, &vec!["andi".into()]);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);
 }
@@ -24,7 +24,7 @@ pub fn test_andi() {
 #[test]
 pub fn test_nop() {
     let buffer = fs::read("tests/programs/nop").unwrap().into();
-    let result = run::<u32, SparseMemory<u32>>(&buffer, &vec!["nop".into()], RISCV_MAX_MEMORY);
+    let result = run::<u32, SparseMemory<u32>>(&buffer, &vec!["nop".into()]);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);
 }
@@ -107,7 +107,7 @@ pub fn test_ebreak() {
 #[test]
 pub fn test_trace() {
     let buffer = fs::read("tests/programs/trace64").unwrap().into();
-    let result = run::<u64, SparseMemory<u64>>(&buffer, &vec!["trace64".into()], RISCV_MAX_MEMORY);
+    let result = run::<u64, SparseMemory<u64>>(&buffer, &vec!["trace64".into()]);
     assert!(result.is_err());
     assert_eq!(result.err(), Some(Error::MemWriteOnExecutablePage));
 }
@@ -115,7 +115,7 @@ pub fn test_trace() {
 #[test]
 pub fn test_jump0() {
     let buffer = fs::read("tests/programs/jump0_64").unwrap().into();
-    let result = run::<u64, SparseMemory<u64>>(&buffer, &vec!["jump0_64".into()], RISCV_MAX_MEMORY);
+    let result = run::<u64, SparseMemory<u64>>(&buffer, &vec!["jump0_64".into()]);
     assert!(result.is_err());
     assert_eq!(result.err(), Some(Error::MemWriteOnExecutablePage));
 }
@@ -123,15 +123,14 @@ pub fn test_jump0() {
 #[test]
 pub fn test_misaligned_jump64() {
     let buffer = fs::read("tests/programs/misaligned_jump64").unwrap().into();
-    let result =
-        run::<u64, SparseMemory<u64>>(&buffer, &vec!["misaligned_jump64".into()], RISCV_MAX_MEMORY);
+    let result = run::<u64, SparseMemory<u64>>(&buffer, &vec!["misaligned_jump64".into()]);
     assert!(result.is_ok());
 }
 
 #[test]
 pub fn test_mulw64() {
     let buffer = fs::read("tests/programs/mulw64").unwrap().into();
-    let result = run::<u64, SparseMemory<u64>>(&buffer, &vec!["mulw64".into()], RISCV_MAX_MEMORY);
+    let result = run::<u64, SparseMemory<u64>>(&buffer, &vec!["mulw64".into()]);
     assert!(result.is_ok());
 }
 
@@ -140,11 +139,7 @@ pub fn test_invalid_file_offset64() {
     let buffer = fs::read("tests/programs/invalid_file_offset64")
         .unwrap()
         .into();
-    let result = run::<u64, SparseMemory<u64>>(
-        &buffer,
-        &vec!["invalid_file_offset64".into()],
-        RISCV_MAX_MEMORY,
-    );
+    let result = run::<u64, SparseMemory<u64>>(&buffer, &vec!["invalid_file_offset64".into()]);
     assert_eq!(result.err(), Some(Error::ElfSegmentAddrOrSizeError));
 }
 
@@ -154,11 +149,7 @@ pub fn test_op_rvc_srli_crash_32() {
     let buffer = fs::read("tests/programs/op_rvc_srli_crash_32")
         .unwrap()
         .into();
-    let result = run::<u32, SparseMemory<u32>>(
-        &buffer,
-        &vec!["op_rvc_srli_crash_32".into()],
-        RISCV_MAX_MEMORY,
-    );
+    let result = run::<u32, SparseMemory<u32>>(&buffer, &vec!["op_rvc_srli_crash_32".into()]);
     assert_eq!(result.err(), Some(Error::MemWriteOnExecutablePage));
 }
 
@@ -168,11 +159,7 @@ pub fn test_op_rvc_srai_crash_32() {
     let buffer = fs::read("tests/programs/op_rvc_srai_crash_32")
         .unwrap()
         .into();
-    let result = run::<u32, SparseMemory<u32>>(
-        &buffer,
-        &vec!["op_rvc_srai_crash_32".into()],
-        RISCV_MAX_MEMORY,
-    );
+    let result = run::<u32, SparseMemory<u32>>(&buffer, &vec!["op_rvc_srai_crash_32".into()]);
     assert!(result.is_ok());
 }
 
@@ -182,27 +169,21 @@ pub fn test_op_rvc_slli_crash_32() {
     let buffer = fs::read("tests/programs/op_rvc_slli_crash_32")
         .unwrap()
         .into();
-    let result = run::<u32, SparseMemory<u32>>(
-        &buffer,
-        &vec!["op_rvc_slli_crash_32".into()],
-        RISCV_MAX_MEMORY,
-    );
+    let result = run::<u32, SparseMemory<u32>>(&buffer, &vec!["op_rvc_slli_crash_32".into()]);
     assert!(result.is_ok());
 }
 
 #[test]
 pub fn test_load_elf_crash_64() {
     let buffer = fs::read("tests/programs/load_elf_crash_64").unwrap().into();
-    let result =
-        run::<u64, SparseMemory<u64>>(&buffer, &vec!["load_elf_crash_64".into()], RISCV_MAX_MEMORY);
+    let result = run::<u64, SparseMemory<u64>>(&buffer, &vec!["load_elf_crash_64".into()]);
     assert_eq!(result.err(), Some(Error::MemWriteOnExecutablePage));
 }
 
 #[test]
 pub fn test_wxorx_crash_64() {
     let buffer = fs::read("tests/programs/wxorx_crash_64").unwrap().into();
-    let result =
-        run::<u64, SparseMemory<u64>>(&buffer, &vec!["wxorx_crash_64".into()], RISCV_MAX_MEMORY);
+    let result = run::<u64, SparseMemory<u64>>(&buffer, &vec!["wxorx_crash_64".into()]);
     assert_eq!(result.err(), Some(Error::MemOutOfBound));
 }
 
@@ -218,9 +199,9 @@ pub fn test_flat_crash_64() {
 
 #[test]
 pub fn test_memory_store_empty_bytes() {
-    assert_memory_store_empty_bytes(&mut FlatMemory::<u64>::new());
-    assert_memory_store_empty_bytes(&mut SparseMemory::<u64>::new());
-    assert_memory_store_empty_bytes(&mut WXorXMemory::<FlatMemory<u64>>::new());
+    assert_memory_store_empty_bytes(&mut FlatMemory::<u64>::default());
+    assert_memory_store_empty_bytes(&mut SparseMemory::<u64>::default());
+    assert_memory_store_empty_bytes(&mut WXorXMemory::<FlatMemory<u64>>::default());
     #[cfg(has_asm)]
     assert_memory_store_empty_bytes(&mut AsmCoreMachine::new(ISA_IMC, VERSION0, 200_000));
 }
@@ -260,7 +241,7 @@ fn assert_memory_load_bytes_all<R: Rng>(
     );
     assert_memory_load_bytes(
         rng,
-        &mut WXorXMemory::<FlatMemory<u64>>::new_with_memory(max_memory),
+        &mut WXorXMemory::new(FlatMemory::<u64>::new_with_memory(max_memory)),
         buf_size,
         addr,
     );

--- a/tests/test_reset.rs
+++ b/tests/test_reset.rs
@@ -24,7 +24,7 @@ impl<Mac: SupportMachine> Syscalls<Mac> for CustomSyscall {
             return Ok(false);
         }
         let cycles = machine.cycles();
-        machine.reset(machine.max_cycles());
+        machine.reset(machine.max_cycles()).expect("reset");
         machine.set_cycles(cycles);
         let code_data = std::fs::read("tests/programs/reset_callee").unwrap();
         let code = Bytes::from(code_data);

--- a/tests/test_simple.rs
+++ b/tests/test_simple.rs
@@ -1,14 +1,14 @@
 use ckb_vm::machine::VERSION0;
 use ckb_vm::{
     run, DefaultCoreMachine, DefaultMachineBuilder, Error, FlatMemory, Instruction, SparseMemory,
-    SupportMachine, ISA_IMC, RISCV_MAX_MEMORY,
+    SupportMachine, ISA_IMC,
 };
 use std::fs;
 
 #[test]
 pub fn test_simple_instructions() {
     let buffer = fs::read("tests/programs/simple").unwrap().into();
-    let result = run::<u32, SparseMemory<u32>>(&buffer, &vec!["simple".into()], RISCV_MAX_MEMORY);
+    let result = run::<u32, SparseMemory<u32>>(&buffer, &vec!["simple".into()]);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);
 }
@@ -16,7 +16,7 @@ pub fn test_simple_instructions() {
 #[test]
 pub fn test_simple_instructions_64() {
     let buffer = fs::read("tests/programs/simple64").unwrap().into();
-    let result = run::<u64, SparseMemory<u64>>(&buffer, &vec!["simple".into()], RISCV_MAX_MEMORY);
+    let result = run::<u64, SparseMemory<u64>>(&buffer, &vec!["simple".into()]);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);
 }
@@ -24,7 +24,7 @@ pub fn test_simple_instructions_64() {
 #[test]
 pub fn test_simple_instructions_flatmemory() {
     let buffer = fs::read("tests/programs/simple").unwrap().into();
-    let result = run::<u32, FlatMemory<u32>>(&buffer, &vec!["simple".into()], RISCV_MAX_MEMORY);
+    let result = run::<u32, FlatMemory<u32>>(&buffer, &vec!["simple".into()]);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), 0);
 }
@@ -71,7 +71,7 @@ pub fn test_simple_max_cycles_reached() {
 #[test]
 pub fn test_simple_invalid_bits() {
     let buffer = fs::read("tests/programs/simple").unwrap().into();
-    let result = run::<u64, SparseMemory<u64>>(&buffer, &vec!["simple".into()], RISCV_MAX_MEMORY);
+    let result = run::<u64, SparseMemory<u64>>(&buffer, &vec!["simple".into()]);
     assert!(result.is_err());
     assert_eq!(result.unwrap_err(), Error::ElfBits);
 }


### PR DESCRIPTION
Different memory trait impls might require different ways of initializing,what's more, having initializers in Memory trait would prevent us from writing `Box<dyn Memory<u64>>`. What we really need here, is a reset memory function. This changes uses `reset_memory` to replace initializers in Memory trait.