### PR TITLE
feat!(0.24-l2): ExecutionContext trait and rename symbols

### DIFF
--- a/definitions/src/generate_asm_constants.rs
+++ b/definitions/src/generate_asm_constants.rs
@@ -206,11 +206,11 @@ fn main() {
 
     println!("#ifdef CKB_VM_ASM_GENERATE_LABEL_TABLES");
     println!("#ifdef __APPLE__");
-    println!(".global _ckb_vm_asm_labels");
-    println!("_ckb_vm_asm_labels:");
+    println!(".global CKB_VM_VERSIONED_SYMBOL(_ckb_vm_asm_labels)");
+    println!("CKB_VM_VERSIONED_SYMBOL(_ckb_vm_asm_labels):");
     println!("#else");
-    println!(".global ckb_vm_asm_labels");
-    println!("ckb_vm_asm_labels:");
+    println!(".global CKB_VM_VERSIONED_SYMBOL(ckb_vm_asm_labels)");
+    println!("CKB_VM_VERSIONED_SYMBOL(ckb_vm_asm_labels):");
     println!("#endif");
     println!(".CKB_VM_ASM_LABEL_TABLE:");
     for _ in 0..0x10 {

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -5,8 +5,10 @@ use crate::{machine::SupportMachine, syscalls::Syscalls};
 
 pub trait ExecutionContext<Mac: SupportMachine> {
     fn initialize(&mut self, machine: &mut Mac) -> Result<(), Error> {
-        // We don't want to change param name to start with _ or others
-        // implementing this would need to remove the _.
+        // We don't want to change the param name to start with an
+        // underscore(_). It doesn't look good in docs. Also when someone
+        // implements this method with IDE completion, they will need to remove
+        // the staring underscore.
         #[allow(clippy::drop_ref)]
         drop(machine);
         Ok(())

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -9,26 +9,22 @@ pub trait ExecutionContext<Mac: SupportMachine> {
         // underscore(_). It doesn't look good in docs. Also when someone
         // implements this method with IDE completion, they will need to remove
         // the staring underscore.
-        #[allow(clippy::drop_ref)]
-        drop(machine);
+        let _ = machine;
         Ok(())
     }
     /// Return true if the syscall has been processed. If a module returns
     /// false, Machine would continue to leverage the next syscall module to
     /// process.
     fn ecall(&mut self, machine: &mut Mac) -> Result<bool, Error> {
-        #[allow(clippy::drop_ref)]
-        drop(machine);
+        let _ = machine;
         Ok(false)
     }
     fn ebreak(&mut self, machine: &mut Mac) -> Result<(), Error> {
-        #[allow(clippy::drop_ref)]
-        drop(machine);
+        let _ = machine;
         Ok(())
     }
     fn instruction_cycles(&self, inst: Instruction) -> u64 {
-        #[allow(clippy::drop_copy)]
-        drop(inst);
+        let _ = inst;
         0
     }
 }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -1,0 +1,178 @@
+use ckb_vm_definitions::instructions::Instruction;
+
+use super::Error;
+use crate::{machine::SupportMachine, syscalls::Syscalls};
+
+pub trait ExecutionContext<Mac: SupportMachine> {
+    fn initialize(&mut self, machine: &mut Mac) -> Result<(), Error> {
+        // We don't want to change param name to start with _ or others
+        // implementing this would need to remove the _.
+        #[allow(clippy::drop_ref)]
+        drop(machine);
+        Ok(())
+    }
+    /// Return true if the syscall has been processed. If a module returns
+    /// false, Machine would continue to leverage the next syscall module to
+    /// process.
+    fn ecall(&mut self, machine: &mut Mac) -> Result<bool, Error> {
+        #[allow(clippy::drop_ref)]
+        drop(machine);
+        Ok(false)
+    }
+    fn ebreak(&mut self, machine: &mut Mac) -> Result<(), Error> {
+        #[allow(clippy::drop_ref)]
+        drop(machine);
+        Ok(())
+    }
+    fn instruction_cycles(&self, inst: Instruction) -> u64 {
+        #[allow(clippy::drop_copy)]
+        drop(inst);
+        0
+    }
+}
+
+pub type BoxedExecutionContext<Mac> = Box<dyn ExecutionContext<Mac> + Send + Sync + 'static>;
+
+impl<Mac: SupportMachine> ExecutionContext<Mac> for BoxedExecutionContext<Mac> {
+    fn initialize(&mut self, machine: &mut Mac) -> Result<(), Error> {
+        (**self).initialize(machine)
+    }
+    fn ecall(&mut self, machine: &mut Mac) -> Result<bool, Error> {
+        (**self).ecall(machine)
+    }
+    fn ebreak(&mut self, machine: &mut Mac) -> Result<(), Error> {
+        (**self).ebreak(machine)
+    }
+    fn instruction_cycles(&self, inst: Instruction) -> u64 {
+        (**self).instruction_cycles(inst)
+    }
+}
+
+impl<Mac: SupportMachine> ExecutionContext<Mac> for () {}
+
+pub struct WithSyscall<Ctx, Sys> {
+    pub(super) base: Ctx,
+    pub(super) syscall: Sys,
+}
+
+impl<Ctx, Sys, Mac> ExecutionContext<Mac> for WithSyscall<Ctx, Sys>
+where
+    Mac: SupportMachine,
+    Ctx: ExecutionContext<Mac>,
+    Sys: Syscalls<Mac>,
+{
+    fn initialize(&mut self, machine: &mut Mac) -> Result<(), Error> {
+        self.base.initialize(machine)?;
+        self.syscall.initialize(machine)
+    }
+    fn ecall(&mut self, machine: &mut Mac) -> Result<bool, Error> {
+        let processed = self.base.ecall(machine)?;
+        if processed {
+            return Ok(processed);
+        }
+        self.syscall.ecall(machine)
+    }
+    fn ebreak(&mut self, machine: &mut Mac) -> Result<(), Error> {
+        self.base.ebreak(machine)
+    }
+    fn instruction_cycles(&self, inst: Instruction) -> u64 {
+        self.base.instruction_cycles(inst)
+    }
+}
+
+pub struct WithDebugger<Ctx, F> {
+    pub(super) base: Ctx,
+    pub(super) debugger: F,
+}
+
+impl<Ctx, F, Mac> ExecutionContext<Mac> for WithDebugger<Ctx, F>
+where
+    Mac: SupportMachine,
+    Ctx: ExecutionContext<Mac>,
+    F: FnMut(&mut Mac) -> Result<(), Error>,
+{
+    fn initialize(&mut self, machine: &mut Mac) -> Result<(), Error> {
+        self.base.initialize(machine)
+    }
+    fn ecall(&mut self, machine: &mut Mac) -> Result<bool, Error> {
+        self.base.ecall(machine)
+    }
+    fn ebreak(&mut self, machine: &mut Mac) -> Result<(), Error> {
+        (self.debugger)(machine)
+    }
+    fn instruction_cycles(&self, inst: Instruction) -> u64 {
+        self.base.instruction_cycles(inst)
+    }
+}
+
+pub struct WithCyclesFunc<Ctx, F> {
+    pub(super) base: Ctx,
+    pub(super) cycles: F,
+}
+
+impl<Ctx, F, Mac> ExecutionContext<Mac> for WithCyclesFunc<Ctx, F>
+where
+    Mac: SupportMachine,
+    Ctx: ExecutionContext<Mac>,
+    F: Fn(Instruction) -> u64,
+{
+    fn initialize(&mut self, machine: &mut Mac) -> Result<(), Error> {
+        self.base.initialize(machine)
+    }
+    fn ecall(&mut self, machine: &mut Mac) -> Result<bool, Error> {
+        self.base.ecall(machine)
+    }
+    fn ebreak(&mut self, machine: &mut Mac) -> Result<(), Error> {
+        self.base.ebreak(machine)
+    }
+    fn instruction_cycles(&self, inst: Instruction) -> u64 {
+        (self.cycles)(inst)
+    }
+}
+
+/// ExecutionContext composing.
+pub trait ExecutionContextExt<Mac: SupportMachine>: ExecutionContext<Mac> {
+    /// Add a syscall handler to the this context.
+    fn with_syscall<Sys>(self, syscall: Sys) -> WithSyscall<Self, Sys>
+    where
+        Self: Sized,
+        Sys: Syscalls<Mac>,
+    {
+        WithSyscall {
+            base: self,
+            syscall,
+        }
+    }
+
+    /// Replace the debugger.
+    fn with_debugger<F>(self, debugger: F) -> WithDebugger<Self, F>
+    where
+        Self: Sized,
+        // For type inference.
+        F: FnMut(&mut Mac) -> Result<(), Error>,
+    {
+        WithDebugger {
+            base: self,
+            debugger,
+        }
+    }
+
+    /// Replace the instruction cycles function.
+    fn with_cycles<F>(self, cycles: F) -> WithCyclesFunc<Self, F>
+    where
+        Self: Sized,
+        F: Fn(Instruction) -> u64,
+    {
+        WithCyclesFunc { base: self, cycles }
+    }
+
+    /// Convert the execution context to be boxed and type erased.
+    fn boxed(self) -> BoxedExecutionContext<Mac>
+    where
+        Self: Sized + Send + Sync + 'static,
+    {
+        Box::new(self)
+    }
+}
+
+impl<Mac: SupportMachine, T: ExecutionContext<Mac>> ExecutionContextExt<Mac> for T {}

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -1,6 +1,0 @@
-use crate::{machine::SupportMachine, Error};
-
-pub trait Debugger<Mac: SupportMachine>: Send + Sync {
-    fn initialize(&mut self, machine: &mut Mac) -> Result<(), Error>;
-    fn ebreak(&mut self, machine: &mut Mac) -> Result<(), Error>;
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,8 @@
 extern crate derive_more;
 
 pub mod bits;
+pub mod context;
 pub mod cost_model;
-pub mod debugger;
 pub mod decoder;
 pub mod error;
 pub mod instructions;
@@ -16,11 +16,11 @@ pub use bytes;
 pub use ckb_vm_definitions;
 
 pub use crate::{
-    debugger::Debugger,
+    context::ExecutionContext,
     instructions::{Instruction, Register},
     machine::{
         trace::TraceMachine, CoreMachine, DefaultCoreMachine, DefaultMachine,
-        DefaultMachineBuilder, InstructionCycleFunc, Machine, SupportMachine,
+        DefaultMachineBuilder, Machine, SupportMachine,
     },
     memory::{flat::FlatMemory, sparse::SparseMemory, wxorx::WXorXMemory, Memory},
     syscalls::Syscalls,

--- a/src/machine/asm/cdefinitions_generated.h
+++ b/src/machine/asm/cdefinitions_generated.h
@@ -216,11 +216,11 @@
 
 #ifdef CKB_VM_ASM_GENERATE_LABEL_TABLES
 #ifdef __APPLE__
-.global _ckb_vm_asm_labels
-_ckb_vm_asm_labels:
+.global CKB_VM_VERSIONED_SYMBOL(_ckb_vm_asm_labels)
+CKB_VM_VERSIONED_SYMBOL(_ckb_vm_asm_labels):
 #else
-.global ckb_vm_asm_labels
-ckb_vm_asm_labels:
+.global CKB_VM_VERSIONED_SYMBOL(ckb_vm_asm_labels)
+CKB_VM_VERSIONED_SYMBOL(ckb_vm_asm_labels):
 #endif
 .CKB_VM_ASM_LABEL_TABLE:
 	.long	.exit_slowpath - .CKB_VM_ASM_LABEL_TABLE

--- a/src/machine/asm/execute_aarch64.S
+++ b/src/machine/asm/execute_aarch64.S
@@ -1,3 +1,7 @@
+#define CONCAT(A, B) A ## _ ## B
+#define CONCAT_EXPAND(A, B) CONCAT(A,B)
+#define CKB_VM_VERSIONED_SYMBOL(symbol) CONCAT_EXPAND(symbol, CKB_VM_VERSION)
+
 #define CKB_VM_ASM_GENERATE_LABEL_TABLES 1
 #include "cdefinitions_generated.h"
 
@@ -126,9 +130,9 @@
   mov IMMEDIATE, TEMP1
 
 #ifdef __APPLE__
-#define CALL_INITED_MEMORY bl _inited_memory
+#define CALL_INITED_MEMORY bl CKB_VM_VERSIONED_SYMBOL(_ckb_vm_inited_memory)
 #else
-#define CALL_INITED_MEMORY bl inited_memory
+#define CALL_INITED_MEMORY bl CKB_VM_VERSIONED_SYMBOL(ckb_vm_inited_memory)
 #endif
 
 /*
@@ -284,11 +288,11 @@
 
 .p2align 3
 #ifdef __APPLE__
-.globl _ckb_vm_x64_execute
-_ckb_vm_x64_execute:
+.globl CKB_VM_VERSIONED_SYMBOL(_ckb_vm_x64_execute)
+CKB_VM_VERSIONED_SYMBOL(_ckb_vm_x64_execute):
 #else
-.globl ckb_vm_x64_execute
-ckb_vm_x64_execute:
+.globl CKB_VM_VERSIONED_SYMBOL(ckb_vm_x64_execute)
+CKB_VM_VERSIONED_SYMBOL(ckb_vm_x64_execute):
 #endif
   stp x19, x20, [sp, -96]!
   stp x21, x22, [sp, 16]

--- a/src/machine/asm/execute_x64.S
+++ b/src/machine/asm/execute_x64.S
@@ -1,3 +1,7 @@
+#define CONCAT(A, B) A ## _ ## B
+#define CONCAT_EXPAND(A, B) CONCAT(A,B)
+#define CKB_VM_VERSIONED_SYMBOL(symbol) CONCAT_EXPAND(symbol, CKB_VM_VERSION)
+
 #define CKB_VM_ASM_GENERATE_LABEL_TABLES 1
 #include "cdefinitions_generated.h"
 
@@ -177,11 +181,11 @@
 #endif
 
 #ifdef __APPLE__
-#define CALL_INITED_MEMORY call _inited_memory
+#define CALL_INITED_MEMORY call CKB_VM_VERSIONED_SYMBOL(_ckb_vm_inited_memory)
 #elif defined IS_WINDOWS
-#define CALL_INITED_MEMORY call inited_memory
+#define CALL_INITED_MEMORY call CKB_VM_VERSIONED_SYMBOL(ckb_vm_inited_memory)
 #else
-#define CALL_INITED_MEMORY call inited_memory@plt
+#define CALL_INITED_MEMORY call CKB_VM_VERSIONED_SYMBOL(ckb_vm_inited_memory)##@plt
 #endif
 
 /*
@@ -392,11 +396,11 @@
   movzbl %ch, RS4_TEMP1d
 
 #ifdef __APPLE__
-.globl _ckb_vm_x64_execute
-_ckb_vm_x64_execute:
+.globl CKB_VM_VERSIONED_SYMBOL(_ckb_vm_x86_execute)
+CKB_VM_VERSIONED_SYMBOL(_ckb_vm_x86_execute):
 #else
-.globl ckb_vm_x64_execute
-ckb_vm_x64_execute:
+.globl CKB_VM_VERSIONED_SYMBOL(ckb_vm_x86_execute)
+CKB_VM_VERSIONED_SYMBOL(ckb_vm_x86_execute):
 #endif
 #ifdef IS_WINDOWS
   push %rsi

--- a/src/machine/asm/execute_x64.S
+++ b/src/machine/asm/execute_x64.S
@@ -396,11 +396,11 @@
   movzbl %ch, RS4_TEMP1d
 
 #ifdef __APPLE__
-.globl CKB_VM_VERSIONED_SYMBOL(_ckb_vm_x86_execute)
-CKB_VM_VERSIONED_SYMBOL(_ckb_vm_x86_execute):
+.globl CKB_VM_VERSIONED_SYMBOL(_ckb_vm_x64_execute)
+CKB_VM_VERSIONED_SYMBOL(_ckb_vm_x64_execute):
 #else
-.globl CKB_VM_VERSIONED_SYMBOL(ckb_vm_x86_execute)
-CKB_VM_VERSIONED_SYMBOL(ckb_vm_x86_execute):
+.globl CKB_VM_VERSIONED_SYMBOL(ckb_vm_x64_execute)
+CKB_VM_VERSIONED_SYMBOL(ckb_vm_x64_execute):
 #endif
 #ifdef IS_WINDOWS
   push %rsi

--- a/src/machine/asm/mod.rs
+++ b/src/machine/asm/mod.rs
@@ -76,7 +76,7 @@ impl CoreMachine for Box<AsmCoreMachine> {
 // but consider that in the asm machine, `frame_index` is stored in `rdi` and `machine`
 // is stored in `rsi`, there is no need to exchange the values in the two registers
 // in this way.
-#[no_mangle]
+#[export_name = concat!("ckb_vm_inited_memory_", env!("CKB_VM_VERSION"))]
 pub extern "C" fn inited_memory(frame_index: u64, machine: &mut AsmCoreMachine) {
     let addr_from = (frame_index << MEMORY_FRAME_SHIFTS) as usize;
     let addr_to = ((frame_index + 1) << MEMORY_FRAME_SHIFTS) as usize;
@@ -457,9 +457,11 @@ impl SupportMachine for Box<AsmCoreMachine> {
 }
 
 extern "C" {
-    pub fn ckb_vm_x64_execute(m: *mut AsmCoreMachine, s: *mut u8) -> c_uchar;
+    #[link_name = concat!("ckb_vm_x86_execute_", env!("CKB_VM_VERSION"))]
+    pub fn ckb_vm_x64_execute(m: *mut AsmCoreMachine, d: *mut u8) -> c_uchar;
     // We are keeping this as a function here, but at the bottom level this really
     // just points to an array of assembly label offsets for each opcode.
+    #[link_name = concat!("ckb_vm_asm_labels_", env!("CKB_VM_VERSION"))]
     pub fn ckb_vm_asm_labels();
 }
 

--- a/src/machine/asm/mod.rs
+++ b/src/machine/asm/mod.rs
@@ -457,7 +457,7 @@ impl SupportMachine for Box<AsmCoreMachine> {
 }
 
 extern "C" {
-    #[link_name = concat!("ckb_vm_x86_execute_", env!("CKB_VM_VERSION"))]
+    #[link_name = concat!("ckb_vm_x64_execute_", env!("CKB_VM_VERSION"))]
     pub fn ckb_vm_x64_execute(m: *mut AsmCoreMachine, d: *mut u8) -> c_uchar;
     // We are keeping this as a function here, but at the bottom level this really
     // just points to an array of assembly label offsets for each opcode.

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 use scroll::Pread;
 
-use super::debugger::Debugger;
+use super::context::*;
 use super::decoder::{build_decoder, Decoder};
 use super::instructions::{execute, Instruction, Register};
 use super::memory::{round_page_down, round_page_up, Memory};
@@ -420,23 +420,15 @@ impl<R: Register, M: Memory> DefaultCoreMachine<R, M> {
     }
 }
 
-pub type InstructionCycleFunc = dyn Fn(Instruction) -> u64 + Send + Sync;
-
-pub struct DefaultMachine<Inner> {
+/// Use DefaultMachineBuilder to build DefaultMachine.
+pub struct DefaultMachine<Inner, ExecutionContext = ()> {
     inner: Inner,
     pause: Pause,
-
-    // We have run benchmarks on secp256k1 verification, the performance
-    // cost of the Box wrapper here is neglectable, hence we are sticking
-    // with Box solution for simplicity now. Later if this becomes an issue,
-    // we can change to static dispatch.
-    instruction_cycle_func: Box<InstructionCycleFunc>,
-    debugger: Option<Box<dyn Debugger<Inner>>>,
-    syscalls: Vec<Box<dyn Syscalls<Inner>>>,
+    context: ExecutionContext,
     exit_code: i8,
 }
 
-impl<Inner: CoreMachine> CoreMachine for DefaultMachine<Inner> {
+impl<Inner: CoreMachine, Ctx> CoreMachine for DefaultMachine<Inner, Ctx> {
     type REG = <Inner as CoreMachine>::REG;
     type MEM = <Inner as CoreMachine>::MEM;
 
@@ -477,7 +469,9 @@ impl<Inner: CoreMachine> CoreMachine for DefaultMachine<Inner> {
     }
 }
 
-impl<Inner: SupportMachine> SupportMachine for DefaultMachine<Inner> {
+impl<Inner: SupportMachine, Ctx: ExecutionContext<Inner>> SupportMachine
+    for DefaultMachine<Inner, Ctx>
+{
     fn cycles(&self) -> u64 {
         self.inner.cycles()
     }
@@ -512,7 +506,7 @@ impl<Inner: SupportMachine> SupportMachine for DefaultMachine<Inner> {
     }
 }
 
-impl<Inner: SupportMachine> Machine for DefaultMachine<Inner> {
+impl<Inner: SupportMachine, Ctx: ExecutionContext<Inner>> Machine for DefaultMachine<Inner, Ctx> {
     fn ecall(&mut self) -> Result<(), Error> {
         let code = self.registers()[A7].to_u64();
         match code {
@@ -523,14 +517,12 @@ impl<Inner: SupportMachine> Machine for DefaultMachine<Inner> {
                 Ok(())
             }
             _ => {
-                for syscall in &mut self.syscalls {
-                    let processed = syscall.ecall(&mut self.inner)?;
-                    if processed {
-                        if self.cycles() > self.max_cycles() {
-                            return Err(Error::CyclesExceeded);
-                        }
-                        return Ok(());
+                let processed = self.context.ecall(&mut self.inner)?;
+                if processed {
+                    if self.cycles() > self.max_cycles() {
+                        return Err(Error::CyclesExceeded);
                     }
+                    return Ok(());
                 }
                 Err(Error::InvalidEcall(code))
             }
@@ -538,17 +530,11 @@ impl<Inner: SupportMachine> Machine for DefaultMachine<Inner> {
     }
 
     fn ebreak(&mut self) -> Result<(), Error> {
-        if let Some(debugger) = &mut self.debugger {
-            debugger.ebreak(&mut self.inner)
-        } else {
-            // Unlike ecall, the default behavior of an EBREAK operation is
-            // a dummy one.
-            Ok(())
-        }
+        self.context.ebreak(&mut self.inner)
     }
 }
 
-impl<Inner: CoreMachine> Display for DefaultMachine<Inner> {
+impl<Inner: CoreMachine, Ctx> Display for DefaultMachine<Inner, Ctx> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "pc  : 0x{:16X}", self.pc().to_u64())?;
         for (i, name) in REGISTER_ABI_NAMES.iter().enumerate() {
@@ -563,15 +549,48 @@ impl<Inner: CoreMachine> Display for DefaultMachine<Inner> {
     }
 }
 
-impl<Inner: SupportMachine> DefaultMachine<Inner> {
+impl<Inner, Ctx> DefaultMachine<Inner, Ctx> {
+    pub fn take_inner(self) -> Inner {
+        self.inner
+    }
+
+    pub fn pause(&self) -> Pause {
+        self.pause.clone()
+    }
+
+    pub fn exit_code(&self) -> i8 {
+        self.exit_code
+    }
+
+    pub fn inner_mut(&mut self) -> &mut Inner {
+        &mut self.inner
+    }
+
+    pub fn context(&self) -> &Ctx {
+        &self.context
+    }
+
+    pub fn context_mut(&mut self) -> &mut Ctx {
+        &mut self.context
+    }
+
+    pub fn take_context(self) -> (Ctx, DefaultMachine<Inner, ()>) {
+        (
+            self.context,
+            DefaultMachine {
+                context: (),
+                exit_code: self.exit_code,
+                inner: self.inner,
+                pause: self.pause,
+            },
+        )
+    }
+}
+
+impl<Inner: SupportMachine, S: ExecutionContext<Inner>> DefaultMachine<Inner, S> {
     pub fn load_program(&mut self, program: &Bytes, args: &[Bytes]) -> Result<u64, Error> {
         let elf_bytes = self.load_elf(program, true)?;
-        for syscall in &mut self.syscalls {
-            syscall.initialize(&mut self.inner)?;
-        }
-        if let Some(debugger) = &mut self.debugger {
-            debugger.initialize(&mut self.inner)?;
-        }
+        self.context.initialize(&mut self.inner)?;
         let memory_size = self.memory().memory_size();
         let stack_size = memory_size / 4;
         let stack_bytes =
@@ -586,26 +605,6 @@ impl<Inner: SupportMachine> DefaultMachine<Inner> {
             ))
         })?;
         Ok(bytes)
-    }
-
-    pub fn take_inner(self) -> Inner {
-        self.inner
-    }
-
-    pub fn pause(&self) -> Pause {
-        self.pause.clone()
-    }
-
-    pub fn exit_code(&self) -> i8 {
-        self.exit_code
-    }
-
-    pub fn instruction_cycle_func(&self) -> &InstructionCycleFunc {
-        &self.instruction_cycle_func
-    }
-
-    pub fn inner_mut(&mut self) -> &mut Inner {
-        &mut self.inner
     }
 
     // This is the most naive way of running the VM, it only decodes each
@@ -637,54 +636,114 @@ impl<Inner: SupportMachine> DefaultMachine<Inner> {
             let memory = self.memory_mut();
             decoder.decode(memory, pc)?
         };
-        let cycles = self.instruction_cycle_func()(instruction);
+        let cycles = self.context().instruction_cycles(instruction);
         self.add_cycles(cycles)?;
         execute(instruction, self)
     }
 }
 
-pub struct DefaultMachineBuilder<Inner> {
+/// Builder for DefaultMachine.
+///
+/// # Context customization
+///
+/// Use the context method if you have a custom type implementing
+/// `ExecutionContext`. Use `syscall`, `debugger` and `instruction_cycle_func`
+/// if you want some ad-hoc customization of the context.
+pub struct DefaultMachineBuilder<Inner, Ctx = ()> {
     inner: Inner,
-    instruction_cycle_func: Box<InstructionCycleFunc>,
-    debugger: Option<Box<dyn Debugger<Inner>>>,
-    syscalls: Vec<Box<dyn Syscalls<Inner>>>,
+    context: Ctx,
 }
 
-impl<Inner> DefaultMachineBuilder<Inner> {
+impl<Inner> DefaultMachineBuilder<Inner, ()> {
+    /// Create a new builder with the default execution context.
     pub fn new(inner: Inner) -> Self {
-        Self {
-            inner,
-            instruction_cycle_func: Box::new(|_| 0),
-            debugger: None,
-            syscalls: vec![],
+        Self { inner, context: () }
+    }
+
+    // Note: we delibrately implement the context method only for Ctx = (), so
+    // one cannot write `builder.syscall(func).context(ctx)`. That'll replace
+    // the syscall handler and is probably not what they want.
+
+    /// Set the execution context.
+    pub fn context<Ctx>(self, context: Ctx) -> DefaultMachineBuilder<Inner, Ctx>
+    where
+        Inner: SupportMachine,
+        // Not strictly necessary. For better type checking.
+        Ctx: ExecutionContext<Inner>,
+    {
+        DefaultMachineBuilder {
+            inner: self.inner,
+            context,
+        }
+    }
+}
+
+impl<Inner, Ctx> DefaultMachineBuilder<Inner, Ctx> {
+    /// Add a syscall handler.
+    pub fn syscall<Sys>(self, syscall: Sys) -> DefaultMachineBuilder<Inner, WithSyscall<Ctx, Sys>>
+    where
+        Inner: SupportMachine,
+        // For type checking.
+        Sys: Syscalls<Inner>,
+    {
+        DefaultMachineBuilder {
+            inner: self.inner,
+            context: WithSyscall {
+                base: self.context,
+                syscall,
+            },
         }
     }
 
-    pub fn instruction_cycle_func(
-        mut self,
-        instruction_cycle_func: Box<InstructionCycleFunc>,
-    ) -> Self {
-        self.instruction_cycle_func = instruction_cycle_func;
-        self
+    /// Set debugger callback.
+    pub fn debugger<F>(self, debugger: F) -> DefaultMachineBuilder<Inner, WithDebugger<Ctx, F>>
+    where
+        // For type inference.
+        F: FnMut(&mut Inner) -> Result<(), Error>,
+    {
+        DefaultMachineBuilder {
+            inner: self.inner,
+            context: WithDebugger {
+                base: self.context,
+                debugger,
+            },
+        }
     }
 
-    pub fn syscall(mut self, syscall: Box<dyn Syscalls<Inner>>) -> Self {
-        self.syscalls.push(syscall);
-        self
+    /// Set instruction cycles function.
+    pub fn instruction_cycle_func<F>(
+        self,
+        cycles: F,
+    ) -> DefaultMachineBuilder<Inner, WithCyclesFunc<Ctx, F>>
+    where
+        F: Fn(Instruction) -> u64,
+    {
+        DefaultMachineBuilder {
+            inner: self.inner,
+            context: WithCyclesFunc {
+                base: self.context,
+                cycles,
+            },
+        }
     }
 
-    pub fn debugger(mut self, debugger: Box<dyn Debugger<Inner>>) -> Self {
-        self.debugger = Some(debugger);
-        self
+    /// Convert the execution context to be boxed and type erased.
+    pub fn boxed(self) -> DefaultMachineBuilder<Inner, BoxedExecutionContext<Inner>>
+    where
+        Inner: SupportMachine,
+        Ctx: ExecutionContext<Inner> + Send + Sync + 'static,
+    {
+        DefaultMachineBuilder {
+            inner: self.inner,
+            context: self.context.boxed(),
+        }
     }
 
-    pub fn build(self) -> DefaultMachine<Inner> {
+    pub fn build(self) -> DefaultMachine<Inner, Ctx> {
         DefaultMachine {
             inner: self.inner,
             pause: Pause::new(),
-            instruction_cycle_func: self.instruction_cycle_func,
-            debugger: self.debugger,
-            syscalls: self.syscalls,
+            context: self.context,
             exit_code: 0,
         }
     }

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -1,10 +1,25 @@
 use super::Error;
 use crate::machine::SupportMachine;
 
-pub trait Syscalls<Mac: SupportMachine>: Send + Sync {
+/// System call handler.
+pub trait Syscalls<Mac: SupportMachine> {
     fn initialize(&mut self, machine: &mut Mac) -> Result<(), Error>;
     // Returned bool means if the syscall has been processed, if
     // a module returns false, Machine would continue to leverage
     // the next syscall module to process.
     fn ecall(&mut self, machine: &mut Mac) -> Result<bool, Error>;
+}
+
+// For better backward compatibility because existing code uses `.syscall(Box::new(SyscallType))`.
+impl<Mac, T> Syscalls<Mac> for Box<T>
+where
+    Mac: SupportMachine,
+    T: Syscalls<Mac>,
+{
+    fn initialize(&mut self, machine: &mut Mac) -> Result<(), Error> {
+        (**self).initialize(machine)
+    }
+    fn ecall(&mut self, machine: &mut Mac) -> Result<bool, Error> {
+        (**self).ecall(machine)
+    }
 }

--- a/tests/test_asm.rs
+++ b/tests/test_asm.rs
@@ -5,7 +5,9 @@ use ckb_vm::machine::asm::{AsmCoreMachine, AsmMachine};
 use ckb_vm::machine::{CoreMachine, VERSION0, VERSION1};
 use ckb_vm::memory::Memory;
 use ckb_vm::registers::{A0, A1, A2, A3, A4, A5, A7};
-use ckb_vm::{Debugger, DefaultMachineBuilder, Error, Register, SupportMachine, Syscalls, ISA_IMC};
+use ckb_vm::{
+    DefaultMachineBuilder, Error, ExecutionContext, Register, SupportMachine, Syscalls, ISA_IMC,
+};
 use std::fs;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
@@ -69,7 +71,7 @@ pub struct CustomDebugger {
     pub value: Arc<AtomicU8>,
 }
 
-impl<Mac: SupportMachine> Debugger<Mac> for CustomDebugger {
+impl<Mac: SupportMachine> ExecutionContext<Mac> for CustomDebugger {
     fn initialize(&mut self, _machine: &mut Mac) -> Result<(), Error> {
         self.value.store(1, Ordering::Relaxed);
         Ok(())
@@ -88,9 +90,9 @@ pub fn test_asm_ebreak() {
 
     let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::max_value());
     let core = DefaultMachineBuilder::new(asm_core)
-        .debugger(Box::new(CustomDebugger {
+        .context(CustomDebugger {
             value: Arc::clone(&value),
-        }))
+        })
         .build();
     let mut machine = AsmMachine::new(core);
     machine

--- a/tests/test_auipc_fusion.rs
+++ b/tests/test_auipc_fusion.rs
@@ -109,7 +109,8 @@ pub fn test_asm_auipc_fusion() {
         let end_instruction = is_basic_block_end_instruction(instruction);
         current_pc += u64::from(instruction_length(instruction));
         trace.instructions[i] = instruction;
-        trace.cycles += machine.machine.instruction_cycle_func()(instruction);
+        // Default cycles func always return zero.
+        trace.cycles += 0;
         let opcode = extract_opcode(instruction);
         // Here we are calculating the absolute address used in direct threading
         // from label offsets.

--- a/tests/test_auipc_fusion.rs
+++ b/tests/test_auipc_fusion.rs
@@ -77,9 +77,7 @@ pub fn test_rust_auipc_fusion() {
 #[cfg(has_asm)]
 #[test]
 pub fn test_asm_auipc_fusion() {
-    extern "C" {
-        fn ckb_vm_asm_labels();
-    }
+    use ckb_vm::machine::asm::ckb_vm_asm_labels;
 
     let buffer = fs::read("tests/programs/auipc_no_sign_extend")
         .unwrap()

--- a/tests/test_misc.rs
+++ b/tests/test_misc.rs
@@ -2,8 +2,8 @@ use ckb_vm::cost_model::constant_cycles;
 use ckb_vm::machine::VERSION0;
 use ckb_vm::registers::{A0, A1, A2, A3, A4, A5, A7};
 use ckb_vm::{
-    run, CoreMachine, Debugger, DefaultCoreMachine, DefaultMachineBuilder, Error, FlatMemory,
-    Memory, Register, SparseMemory, SupportMachine, Syscalls, WXorXMemory, ISA_IMC,
+    run, CoreMachine, DefaultCoreMachine, DefaultMachineBuilder, Error, ExecutionContext,
+    FlatMemory, Memory, Register, SparseMemory, SupportMachine, Syscalls, WXorXMemory, ISA_IMC,
     RISCV_MAX_MEMORY, RISCV_PAGESIZE,
 };
 #[cfg(has_asm)]
@@ -72,7 +72,7 @@ pub struct CustomDebugger {
     pub value: Arc<AtomicU8>,
 }
 
-impl<Mac: SupportMachine> Debugger<Mac> for CustomDebugger {
+impl<Mac: SupportMachine> ExecutionContext<Mac> for CustomDebugger {
     fn initialize(&mut self, _machine: &mut Mac) -> Result<(), Error> {
         self.value.store(1, Ordering::Relaxed);
         Ok(())
@@ -91,9 +91,9 @@ pub fn test_ebreak() {
     let core_machine =
         DefaultCoreMachine::<u64, SparseMemory<u64>>::new(ISA_IMC, VERSION0, u64::max_value());
     let mut machine = DefaultMachineBuilder::new(core_machine)
-        .debugger(Box::new(CustomDebugger {
+        .context(CustomDebugger {
             value: Arc::clone(&value),
-        }))
+        })
         .build();
     machine
         .load_program(&buffer, &vec!["ebreak".into()])


### PR DESCRIPTION
* Use generic type parameter instead of `Box<dyn>` to support different !Send/!Sync/not 'static Syscalls.
* Rename symbols so this can be used with crates.io version in one binary.