### PR TITLE
chore: Use `as` provided by mingw on Windows

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -159,9 +159,7 @@ jobs:
         run: make ci-asm
 
   windows-x86-ci-asm:
-    # We must use windows-2019 here, otherwise we will encounter some bugs, for futher details, see
-    # https://github.com/yasm/yasm/issues/153
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
@@ -169,11 +167,8 @@ jobs:
         # https://github.com/ScoopInstaller/Install#for-admin
         run: |
           iex "& {$(irm get.scoop.sh)} -RunAsAdmin"
-          scoop install llvm
-          scoop install yasm
+          scoop install mingw
       - name: Run ci-asm
         shell: pwsh
         run: |
-          $env:path="C:\Users\runneradmin\scoop\apps\llvm\current;"+$env:path
-          $env:path="C:\Users\runneradmin\scoop\apps\yasm\current;"+$env:path
           make ci-asm


### PR DESCRIPTION
Previously, we were using clang (as a preprocessor) & yasm to transform assembly source code on Windows. On the one hand, this is really a hack solution to build a GAS-coupled assembly source file, on the other hand, yasm hasn't seen a proper release in years, making us believe that yasm is slowly becoming unmaintained. This change switches to use mingw when building the assembly source code, mingw is actively maintained now, which will reduce any problems we might run into.

Note that we only activate the new logic when target environment is `msvc`, for `x86_64-pc-windows-gnu` target, current logic would already work flawlessly.