### PR TITLE
Set an executable page at the top of the stack

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ enable-chaos-mode-by-default = ["ckb-vm-definitions/enable-chaos-mode-by-default
 # Disable slow tests to run miri on CI
 miri-ci = []
 pprof = []
+heap-stack-overlap-detect = []
 
 [dependencies]
 byteorder = "1"

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -175,6 +175,16 @@ pub trait SupportMachine: CoreMachine {
         stack_start: u64,
         stack_size: u64,
     ) -> Result<u64, Error> {
+        #[cfg(feature = "heap-stack-overlap-detect")]
+        {
+            use super::memory::FLAG_EXECUTABLE;
+            use super::RISCV_PAGESIZE;
+            // When the heap or stack attempts to write data to this area,
+            // ckb-vm will return an error due to wxorx rules.
+            self.memory_mut()
+                .set_flag(stack_start / RISCV_PAGESIZE as u64, FLAG_EXECUTABLE)?;
+        }
+
         // When we re-ordered the sections of a program, writing data in high memory
         // will cause unnecessary changes. At the same time, for ckb, argc is always 0
         // and the memory is initialized to 0, so memory writing can be safely skipped.

--- a/tests/test_asm.rs
+++ b/tests/test_asm.rs
@@ -266,6 +266,7 @@ pub fn test_asm_wxorx_crash_64() {
     );
 }
 
+#[cfg(not(feature = "heap-stack-overlap-detect"))]
 #[test]
 pub fn test_asm_alloc_many() {
     let buffer = fs::read("tests/programs/alloc_many").unwrap().into();

--- a/tests/test_dy_memory.rs
+++ b/tests/test_dy_memory.rs
@@ -42,6 +42,7 @@ fn run_memory_suc(memory_size: usize, bin_path: String, bin_name: String) {
     }
 }
 
+#[cfg(not(feature = "heap-stack-overlap-detect"))]
 #[test]
 fn test_dy_memory() {
     run_memory_suc(

--- a/tests/test_resume.rs
+++ b/tests/test_resume.rs
@@ -1,4 +1,5 @@
 #![cfg(has_asm)]
+#![cfg(not(feature = "heap-stack-overlap-detect"))]
 pub mod machine_build;
 use bytes::Bytes;
 use ckb_vm::cost_model::constant_cycles;

--- a/tests/test_resume2.rs
+++ b/tests/test_resume2.rs
@@ -1,4 +1,5 @@
 #![cfg(has_asm)]
+#![cfg(not(feature = "heap-stack-overlap-detect"))]
 pub mod machine_build;
 use bytes::Bytes;
 use ckb_vm::cost_model::constant_cycles;


### PR DESCRIPTION
When this feature is enabled, the top of the stack will be marked as an executable memory page. If the heap or stack attempts to write data to this area, ckb-vm will return an error due to the wxorx rules.

The purpose of this feature is to use it in dapp's testcase, which can reduce the occurrence of overlap.

Note that we have several test cases that use too much heap, which will trigger overlap checks.