### PR TITLE
feat!: generic syscall handlers

### DIFF
--- a/src/machine/asm/mod.rs
+++ b/src/machine/asm/mod.rs
@@ -27,8 +27,8 @@ use crate::{
         fill_page_data, get_page_indices, memset, round_page_down, round_page_up, FLAG_DIRTY,
         FLAG_EXECUTABLE, FLAG_FREEZED, FLAG_WRITABLE, FLAG_WXORX_BIT,
     },
-    CoreMachine, DefaultMachine, Error, Machine, Memory, SupportMachine, MEMORY_FRAME_SHIFTS,
-    RISCV_MAX_MEMORY, RISCV_PAGES, RISCV_PAGESIZE,
+    CoreMachine, DefaultMachine, Error, Machine, Memory, SupportMachine, Syscalls,
+    MEMORY_FRAME_SHIFTS, RISCV_MAX_MEMORY, RISCV_PAGES, RISCV_PAGESIZE,
 };
 
 impl CoreMachine for Box<AsmCoreMachine> {
@@ -599,12 +599,12 @@ extern "C" {
     pub fn ckb_vm_asm_labels();
 }
 
-pub struct AsmMachine {
-    pub machine: DefaultMachine<Box<AsmCoreMachine>>,
+pub struct AsmMachine<S = ()> {
+    pub machine: DefaultMachine<Box<AsmCoreMachine>, S>,
 }
 
-impl AsmMachine {
-    pub fn new(machine: DefaultMachine<Box<AsmCoreMachine>>) -> Self {
+impl<S: Syscalls<Box<AsmCoreMachine>>> AsmMachine<S> {
+    pub fn new(machine: DefaultMachine<Box<AsmCoreMachine>, S>) -> Self {
         Self { machine }
     }
 

--- a/src/machine/trace.rs
+++ b/src/machine/trace.rs
@@ -1,3 +1,5 @@
+use crate::Syscalls;
+
 use super::{
     super::{
         decoder::{build_decoder, InstDecoder},
@@ -46,14 +48,14 @@ fn calculate_slot(addr: u64) -> usize {
     (addr as usize >> TRACE_ADDRESS_SHIFTS) & TRACE_MASK
 }
 
-pub struct TraceMachine<Inner: SupportMachine> {
-    pub machine: DefaultMachine<Inner>,
+pub struct TraceMachine<Inner: SupportMachine, S: Syscalls<Inner> = ()> {
+    pub machine: DefaultMachine<Inner, S>,
 
-    factory: ThreadFactory<DefaultMachine<Inner>>,
-    traces: Vec<Trace<DefaultMachine<Inner>>>,
+    factory: ThreadFactory<DefaultMachine<Inner, S>>,
+    traces: Vec<Trace<DefaultMachine<Inner, S>>>,
 }
 
-impl<Inner: SupportMachine> CoreMachine for TraceMachine<Inner> {
+impl<Inner: SupportMachine, S: Syscalls<Inner>> CoreMachine for TraceMachine<Inner, S> {
     type REG = <Inner as CoreMachine>::REG;
     type MEM = <Inner as CoreMachine>::MEM;
 
@@ -94,7 +96,7 @@ impl<Inner: SupportMachine> CoreMachine for TraceMachine<Inner> {
     }
 }
 
-impl<Inner: SupportMachine> Machine for TraceMachine<Inner> {
+impl<Inner: SupportMachine, S: Syscalls<Inner>> Machine for TraceMachine<Inner, S> {
     fn ecall(&mut self) -> Result<(), Error> {
         self.machine.ecall()
     }
@@ -104,8 +106,8 @@ impl<Inner: SupportMachine> Machine for TraceMachine<Inner> {
     }
 }
 
-impl<Inner: SupportMachine> TraceMachine<Inner> {
-    pub fn new(machine: DefaultMachine<Inner>) -> Self {
+impl<Inner: SupportMachine, S: Syscalls<Inner>> TraceMachine<Inner, S> {
+    pub fn new(machine: DefaultMachine<Inner, S>) -> Self {
         Self {
             machine,
             factory: ThreadFactory::create(),

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -1,10 +1,67 @@
 use super::Error;
 use crate::machine::SupportMachine;
 
-pub trait Syscalls<Mac: SupportMachine>: Send + Sync {
+pub trait Syscalls<Mac: SupportMachine> {
     fn initialize(&mut self, machine: &mut Mac) -> Result<(), Error>;
-    // Returned bool means if the syscall has been processed, if
-    // a module returns false, Machine would continue to leverage
-    // the next syscall module to process.
+    /// Returned bool means if the syscall has been processed, if
+    /// a module returns false, Machine would continue to leverage
+    /// the next syscall module to process.
+    ///
+    /// See Syscalls impl for Vec<BoxedSyscalls>.
     fn ecall(&mut self, machine: &mut Mac) -> Result<bool, Error>;
+}
+
+/// No syscalls.
+impl<Mac: SupportMachine> Syscalls<Mac> for () {
+    /// No-op.
+    fn initialize(&mut self, _machine: &mut Mac) -> Result<(), Error> {
+        Ok(())
+    }
+    /// Always return Ok(false).
+    fn ecall(&mut self, _machine: &mut Mac) -> Result<bool, Error> {
+        Ok(false)
+    }
+}
+
+/// When initialization is not necessary, you can use a simple closure to handle syscalls.
+impl<Mac, F> Syscalls<Mac> for F
+where
+    Mac: SupportMachine,
+    F: FnMut(&mut Mac) -> Result<bool, Error>,
+{
+    fn initialize(&mut self, _machine: &mut Mac) -> Result<(), Error> {
+        Ok(())
+    }
+    fn ecall(&mut self, machine: &mut Mac) -> Result<bool, Error> {
+        self(machine)
+    }
+}
+
+pub type BoxedSyscalls<Mac> = Box<dyn Syscalls<Mac> + Send + Sync + 'static>;
+
+impl<Mac: SupportMachine> Syscalls<Mac> for BoxedSyscalls<Mac> {
+    fn initialize(&mut self, machine: &mut Mac) -> Result<(), Error> {
+        (**self).initialize(machine)
+    }
+    fn ecall(&mut self, machine: &mut Mac) -> Result<bool, Error> {
+        (**self).ecall(machine)
+    }
+}
+
+impl<Mac: SupportMachine> Syscalls<Mac> for Vec<BoxedSyscalls<Mac>> {
+    fn initialize(&mut self, machine: &mut Mac) -> Result<(), Error> {
+        for s in self {
+            s.initialize(machine)?;
+        }
+        Ok(())
+    }
+    fn ecall(&mut self, machine: &mut Mac) -> Result<bool, Error> {
+        for s in self {
+            let processed = s.ecall(machine)?;
+            if processed {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
 }

--- a/tests/machine_build.rs
+++ b/tests/machine_build.rs
@@ -9,7 +9,7 @@ use ckb_vm::{
     ISA_A, ISA_B, ISA_IMC, ISA_MOP,
 };
 
-pub struct SleepSyscall {}
+pub struct SleepSyscall;
 
 impl<Mac: SupportMachine> Syscalls<Mac> for SleepSyscall {
     fn initialize(&mut self, _machine: &mut Mac) -> Result<(), Error> {
@@ -30,12 +30,12 @@ impl<Mac: SupportMachine> Syscalls<Mac> for SleepSyscall {
 }
 
 #[cfg(has_asm)]
-pub fn asm_v1_imcb(path: &str) -> AsmMachine {
+pub fn asm_v1_imcb(path: &str) -> AsmMachine<SleepSyscall> {
     let buffer: Bytes = std::fs::read(path).unwrap().into();
     let asm_core = AsmCoreMachine::new(ISA_IMC | ISA_B, VERSION1, u64::max_value());
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
         .instruction_cycle_func(Box::new(constant_cycles))
-        .syscall(Box::new(SleepSyscall {}))
+        .syscall(SleepSyscall)
         .build();
     let mut machine = AsmMachine::new(core);
     machine
@@ -46,7 +46,7 @@ pub fn asm_v1_imcb(path: &str) -> AsmMachine {
 
 pub fn int_v1_imcb(
     path: &str,
-) -> TraceMachine<DefaultCoreMachine<u64, WXorXMemory<SparseMemory<u64>>>> {
+) -> TraceMachine<DefaultCoreMachine<u64, WXorXMemory<SparseMemory<u64>>>, SleepSyscall> {
     let buffer: Bytes = std::fs::read(path).unwrap().into();
     let core_machine = DefaultCoreMachine::<u64, WXorXMemory<SparseMemory<u64>>>::new(
         ISA_IMC | ISA_B,
@@ -56,7 +56,7 @@ pub fn int_v1_imcb(
     let mut machine = TraceMachine::new(
         DefaultMachineBuilder::new(core_machine)
             .instruction_cycle_func(Box::new(constant_cycles))
-            .syscall(Box::new(SleepSyscall {}))
+            .syscall(SleepSyscall)
             .build(),
     );
     machine
@@ -66,17 +66,17 @@ pub fn int_v1_imcb(
 }
 
 #[cfg(has_asm)]
-pub fn asm_v1_mop(path: &str, args: Vec<Bytes>) -> AsmMachine {
+pub fn asm_v1_mop(path: &str, args: Vec<Bytes>) -> AsmMachine<SleepSyscall> {
     asm_mop(path, args, VERSION1)
 }
 
 #[cfg(has_asm)]
-pub fn asm_mop(path: &str, args: Vec<Bytes>, version: u32) -> AsmMachine {
+pub fn asm_mop(path: &str, args: Vec<Bytes>, version: u32) -> AsmMachine<SleepSyscall> {
     let buffer: Bytes = std::fs::read(path).unwrap().into();
     let asm_core = AsmCoreMachine::new(ISA_IMC | ISA_B | ISA_MOP, version, u64::max_value());
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
         .instruction_cycle_func(Box::new(constant_cycles))
-        .syscall(Box::new(SleepSyscall {}))
+        .syscall(SleepSyscall)
         .build();
     let mut machine = AsmMachine::new(core);
     let mut argv = vec![Bytes::from("main")];
@@ -88,7 +88,7 @@ pub fn asm_mop(path: &str, args: Vec<Bytes>, version: u32) -> AsmMachine {
 pub fn int_v1_mop(
     path: &str,
     args: Vec<Bytes>,
-) -> TraceMachine<DefaultCoreMachine<u64, WXorXMemory<SparseMemory<u64>>>> {
+) -> TraceMachine<DefaultCoreMachine<u64, WXorXMemory<SparseMemory<u64>>>, SleepSyscall> {
     int_mop(path, args, VERSION1)
 }
 
@@ -96,7 +96,7 @@ pub fn int_mop(
     path: &str,
     args: Vec<Bytes>,
     version: u32,
-) -> TraceMachine<DefaultCoreMachine<u64, WXorXMemory<SparseMemory<u64>>>> {
+) -> TraceMachine<DefaultCoreMachine<u64, WXorXMemory<SparseMemory<u64>>>, SleepSyscall> {
     let buffer: Bytes = std::fs::read(path).unwrap().into();
     let core_machine = DefaultCoreMachine::<u64, WXorXMemory<SparseMemory<u64>>>::new(
         ISA_IMC | ISA_B | ISA_MOP,
@@ -106,7 +106,7 @@ pub fn int_mop(
     let mut machine = TraceMachine::new(
         DefaultMachineBuilder::new(core_machine)
             .instruction_cycle_func(Box::new(constant_cycles))
-            .syscall(Box::new(SleepSyscall {}))
+            .syscall(SleepSyscall)
             .build(),
     );
     let mut argv = vec![Bytes::from("main")];
@@ -116,12 +116,12 @@ pub fn int_mop(
 }
 
 #[cfg(has_asm)]
-pub fn asm_v2_imacb(path: &str) -> AsmMachine {
+pub fn asm_v2_imacb(path: &str) -> AsmMachine<SleepSyscall> {
     let buffer: Bytes = std::fs::read(path).unwrap().into();
     let asm_core = AsmCoreMachine::new(ISA_IMC | ISA_A | ISA_B, VERSION2, u64::max_value());
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
         .instruction_cycle_func(Box::new(constant_cycles))
-        .syscall(Box::new(SleepSyscall {}))
+        .syscall(SleepSyscall)
         .build();
     let mut machine = AsmMachine::new(core);
     machine
@@ -132,7 +132,7 @@ pub fn asm_v2_imacb(path: &str) -> AsmMachine {
 
 pub fn int_v2_imacb(
     path: &str,
-) -> TraceMachine<DefaultCoreMachine<u64, WXorXMemory<SparseMemory<u64>>>> {
+) -> TraceMachine<DefaultCoreMachine<u64, WXorXMemory<SparseMemory<u64>>>, SleepSyscall> {
     let buffer: Bytes = std::fs::read(path).unwrap().into();
     let core_machine = DefaultCoreMachine::<u64, WXorXMemory<SparseMemory<u64>>>::new(
         ISA_IMC | ISA_A | ISA_B,
@@ -142,7 +142,7 @@ pub fn int_v2_imacb(
     let mut machine = TraceMachine::new(
         DefaultMachineBuilder::new(core_machine)
             .instruction_cycle_func(Box::new(constant_cycles))
-            .syscall(Box::new(SleepSyscall {}))
+            .syscall(SleepSyscall)
             .build(),
     );
     machine

--- a/tests/test_asm.rs
+++ b/tests/test_asm.rs
@@ -28,27 +28,19 @@ pub fn test_asm_simple64() {
     assert_eq!(result.unwrap(), 0);
 }
 
-pub struct CustomSyscall {}
-
-impl<Mac: SupportMachine> Syscalls<Mac> for CustomSyscall {
-    fn initialize(&mut self, _machine: &mut Mac) -> Result<(), Error> {
-        Ok(())
+fn custom_syscall<Mac: SupportMachine>(machine: &mut Mac) -> Result<bool, Error> {
+    let code = &machine.registers()[A7];
+    if code.to_i32() != 1111 {
+        return Ok(false);
     }
-
-    fn ecall(&mut self, machine: &mut Mac) -> Result<bool, Error> {
-        let code = &machine.registers()[A7];
-        if code.to_i32() != 1111 {
-            return Ok(false);
-        }
-        let result = machine.registers()[A0]
-            .overflowing_add(&machine.registers()[A1])
-            .overflowing_add(&machine.registers()[A2])
-            .overflowing_add(&machine.registers()[A3])
-            .overflowing_add(&machine.registers()[A4])
-            .overflowing_add(&machine.registers()[A5]);
-        machine.set_register(A0, result);
-        Ok(true)
-    }
+    let result = machine.registers()[A0]
+        .overflowing_add(&machine.registers()[A1])
+        .overflowing_add(&machine.registers()[A2])
+        .overflowing_add(&machine.registers()[A3])
+        .overflowing_add(&machine.registers()[A4])
+        .overflowing_add(&machine.registers()[A5]);
+    machine.set_register(A0, result);
+    Ok(true)
 }
 
 #[test]
@@ -56,7 +48,7 @@ pub fn test_asm_with_custom_syscall() {
     let buffer = fs::read("tests/programs/syscall64").unwrap().into();
     let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::max_value());
     let core = DefaultMachineBuilder::new(asm_core)
-        .syscall(Box::new(CustomSyscall {}))
+        .syscall(custom_syscall)
         .build();
     let mut machine = AsmMachine::new(core);
     machine
@@ -308,7 +300,7 @@ pub fn test_asm_rvc_pageend() {
     assert_eq!(result.unwrap(), 0);
 }
 
-pub struct OutOfCyclesSyscall {}
+pub struct OutOfCyclesSyscall;
 
 impl<Mac: SupportMachine> Syscalls<Mac> for OutOfCyclesSyscall {
     fn initialize(&mut self, _machine: &mut Mac) -> Result<(), Error> {
@@ -338,7 +330,7 @@ pub fn test_asm_outofcycles_in_syscall() {
     let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, 20);
     let core = DefaultMachineBuilder::new(asm_core)
         .instruction_cycle_func(Box::new(constant_cycles))
-        .syscall(Box::new(OutOfCyclesSyscall {}))
+        .syscall(OutOfCyclesSyscall)
         .build();
     let mut machine = AsmMachine::new(core);
     machine

--- a/tests/test_reset.rs
+++ b/tests/test_reset.rs
@@ -11,7 +11,7 @@ use ckb_vm::{
 #[allow(dead_code)]
 mod machine_build;
 
-pub struct CustomSyscall {}
+pub struct CustomSyscall;
 
 impl<Mac: SupportMachine> Syscalls<Mac> for CustomSyscall {
     fn initialize(&mut self, _: &mut Mac) -> Result<(), Error> {
@@ -50,7 +50,7 @@ fn test_reset_int() {
     );
     let mut machine = DefaultMachineBuilder::new(core_machine)
         .instruction_cycle_func(Box::new(constant_cycles))
-        .syscall(Box::new(CustomSyscall {}))
+        .syscall(CustomSyscall)
         .build();
     machine.load_program(&code, &vec![]).unwrap();
     let result = machine.run();
@@ -73,7 +73,7 @@ fn test_reset_int_with_trace() {
     let mut machine = TraceMachine::new(
         DefaultMachineBuilder::new(core_machine)
             .instruction_cycle_func(Box::new(constant_cycles))
-            .syscall(Box::new(CustomSyscall {}))
+            .syscall(CustomSyscall)
             .build(),
     );
     machine.load_program(&code, &vec![]).unwrap();
@@ -93,7 +93,7 @@ fn test_reset_asm() {
     let asm_core = AsmCoreMachine::new(ISA_IMC | ISA_MOP, VERSION1, u64::max_value());
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
         .instruction_cycle_func(Box::new(constant_cycles))
-        .syscall(Box::new(CustomSyscall {}))
+        .syscall(CustomSyscall)
         .build();
     let mut machine = AsmMachine::new(core);
     machine.load_program(&code, &vec![]).unwrap();

--- a/tests/test_resume2.rs
+++ b/tests/test_resume2.rs
@@ -382,7 +382,7 @@ impl MachineTy {
                 let asm_core1 = AsmCoreMachine::new(ISA_IMC, version, 0);
                 let core1 = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core1)
                     .instruction_cycle_func(Box::new(constant_cycles))
-                    .syscall(Box::new(InsertDataSyscall(context.clone())))
+                    .syscall(InsertDataSyscall(context.clone()))
                     .build();
                 Machine::Asm(AsmMachine::new(core1), context)
             }
@@ -396,7 +396,7 @@ impl MachineTy {
                         core_machine1,
                     )
                     .instruction_cycle_func(Box::new(constant_cycles))
-                    .syscall(Box::new(InsertDataSyscall(context.clone())))
+                    .syscall(InsertDataSyscall(context.clone()))
                     .build(),
                     context,
                 )
@@ -412,7 +412,7 @@ impl MachineTy {
                             DefaultCoreMachine<u64, WXorXMemory<SparseMemory<u64>>>,
                         >::new(core_machine1)
                         .instruction_cycle_func(Box::new(constant_cycles))
-                        .syscall(Box::new(InsertDataSyscall(context.clone())))
+                        .syscall(InsertDataSyscall(context.clone()))
                         .build(),
                     ),
                     context,
@@ -423,13 +423,16 @@ impl MachineTy {
 }
 
 enum Machine {
-    Asm(AsmMachine, Arc<Mutex<Snapshot2Context<u64, TestSource>>>),
+    Asm(
+        AsmMachine<InsertDataSyscall>,
+        Arc<Mutex<Snapshot2Context<u64, TestSource>>>,
+    ),
     Interpreter(
-        DefaultMachine<DefaultCoreMachine<u64, WXorXMemory<SparseMemory<u64>>>>,
+        DefaultMachine<DefaultCoreMachine<u64, WXorXMemory<SparseMemory<u64>>>, InsertDataSyscall>,
         Arc<Mutex<Snapshot2Context<u64, TestSource>>>,
     ),
     InterpreterWithTrace(
-        TraceMachine<DefaultCoreMachine<u64, WXorXMemory<SparseMemory<u64>>>>,
+        TraceMachine<DefaultCoreMachine<u64, WXorXMemory<SparseMemory<u64>>>, InsertDataSyscall>,
         Arc<Mutex<Snapshot2Context<u64, TestSource>>>,
     ),
 }


### PR DESCRIPTION
Syscall handlers with limited lifetime and are `!Send` can still be very useful.

We can support them (in addition to `'static + Send + Sync` handlers) by making the syscall handler type a generic type parameter. Unlike previous ckb-vm versions, we **are not adding a lifetime parameter to the machine types**.

I've also implemented `Syscall` for `()` (for when there's no syscalls) and `&mut impl SupportMachine -> Result` closures. `Vec<BoxedSyscalls>` is now handled by `impl Syscall for Vec<BoxedSyscalls>`.