### PR TITLE
feat: Add opcode enumerating helpers using macros

### DIFF
--- a/definitions/Cargo.toml
+++ b/definitions/Cargo.toml
@@ -16,3 +16,6 @@ enable-chaos-mode-by-default = []
 [[bin]]
 name = "generate_asm_constants"
 path = "src/generate_asm_constants.rs"
+
+[dependencies]
+paste = "1.0.12"

--- a/definitions/src/generate_asm_constants.rs
+++ b/definitions/src/generate_asm_constants.rs
@@ -5,15 +5,25 @@ use ckb_vm_definitions::{
         TRACE_ITEM_LENGTH,
     },
     instructions::{
-        instruction_opcode_name, Instruction, INSTRUCTION_OPCODE_NAMES, MAXIMUM_OPCODE,
+        instruction_opcode_name, Instruction, MAXIMUM_OPCODE,
         MINIMAL_OPCODE,
     },
     memory::{FLAG_DIRTY, FLAG_EXECUTABLE, FLAG_FREEZED, FLAG_WRITABLE, FLAG_WXORX_BIT},
     registers::{RA, SP},
     MEMORY_FRAMES, MEMORY_FRAMESIZE, MEMORY_FRAME_PAGE_SHIFTS, MEMORY_FRAME_SHIFTS,
     RISCV_MAX_MEMORY, RISCV_PAGES, RISCV_PAGESIZE, RISCV_PAGE_SHIFTS,
+    for_each_inst,
 };
 use std::mem::{size_of, zeroed};
+
+macro_rules! print_inst_label {
+    ($name:ident, $real_name:ident, $code:expr) => {
+        println!(
+            "\t.long\t.CKB_VM_ASM_LABEL_OP_{} - .CKB_VM_ASM_LABEL_TABLE",
+            stringify!($real_name)
+        );
+    };
+}
 
 // This utility helps us generate C-based macros containing definitions
 // such as return code, opcode, struct size, struct offset, etc. The exact
@@ -215,11 +225,6 @@ fn main() {
     for _ in 0..0x10 {
         println!("\t.long\t.exit_slowpath - .CKB_VM_ASM_LABEL_TABLE");
     }
-    for name in INSTRUCTION_OPCODE_NAMES.iter() {
-        println!(
-            "\t.long\t.CKB_VM_ASM_LABEL_OP_{} - .CKB_VM_ASM_LABEL_TABLE",
-            name
-        );
-    }
+    for_each_inst!(print_inst_label);
     println!("#endif /* CKB_VM_ASM_GENERATE_LABEL_TABLES */");
 }

--- a/definitions/src/generate_asm_constants.rs
+++ b/definitions/src/generate_asm_constants.rs
@@ -4,15 +4,12 @@ use ckb_vm_definitions::{
         RET_ECALL, RET_INVALID_PERMISSION, RET_MAX_CYCLES_EXCEEDED, RET_OUT_OF_BOUND, RET_SLOWPATH,
         TRACE_ITEM_LENGTH,
     },
-    instructions::{
-        instruction_opcode_name, Instruction, MAXIMUM_OPCODE,
-        MINIMAL_OPCODE,
-    },
+    for_each_inst,
+    instructions::{instruction_opcode_name, Instruction, MAXIMUM_OPCODE, MINIMAL_OPCODE},
     memory::{FLAG_DIRTY, FLAG_EXECUTABLE, FLAG_FREEZED, FLAG_WRITABLE, FLAG_WXORX_BIT},
     registers::{RA, SP},
     MEMORY_FRAMES, MEMORY_FRAMESIZE, MEMORY_FRAME_PAGE_SHIFTS, MEMORY_FRAME_SHIFTS,
     RISCV_MAX_MEMORY, RISCV_PAGES, RISCV_PAGESIZE, RISCV_PAGE_SHIFTS,
-    for_each_inst,
 };
 use std::mem::{size_of, zeroed};
 

--- a/definitions/src/instructions.rs
+++ b/definitions/src/instructions.rs
@@ -254,7 +254,7 @@ macro_rules! __for_each_inst_inner {
 macro_rules! for_each_inst {
     ($callback:ident) => {
         $crate::__for_each_inst_inner!($callback);
-    }
+    };
 }
 
 /// Generates a match expression containing all instructions, it takes 3
@@ -267,12 +267,10 @@ macro_rules! for_each_inst {
 /// not match any opcode
 #[macro_export]
 macro_rules! for_each_inst_match {
-    ($callback:ident, $val:expr, $others:expr) => {
-        {
-            $crate::__for_each_inst_inner!((1, __res__, $val, $callback, $others));
-            __res__
-        }
-    }
+    ($callback:ident, $val:expr, $others:expr) => {{
+        $crate::__for_each_inst_inner!((1, __res__, $val, $callback, $others));
+        __res__
+    }};
 }
 
 /// Generates a match expression doing fold on all instructions
@@ -285,7 +283,7 @@ macro_rules! for_each_inst_match {
 macro_rules! for_each_inst_fold {
     ($callback:ident, $x:ident) => {
         $crate::__for_each_inst_inner!((2, $x, $callback));
-    }
+    };
 }
 
 macro_rules! define_instruction {

--- a/definitions/src/instructions.rs
+++ b/definitions/src/instructions.rs
@@ -32,335 +32,278 @@
 // path, at this time the value of op2 is ignored.
 // When the op value is 0x00-0x0f, op and op2 are combined to express a
 // second-level instruction under slow path.
+//
+// Notice that this module now uses macro-based techniques to define opcodes.
+// To see a full list of opcodes as plain Rust source code, install
+// [cargo-expand](https://github.com/dtolnay/cargo-expand) first, then use the
+// following command:
+//
+// cargo expand --manifest-path=definitions/Cargo.toml --lib instructions
 pub type Instruction = u64;
 
 pub type InstructionOpcode = u16;
 
-// IMC
-pub const OP_UNLOADED: InstructionOpcode = 0x10;
-pub const OP_ADD: InstructionOpcode = 0x11;
-pub const OP_ADDI: InstructionOpcode = 0x12;
-pub const OP_ADDIW: InstructionOpcode = 0x13;
-pub const OP_ADDW: InstructionOpcode = 0x14;
-pub const OP_AND: InstructionOpcode = 0x15;
-pub const OP_ANDI: InstructionOpcode = 0x16;
-pub const OP_AUIPC: InstructionOpcode = 0x17;
-pub const OP_BEQ: InstructionOpcode = 0x18;
-pub const OP_BGE: InstructionOpcode = 0x19;
-pub const OP_BGEU: InstructionOpcode = 0x1a;
-pub const OP_BLT: InstructionOpcode = 0x1b;
-pub const OP_BLTU: InstructionOpcode = 0x1c;
-pub const OP_BNE: InstructionOpcode = 0x1d;
-pub const OP_DIV: InstructionOpcode = 0x1e;
-pub const OP_DIVU: InstructionOpcode = 0x1f;
-pub const OP_DIVUW: InstructionOpcode = 0x20;
-pub const OP_DIVW: InstructionOpcode = 0x21;
-pub const OP_EBREAK: InstructionOpcode = 0x22;
-pub const OP_ECALL: InstructionOpcode = 0x23;
-pub const OP_FENCE: InstructionOpcode = 0x24;
-pub const OP_FENCEI: InstructionOpcode = 0x25;
-pub const OP_JAL: InstructionOpcode = 0x26;
-pub const OP_JALR_VERSION0: InstructionOpcode = 0x27;
-pub const OP_JALR_VERSION1: InstructionOpcode = 0x28;
-pub const OP_LB_VERSION0: InstructionOpcode = 0x29;
-pub const OP_LB_VERSION1: InstructionOpcode = 0x2a;
-pub const OP_LBU_VERSION0: InstructionOpcode = 0x2b;
-pub const OP_LBU_VERSION1: InstructionOpcode = 0x2c;
-pub const OP_LD_VERSION0: InstructionOpcode = 0x2d;
-pub const OP_LD_VERSION1: InstructionOpcode = 0x2e;
-pub const OP_LH_VERSION0: InstructionOpcode = 0x2f;
-pub const OP_LH_VERSION1: InstructionOpcode = 0x30;
-pub const OP_LHU_VERSION0: InstructionOpcode = 0x31;
-pub const OP_LHU_VERSION1: InstructionOpcode = 0x32;
-pub const OP_LUI: InstructionOpcode = 0x33;
-pub const OP_LW_VERSION0: InstructionOpcode = 0x34;
-pub const OP_LW_VERSION1: InstructionOpcode = 0x35;
-pub const OP_LWU_VERSION0: InstructionOpcode = 0x36;
-pub const OP_LWU_VERSION1: InstructionOpcode = 0x37;
-pub const OP_MUL: InstructionOpcode = 0x38;
-pub const OP_MULH: InstructionOpcode = 0x39;
-pub const OP_MULHSU: InstructionOpcode = 0x3a;
-pub const OP_MULHU: InstructionOpcode = 0x3b;
-pub const OP_MULW: InstructionOpcode = 0x3c;
-pub const OP_OR: InstructionOpcode = 0x3d;
-pub const OP_ORI: InstructionOpcode = 0x3e;
-pub const OP_REM: InstructionOpcode = 0x3f;
-pub const OP_REMU: InstructionOpcode = 0x40;
-pub const OP_REMUW: InstructionOpcode = 0x41;
-pub const OP_REMW: InstructionOpcode = 0x42;
-pub const OP_SB: InstructionOpcode = 0x43;
-pub const OP_SD: InstructionOpcode = 0x44;
-pub const OP_SH: InstructionOpcode = 0x45;
-pub const OP_SLL: InstructionOpcode = 0x46;
-pub const OP_SLLI: InstructionOpcode = 0x47;
-pub const OP_SLLIW: InstructionOpcode = 0x48;
-pub const OP_SLLW: InstructionOpcode = 0x49;
-pub const OP_SLT: InstructionOpcode = 0x4a;
-pub const OP_SLTI: InstructionOpcode = 0x4b;
-pub const OP_SLTIU: InstructionOpcode = 0x4c;
-pub const OP_SLTU: InstructionOpcode = 0x4d;
-pub const OP_SRA: InstructionOpcode = 0x4e;
-pub const OP_SRAI: InstructionOpcode = 0x4f;
-pub const OP_SRAIW: InstructionOpcode = 0x50;
-pub const OP_SRAW: InstructionOpcode = 0x51;
-pub const OP_SRL: InstructionOpcode = 0x52;
-pub const OP_SRLI: InstructionOpcode = 0x53;
-pub const OP_SRLIW: InstructionOpcode = 0x54;
-pub const OP_SRLW: InstructionOpcode = 0x55;
-pub const OP_SUB: InstructionOpcode = 0x56;
-pub const OP_SUBW: InstructionOpcode = 0x57;
-pub const OP_SW: InstructionOpcode = 0x58;
-pub const OP_XOR: InstructionOpcode = 0x59;
-pub const OP_XORI: InstructionOpcode = 0x5a;
-// A
-pub const OP_LR_W: InstructionOpcode = 0x5b;
-pub const OP_SC_W: InstructionOpcode = 0x5c;
-pub const OP_AMOSWAP_W: InstructionOpcode = 0x5d;
-pub const OP_AMOADD_W: InstructionOpcode = 0x5e;
-pub const OP_AMOXOR_W: InstructionOpcode = 0x5f;
-pub const OP_AMOAND_W: InstructionOpcode = 0x60;
-pub const OP_AMOOR_W: InstructionOpcode = 0x61;
-pub const OP_AMOMIN_W: InstructionOpcode = 0x62;
-pub const OP_AMOMAX_W: InstructionOpcode = 0x63;
-pub const OP_AMOMINU_W: InstructionOpcode = 0x64;
-pub const OP_AMOMAXU_W: InstructionOpcode = 0x65;
-pub const OP_LR_D: InstructionOpcode = 0x66;
-pub const OP_SC_D: InstructionOpcode = 0x67;
-pub const OP_AMOSWAP_D: InstructionOpcode = 0x68;
-pub const OP_AMOADD_D: InstructionOpcode = 0x69;
-pub const OP_AMOXOR_D: InstructionOpcode = 0x6a;
-pub const OP_AMOAND_D: InstructionOpcode = 0x6b;
-pub const OP_AMOOR_D: InstructionOpcode = 0x6c;
-pub const OP_AMOMIN_D: InstructionOpcode = 0x6d;
-pub const OP_AMOMAX_D: InstructionOpcode = 0x6e;
-pub const OP_AMOMINU_D: InstructionOpcode = 0x6f;
-pub const OP_AMOMAXU_D: InstructionOpcode = 0x70;
-// B
-pub const OP_ADDUW: InstructionOpcode = 0x71;
-pub const OP_ANDN: InstructionOpcode = 0x72;
-pub const OP_BCLR: InstructionOpcode = 0x73;
-pub const OP_BCLRI: InstructionOpcode = 0x74;
-pub const OP_BEXT: InstructionOpcode = 0x75;
-pub const OP_BEXTI: InstructionOpcode = 0x76;
-pub const OP_BINV: InstructionOpcode = 0x77;
-pub const OP_BINVI: InstructionOpcode = 0x78;
-pub const OP_BSET: InstructionOpcode = 0x79;
-pub const OP_BSETI: InstructionOpcode = 0x7a;
-pub const OP_CLMUL: InstructionOpcode = 0x7b;
-pub const OP_CLMULH: InstructionOpcode = 0x7c;
-pub const OP_CLMULR: InstructionOpcode = 0x7d;
-pub const OP_CLZ: InstructionOpcode = 0x7e;
-pub const OP_CLZW: InstructionOpcode = 0x7f;
-pub const OP_CPOP: InstructionOpcode = 0x80;
-pub const OP_CPOPW: InstructionOpcode = 0x81;
-pub const OP_CTZ: InstructionOpcode = 0x82;
-pub const OP_CTZW: InstructionOpcode = 0x83;
-pub const OP_MAX: InstructionOpcode = 0x84;
-pub const OP_MAXU: InstructionOpcode = 0x85;
-pub const OP_MIN: InstructionOpcode = 0x86;
-pub const OP_MINU: InstructionOpcode = 0x87;
-pub const OP_ORCB: InstructionOpcode = 0x88;
-pub const OP_ORN: InstructionOpcode = 0x89;
-pub const OP_REV8: InstructionOpcode = 0x8a;
-pub const OP_ROL: InstructionOpcode = 0x8b;
-pub const OP_ROLW: InstructionOpcode = 0x8c;
-pub const OP_ROR: InstructionOpcode = 0x8d;
-pub const OP_RORI: InstructionOpcode = 0x8e;
-pub const OP_RORIW: InstructionOpcode = 0x8f;
-pub const OP_RORW: InstructionOpcode = 0x90;
-pub const OP_SEXTB: InstructionOpcode = 0x91;
-pub const OP_SEXTH: InstructionOpcode = 0x92;
-pub const OP_SH1ADD: InstructionOpcode = 0x93;
-pub const OP_SH1ADDUW: InstructionOpcode = 0x94;
-pub const OP_SH2ADD: InstructionOpcode = 0x95;
-pub const OP_SH2ADDUW: InstructionOpcode = 0x96;
-pub const OP_SH3ADD: InstructionOpcode = 0x97;
-pub const OP_SH3ADDUW: InstructionOpcode = 0x98;
-pub const OP_SLLIUW: InstructionOpcode = 0x99;
-pub const OP_XNOR: InstructionOpcode = 0x9a;
-pub const OP_ZEXTH: InstructionOpcode = 0x9b;
-// Mop
-pub const OP_WIDE_MUL: InstructionOpcode = 0x9c;
-pub const OP_WIDE_MULU: InstructionOpcode = 0x9d;
-pub const OP_WIDE_MULSU: InstructionOpcode = 0x9e;
-pub const OP_WIDE_DIV: InstructionOpcode = 0x9f;
-pub const OP_WIDE_DIVU: InstructionOpcode = 0xa0;
-pub const OP_FAR_JUMP_REL: InstructionOpcode = 0xa1;
-pub const OP_FAR_JUMP_ABS: InstructionOpcode = 0xa2;
-pub const OP_ADC: InstructionOpcode = 0xa3;
-pub const OP_SBB: InstructionOpcode = 0xa4;
-pub const OP_ADCS: InstructionOpcode = 0xa5;
-pub const OP_SBBS: InstructionOpcode = 0xa6;
-pub const OP_ADD3A: InstructionOpcode = 0xa7;
-pub const OP_ADD3B: InstructionOpcode = 0xa8;
-pub const OP_ADD3C: InstructionOpcode = 0xa9;
-pub const OP_CUSTOM_LOAD_UIMM: InstructionOpcode = 0xaa;
-pub const OP_CUSTOM_LOAD_IMM: InstructionOpcode = 0xab;
-pub const OP_CUSTOM_TRACE_END: InstructionOpcode = 0xac;
+pub use paste::paste;
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __apply {
+    ($callback:ident, $(($name:ident, $code:expr)),*) => {
+        $crate::instructions::paste! {
+            $(
+                $callback!([< OP_ $name >], $name, $code);
+            )*
+        }
+    };
+    ((1, $res:ident, $x:expr, $callback:ident, $others:expr), $(($name:ident, $code:expr)),*) => {
+        $crate::instructions::paste! {
+            let $res = match $x {
+                $( $code => $callback!([< OP_ $name >], $name, $code), )*
+                _ => $others
+            };
+        }
+    };
+    ((2, $x:ident, $callback:ident), $(($name:ident, $code:expr)),*) => {
+        $crate::instructions::paste! {
+            $(
+                $callback!([< OP_ $name >], $name, $code, $x);
+            )*
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __for_each_inst_inner {
+    ($callback:tt) => {
+        $crate::__apply!(
+            $callback,
+            // IMC
+            (UNLOADED, 0x10),
+            (ADD, 0x11),
+            (ADDI, 0x12),
+            (ADDIW, 0x13),
+            (ADDW, 0x14),
+            (AND, 0x15),
+            (ANDI, 0x16),
+            (AUIPC, 0x17),
+            (BEQ, 0x18),
+            (BGE, 0x19),
+            (BGEU, 0x1a),
+            (BLT, 0x1b),
+            (BLTU, 0x1c),
+            (BNE, 0x1d),
+            (DIV, 0x1e),
+            (DIVU, 0x1f),
+            (DIVUW, 0x20),
+            (DIVW, 0x21),
+            (EBREAK, 0x22),
+            (ECALL, 0x23),
+            (FENCE, 0x24),
+            (FENCEI, 0x25),
+            (JAL, 0x26),
+            (JALR_VERSION0, 0x27),
+            (JALR_VERSION1, 0x28),
+            (LB_VERSION0, 0x29),
+            (LB_VERSION1, 0x2a),
+            (LBU_VERSION0, 0x2b),
+            (LBU_VERSION1, 0x2c),
+            (LD_VERSION0, 0x2d),
+            (LD_VERSION1, 0x2e),
+            (LH_VERSION0, 0x2f),
+            (LH_VERSION1, 0x30),
+            (LHU_VERSION0, 0x31),
+            (LHU_VERSION1, 0x32),
+            (LUI, 0x33),
+            (LW_VERSION0, 0x34),
+            (LW_VERSION1, 0x35),
+            (LWU_VERSION0, 0x36),
+            (LWU_VERSION1, 0x37),
+            (MUL, 0x38),
+            (MULH, 0x39),
+            (MULHSU, 0x3a),
+            (MULHU, 0x3b),
+            (MULW, 0x3c),
+            (OR, 0x3d),
+            (ORI, 0x3e),
+            (REM, 0x3f),
+            (REMU, 0x40),
+            (REMUW, 0x41),
+            (REMW, 0x42),
+            (SB, 0x43),
+            (SD, 0x44),
+            (SH, 0x45),
+            (SLL, 0x46),
+            (SLLI, 0x47),
+            (SLLIW, 0x48),
+            (SLLW, 0x49),
+            (SLT, 0x4a),
+            (SLTI, 0x4b),
+            (SLTIU, 0x4c),
+            (SLTU, 0x4d),
+            (SRA, 0x4e),
+            (SRAI, 0x4f),
+            (SRAIW, 0x50),
+            (SRAW, 0x51),
+            (SRL, 0x52),
+            (SRLI, 0x53),
+            (SRLIW, 0x54),
+            (SRLW, 0x55),
+            (SUB, 0x56),
+            (SUBW, 0x57),
+            (SW, 0x58),
+            (XOR, 0x59),
+            (XORI, 0x5a),
+            // A
+            (LR_W, 0x5b),
+            (SC_W, 0x5c),
+            (AMOSWAP_W, 0x5d),
+            (AMOADD_W, 0x5e),
+            (AMOXOR_W, 0x5f),
+            (AMOAND_W, 0x60),
+            (AMOOR_W, 0x61),
+            (AMOMIN_W, 0x62),
+            (AMOMAX_W, 0x63),
+            (AMOMINU_W, 0x64),
+            (AMOMAXU_W, 0x65),
+            (LR_D, 0x66),
+            (SC_D, 0x67),
+            (AMOSWAP_D, 0x68),
+            (AMOADD_D, 0x69),
+            (AMOXOR_D, 0x6a),
+            (AMOAND_D, 0x6b),
+            (AMOOR_D, 0x6c),
+            (AMOMIN_D, 0x6d),
+            (AMOMAX_D, 0x6e),
+            (AMOMINU_D, 0x6f),
+            (AMOMAXU_D, 0x70),
+            // B
+            (ADDUW, 0x71),
+            (ANDN, 0x72),
+            (BCLR, 0x73),
+            (BCLRI, 0x74),
+            (BEXT, 0x75),
+            (BEXTI, 0x76),
+            (BINV, 0x77),
+            (BINVI, 0x78),
+            (BSET, 0x79),
+            (BSETI, 0x7a),
+            (CLMUL, 0x7b),
+            (CLMULH, 0x7c),
+            (CLMULR, 0x7d),
+            (CLZ, 0x7e),
+            (CLZW, 0x7f),
+            (CPOP, 0x80),
+            (CPOPW, 0x81),
+            (CTZ, 0x82),
+            (CTZW, 0x83),
+            (MAX, 0x84),
+            (MAXU, 0x85),
+            (MIN, 0x86),
+            (MINU, 0x87),
+            (ORCB, 0x88),
+            (ORN, 0x89),
+            (REV8, 0x8a),
+            (ROL, 0x8b),
+            (ROLW, 0x8c),
+            (ROR, 0x8d),
+            (RORI, 0x8e),
+            (RORIW, 0x8f),
+            (RORW, 0x90),
+            (SEXTB, 0x91),
+            (SEXTH, 0x92),
+            (SH1ADD, 0x93),
+            (SH1ADDUW, 0x94),
+            (SH2ADD, 0x95),
+            (SH2ADDUW, 0x96),
+            (SH3ADD, 0x97),
+            (SH3ADDUW, 0x98),
+            (SLLIUW, 0x99),
+            (XNOR, 0x9a),
+            (ZEXTH, 0x9b),
+            // Mop
+            (WIDE_MUL, 0x9c),
+            (WIDE_MULU, 0x9d),
+            (WIDE_MULSU, 0x9e),
+            (WIDE_DIV, 0x9f),
+            (WIDE_DIVU, 0xa0),
+            (FAR_JUMP_REL, 0xa1),
+            (FAR_JUMP_ABS, 0xa2),
+            (ADC, 0xa3),
+            (SBB, 0xa4),
+            (ADCS, 0xa5),
+            (SBBS, 0xa6),
+            (ADD3A, 0xa7),
+            (ADD3B, 0xa8),
+            (ADD3C, 0xa9),
+            (CUSTOM_LOAD_UIMM, 0xaa),
+            (CUSTOM_LOAD_IMM, 0xab),
+            (CUSTOM_TRACE_END, 0xac)
+        );
+    };
+}
+
+/// Generates a possible definition for each instruction, it leverages
+/// a callback macro that takes 3 arguments:
+///
+/// 1. $name: an identifier containing the full defined opcode name,
+/// e.g., OP_ADD
+/// 2. $real_name: an identifier containing just the opcode part, e.g., ADD
+/// 3. $code: an expr containing the actual opcode number
+#[macro_export]
+macro_rules! for_each_inst {
+    ($callback:ident) => {
+        $crate::__for_each_inst_inner!($callback);
+    }
+}
+
+/// Generates a match expression containing all instructions, it takes 3
+/// arguments:
+///
+/// * A callback macro that takes the exact same arguments as callback
+/// macro in +for_each_inst+
+/// * A value expression containing the actual value to match against.
+/// * An expression used as wildcard matches when the passed value does
+/// not match any opcode
+#[macro_export]
+macro_rules! for_each_inst_match {
+    ($callback:ident, $val:expr, $others:expr) => {
+        {
+            $crate::__for_each_inst_inner!((1, __res__, $val, $callback, $others));
+            __res__
+        }
+    }
+}
+
+/// Generates a match expression doing fold on all instructions
+///
+/// * A callback macro that takes 4 arguments: the first 3 arguments are
+/// exactly the same as the 3 callback arguments in +for_each_inst+, the
+/// 4th argument here is the identifier below to work with hygienic macros.
+/// * An identifier for a mutable variable used for folding
+#[macro_export]
+macro_rules! for_each_inst_fold {
+    ($callback:ident, $x:ident) => {
+        $crate::__for_each_inst_inner!((2, $x, $callback));
+    }
+}
+
+macro_rules! define_instruction {
+    ($name:ident, $real_name:ident, $code:expr) => {
+        pub const $name: InstructionOpcode = $code;
+    };
+}
+for_each_inst!(define_instruction);
 
 pub const MINIMAL_OPCODE: InstructionOpcode = OP_UNLOADED;
 pub const MAXIMUM_OPCODE: InstructionOpcode = OP_CUSTOM_TRACE_END;
 
-pub const INSTRUCTION_OPCODE_NAMES: [&str; (MAXIMUM_OPCODE - MINIMAL_OPCODE + 1) as usize] = [
-    "UNLOADED",
-    "ADD",
-    "ADDI",
-    "ADDIW",
-    "ADDW",
-    "AND",
-    "ANDI",
-    "AUIPC",
-    "BEQ",
-    "BGE",
-    "BGEU",
-    "BLT",
-    "BLTU",
-    "BNE",
-    "DIV",
-    "DIVU",
-    "DIVUW",
-    "DIVW",
-    "EBREAK",
-    "ECALL",
-    "FENCE",
-    "FENCEI",
-    "JAL",
-    "JALR_VERSION0",
-    "JALR_VERSION1",
-    "LB_VERSION0",
-    "LB_VERSION1",
-    "LBU_VERSION0",
-    "LBU_VERSION1",
-    "LD_VERSION0",
-    "LD_VERSION1",
-    "LH_VERSION0",
-    "LH_VERSION1",
-    "LHU_VERSION0",
-    "LHU_VERSION1",
-    "LUI",
-    "LW_VERSION0",
-    "LW_VERSION1",
-    "LWU_VERSION0",
-    "LWU_VERSION1",
-    "MUL",
-    "MULH",
-    "MULHSU",
-    "MULHU",
-    "MULW",
-    "OR",
-    "ORI",
-    "REM",
-    "REMU",
-    "REMUW",
-    "REMW",
-    "SB",
-    "SD",
-    "SH",
-    "SLL",
-    "SLLI",
-    "SLLIW",
-    "SLLW",
-    "SLT",
-    "SLTI",
-    "SLTIU",
-    "SLTU",
-    "SRA",
-    "SRAI",
-    "SRAIW",
-    "SRAW",
-    "SRL",
-    "SRLI",
-    "SRLIW",
-    "SRLW",
-    "SUB",
-    "SUBW",
-    "SW",
-    "XOR",
-    "XORI",
-    "LR_W",
-    "SC_W",
-    "AMOSWAP_W",
-    "AMOADD_W",
-    "AMOXOR_W",
-    "AMOAND_W",
-    "AMOOR_W",
-    "AMOMIN_W",
-    "AMOMAX_W",
-    "AMOMINU_W",
-    "AMOMAXU_W",
-    "LR_D",
-    "SC_D",
-    "AMOSWAP_D",
-    "AMOADD_D",
-    "AMOXOR_D",
-    "AMOAND_D",
-    "AMOOR_D",
-    "AMOMIN_D",
-    "AMOMAX_D",
-    "AMOMINU_D",
-    "AMOMAXU_D",
-    "ADDUW",
-    "ANDN",
-    "BCLR",
-    "BCLRI",
-    "BEXT",
-    "BEXTI",
-    "BINV",
-    "BINVI",
-    "BSET",
-    "BSETI",
-    "CLMUL",
-    "CLMULH",
-    "CLMULR",
-    "CLZ",
-    "CLZW",
-    "CPOP",
-    "CPOPW",
-    "CTZ",
-    "CTZW",
-    "MAX",
-    "MAXU",
-    "MIN",
-    "MINU",
-    "ORCB",
-    "ORN",
-    "REV8",
-    "ROL",
-    "ROLW",
-    "ROR",
-    "RORI",
-    "RORIW",
-    "RORW",
-    "SEXTB",
-    "SEXTH",
-    "SH1ADD",
-    "SH1ADDUW",
-    "SH2ADD",
-    "SH2ADDUW",
-    "SH3ADD",
-    "SH3ADDUW",
-    "SLLIUW",
-    "XNOR",
-    "ZEXTH",
-    "WIDE_MUL",
-    "WIDE_MULU",
-    "WIDE_MULSU",
-    "WIDE_DIV",
-    "WIDE_DIVU",
-    "FAR_JUMP_REL",
-    "FAR_JUMP_ABS",
-    "ADC",
-    "SBB",
-    "ADCS",
-    "SBBS",
-    "ADD3A",
-    "ADD3B",
-    "ADD3C",
-    "CUSTOM_LOAD_UIMM",
-    "CUSTOM_LOAD_IMM",
-    "CUSTOM_TRACE_END",
-];
+macro_rules! inst_real_name {
+    ($name:ident, $real_name:ident, $code:expr) => {
+        stringify!($real_name)
+    };
+}
 
 pub fn instruction_opcode_name(i: InstructionOpcode) -> &'static str {
-    INSTRUCTION_OPCODE_NAMES[(i - MINIMAL_OPCODE) as usize]
+    for_each_inst_match!(inst_real_name, i, "UNKNOWN_INSTRUCTION!")
 }

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -455,6 +455,8 @@ pub fn instruction_length(i: Instruction) -> u8 {
 mod tests {
     use super::i::factory;
     use super::*;
+    use ckb_vm_definitions::{for_each_inst_fold, instructions::MAXIMUM_OPCODE};
+    use std::cmp::{max, min};
     use std::mem::size_of;
 
     #[test]
@@ -477,5 +479,31 @@ mod tests {
         let stype = Stype(decoded);
 
         assert_eq!("beq a0,a5,-192", format!("{}", stype));
+    }
+
+    macro_rules! update_min_opcode {
+        ($name:ident, $real_name:ident, $code:expr, $x:ident) => {
+            $x = min($code, $x);
+        };
+    }
+
+    #[test]
+    fn test_minimal_opcode_is_minimal() {
+        let mut o = MINIMAL_OPCODE;
+        for_each_inst_fold!(update_min_opcode, o);
+        assert_eq!(MINIMAL_OPCODE, o);
+    }
+
+    macro_rules! update_max_opcode {
+        ($name:ident, $real_name:ident, $code:expr, $x:ident) => {
+            $x = max($code, $x);
+        };
+    }
+
+    #[test]
+    fn test_maximal_opcode_is_maximal() {
+        let mut o = MAXIMUM_OPCODE;
+        for_each_inst_fold!(update_max_opcode, o);
+        assert_eq!(MAXIMUM_OPCODE, o);
     }
 }


### PR DESCRIPTION
Previously, we have to manually maintain the opcodes so the list of opcode definitions is in sync with the array of
`INSTRUCTION_OPCODE_NAMES`, which is a tedious step. In addition, it is also quite easier to forget one opcode or two in the implementations somewhere. This change leverages some purposely designed macros to grant us a way to enumerate all the macros, providing accessing code for each of them individually. This way we can define opcodes in one place and make sure every enumeration contains all the opcodes correctly.

Note that using macros does have the drawbacks of making code less clearer to read. We are also providing a one-line command to generate the underlying Rust code. What's more one can also refer to Rust docs to see all the defined opcodes