### PR TITLE
The get_page_indices function requires that length cannot be 0

### DIFF
--- a/src/snapshot2.rs
+++ b/src/snapshot2.rs
@@ -267,6 +267,9 @@ impl<I: Clone + PartialEq, D: DataSource<I>> Snapshot2Context<I, D> {
         start: u64,
         length: u64,
     ) -> Result<(), Error> {
+        if length == 0 {
+            return Ok(());
+        }
         let page_indices = get_page_indices(start, length);
         for page in page_indices.0..=page_indices.1 {
             machine.memory_mut().set_flag(page, FLAG_DIRTY)?;

--- a/tests/test_resume2.rs
+++ b/tests/test_resume2.rs
@@ -649,13 +649,13 @@ pub fn test_store_bytes_twice() {
         }
         _ => unimplemented!(),
     }
-    let a = machine.full_memory().unwrap()[4096 * 2];
+    let mem1 = machine.full_memory().unwrap();
 
     let snapshot = machine.snapshot().unwrap();
     let mut machine2 = MachineTy::Asm.build(data_source.clone(), VERSION2);
     machine2.resume(snapshot).unwrap();
     machine2.set_max_cycles(u64::MAX);
-    let b = machine2.full_memory().unwrap()[4096 * 2];
+    let mem2 = machine2.full_memory().unwrap();
 
-    assert_eq!(a, b);
+    assert_eq!(mem1, mem2);
 }


### PR DESCRIPTION
See https://github.com/nervosnetwork/ckb-vm/blob/develop/src/memory/mod.rs#L117