### PR TITLE
test: Add ci job to run spawn tests in release mode

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,6 +36,14 @@ jobs:
       - script: make ci-asm
         displayName: Run ci-asm
 
+  - job: LinuxSpawnStackCheck
+    pool:
+      vmImage: 'ubuntu-20.04'
+    steps:
+      - template: devtools/azure/linux-dependencies.yml
+      - script: cargo test test_spawn --release --features=asm -- --nocapture
+        displayName: Run spawn tests
+
   - job: LinuxCI
     pool:
       vmImage: 'ubuntu-20.04'


### PR DESCRIPTION
Fundamentally, it really only matters to inspect stack size usage in release builds. However, it remains a question if we want to also run those tests using debug builds.