### PR TITLE
A is no longer enabled by default

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -69,7 +69,7 @@ jobs:
           ln -snf .. ckb-vm-test-suite/ckb-vm
           docker run --rm -v `pwd`:/code nervos/ckb-riscv-gnu-toolchain:bionic-20210804 cp -r /riscv /code/riscv
           cd ckb-vm-test-suite
-          git checkout 86480364649c9cb6ac01674fe51156e7cf50a31a
+          git checkout 2ef749d0f580958043264a798e560fe25fec0c6e
           git submodule update --init --recursive
           RISCV=`pwd`/../riscv ./test.sh
 
@@ -136,7 +136,7 @@ jobs:
           ln -snf .. ckb-vm-test-suite/ckb-vm
           docker run --rm -v `pwd`:/code nervos/ckb-riscv-gnu-toolchain:bionic-20210804 cp -r /riscv /code/riscv
           cd ckb-vm-test-suite
-          git checkout 86480364649c9cb6ac01674fe51156e7cf50a31a
+          git checkout 2ef749d0f580958043264a798e560fe25fec0c6e
           git submodule update --init --recursive
           RISCV=`pwd`/../riscv ./test.sh --build-only
           cd ..

--- a/definitions/src/lib.rs
+++ b/definitions/src/lib.rs
@@ -15,4 +15,5 @@ pub const DEFAULT_MEMORY_SIZE: usize = 4 << 20; // 4 MB
 pub const ISA_IMC: u8 = 0b0000_0000;
 pub const ISA_B: u8 = 0b0000_0001;
 pub const ISA_MOP: u8 = 0b0000_0010;
+// Extension ISA_A is not enabled in ckb 2nd hardfork(aka, meepo hardfork)
 pub const ISA_A: u8 = 0b0000_0100;

--- a/examples/ckb_vm_runner.rs
+++ b/examples/ckb_vm_runner.rs
@@ -40,7 +40,7 @@ impl<Mac: SupportMachine> Syscalls<Mac> for DebugSyscall {
 #[cfg(has_asm)]
 fn main_asm(code: Bytes, args: Vec<Bytes>) -> Result<(), Box<dyn std::error::Error>> {
     let asm_core = ckb_vm::machine::asm::AsmCoreMachine::new(
-        ckb_vm::ISA_IMC | ckb_vm::ISA_B | ckb_vm::ISA_MOP | ckb_vm::ISA_A,
+        ckb_vm::ISA_IMC | ckb_vm::ISA_B | ckb_vm::ISA_MOP,
         ckb_vm::machine::VERSION2,
         u64::MAX,
     );
@@ -64,7 +64,7 @@ fn main_asm(code: Bytes, args: Vec<Bytes>) -> Result<(), Box<dyn std::error::Err
 #[cfg(not(has_asm))]
 fn main_int(code: Bytes, args: Vec<Bytes>) -> Result<(), Box<dyn std::error::Error>> {
     let core_machine = ckb_vm::DefaultCoreMachine::<u64, ckb_vm::SparseMemory<u64>>::new(
-        ckb_vm::ISA_IMC | ckb_vm::ISA_B | ckb_vm::ISA_MOP | ckb_vm::ISA_A,
+        ckb_vm::ISA_IMC | ckb_vm::ISA_B | ckb_vm::ISA_MOP,
         ckb_vm::machine::VERSION2,
         u64::MAX,
     );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ pub fn run<R: Register, M: Memory<REG = R> + Default>(
     args: &[Bytes],
 ) -> Result<i8, Error> {
     let core_machine = DefaultCoreMachine::<R, WXorXMemory<M>>::new_with_memory(
-        ISA_IMC | ISA_A | ISA_B | ISA_MOP,
+        ISA_IMC | ISA_B | ISA_MOP,
         machine::VERSION2,
         u64::MAX,
         WXorXMemory::new(M::default()),
@@ -57,7 +57,7 @@ pub fn run_with_memory<R: Register, M: Memory<REG = R>>(
     memory: M,
 ) -> Result<i8, Error> {
     let core_machine = DefaultCoreMachine::<R, WXorXMemory<M>>::new_with_memory(
-        ISA_IMC | ISA_A | ISA_B | ISA_MOP,
+        ISA_IMC | ISA_B | ISA_MOP,
         machine::VERSION2,
         u64::MAX,
         WXorXMemory::new(memory),

--- a/tests/machine_build.rs
+++ b/tests/machine_build.rs
@@ -2,11 +2,10 @@ use bytes::Bytes;
 use ckb_vm::cost_model::constant_cycles;
 #[cfg(has_asm)]
 use ckb_vm::machine::asm::{AsmCoreMachine, AsmMachine};
-use ckb_vm::machine::{trace::TraceMachine, DefaultCoreMachine, VERSION1, VERSION2};
+use ckb_vm::machine::{trace::TraceMachine, DefaultCoreMachine};
 use ckb_vm::registers::{A0, A7};
 use ckb_vm::{
     DefaultMachineBuilder, Error, Register, SparseMemory, SupportMachine, Syscalls, WXorXMemory,
-    ISA_A, ISA_B, ISA_IMC, ISA_MOP,
 };
 
 pub struct SleepSyscall {}
@@ -30,50 +29,9 @@ impl<Mac: SupportMachine> Syscalls<Mac> for SleepSyscall {
 }
 
 #[cfg(has_asm)]
-pub fn asm_v1_imcb(path: &str) -> AsmMachine {
+pub fn asm(path: &str, args: Vec<Bytes>, version: u32, isa: u8) -> AsmMachine {
     let buffer: Bytes = std::fs::read(path).unwrap().into();
-    let asm_core = AsmCoreMachine::new(ISA_IMC | ISA_B, VERSION1, u64::MAX);
-    let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
-        .instruction_cycle_func(Box::new(constant_cycles))
-        .syscall(Box::new(SleepSyscall {}))
-        .build();
-    let mut machine = AsmMachine::new(core);
-    machine
-        .load_program(&buffer, &vec![Bytes::from("main")])
-        .unwrap();
-    machine
-}
-
-pub fn int_v1_imcb(
-    path: &str,
-) -> TraceMachine<DefaultCoreMachine<u64, WXorXMemory<SparseMemory<u64>>>> {
-    let buffer: Bytes = std::fs::read(path).unwrap().into();
-    let core_machine = DefaultCoreMachine::<u64, WXorXMemory<SparseMemory<u64>>>::new(
-        ISA_IMC | ISA_B,
-        VERSION1,
-        u64::MAX,
-    );
-    let mut machine = TraceMachine::new(
-        DefaultMachineBuilder::new(core_machine)
-            .instruction_cycle_func(Box::new(constant_cycles))
-            .syscall(Box::new(SleepSyscall {}))
-            .build(),
-    );
-    machine
-        .load_program(&buffer, &vec![Bytes::from("main")])
-        .unwrap();
-    machine
-}
-
-#[cfg(has_asm)]
-pub fn asm_v1_mop(path: &str, args: Vec<Bytes>) -> AsmMachine {
-    asm_mop(path, args, VERSION1)
-}
-
-#[cfg(has_asm)]
-pub fn asm_mop(path: &str, args: Vec<Bytes>, version: u32) -> AsmMachine {
-    let buffer: Bytes = std::fs::read(path).unwrap().into();
-    let asm_core = AsmCoreMachine::new(ISA_IMC | ISA_B | ISA_MOP, version, u64::MAX);
+    let asm_core = AsmCoreMachine::new(isa, version, u64::MAX);
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
         .instruction_cycle_func(Box::new(constant_cycles))
         .syscall(Box::new(SleepSyscall {}))
@@ -85,24 +43,15 @@ pub fn asm_mop(path: &str, args: Vec<Bytes>, version: u32) -> AsmMachine {
     machine
 }
 
-pub fn int_v1_mop(
-    path: &str,
-    args: Vec<Bytes>,
-) -> TraceMachine<DefaultCoreMachine<u64, WXorXMemory<SparseMemory<u64>>>> {
-    int_mop(path, args, VERSION1)
-}
-
-pub fn int_mop(
+pub fn int(
     path: &str,
     args: Vec<Bytes>,
     version: u32,
+    isa: u8,
 ) -> TraceMachine<DefaultCoreMachine<u64, WXorXMemory<SparseMemory<u64>>>> {
     let buffer: Bytes = std::fs::read(path).unwrap().into();
-    let core_machine = DefaultCoreMachine::<u64, WXorXMemory<SparseMemory<u64>>>::new(
-        ISA_IMC | ISA_B | ISA_MOP,
-        version,
-        u64::MAX,
-    );
+    let core_machine =
+        DefaultCoreMachine::<u64, WXorXMemory<SparseMemory<u64>>>::new(isa, version, u64::MAX);
     let mut machine = TraceMachine::new(
         DefaultMachineBuilder::new(core_machine)
             .instruction_cycle_func(Box::new(constant_cycles))
@@ -112,41 +61,5 @@ pub fn int_mop(
     let mut argv = vec![Bytes::from("main")];
     argv.extend_from_slice(&args);
     machine.load_program(&buffer, &argv).unwrap();
-    machine
-}
-
-#[cfg(has_asm)]
-pub fn asm_v2_imacb(path: &str) -> AsmMachine {
-    let buffer: Bytes = std::fs::read(path).unwrap().into();
-    let asm_core = AsmCoreMachine::new(ISA_IMC | ISA_A | ISA_B, VERSION2, u64::MAX);
-    let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
-        .instruction_cycle_func(Box::new(constant_cycles))
-        .syscall(Box::new(SleepSyscall {}))
-        .build();
-    let mut machine = AsmMachine::new(core);
-    machine
-        .load_program(&buffer, &vec![Bytes::from("main")])
-        .unwrap();
-    machine
-}
-
-pub fn int_v2_imacb(
-    path: &str,
-) -> TraceMachine<DefaultCoreMachine<u64, WXorXMemory<SparseMemory<u64>>>> {
-    let buffer: Bytes = std::fs::read(path).unwrap().into();
-    let core_machine = DefaultCoreMachine::<u64, WXorXMemory<SparseMemory<u64>>>::new(
-        ISA_IMC | ISA_A | ISA_B,
-        VERSION2,
-        u64::MAX,
-    );
-    let mut machine = TraceMachine::new(
-        DefaultMachineBuilder::new(core_machine)
-            .instruction_cycle_func(Box::new(constant_cycles))
-            .syscall(Box::new(SleepSyscall {}))
-            .build(),
-    );
-    machine
-        .load_program(&buffer, &vec![Bytes::from("main")])
-        .unwrap();
     machine
 }

--- a/tests/test_a_extension.rs
+++ b/tests/test_a_extension.rs
@@ -1,18 +1,28 @@
-use ckb_vm::Error;
+use ckb_vm::{machine::VERSION2, Error, ISA_A, ISA_IMC};
 #[cfg(has_asm)]
 use ckb_vm::{CoreMachine, Memory};
 pub mod machine_build;
 
 #[test]
 pub fn test_write_permission_bug() {
-    let mut machine = machine_build::int_v2_imacb("tests/programs/amo_write_permission");
+    let mut machine = machine_build::int(
+        "tests/programs/amo_write_permission",
+        vec![],
+        VERSION2,
+        ISA_IMC | ISA_A,
+    );
     let ret = machine.run();
     assert!(ret.is_err());
     assert_eq!(ret.err(), Some(Error::MemWriteOnExecutablePage(16)));
 
     #[cfg(has_asm)]
     {
-        let mut machine_asm = machine_build::asm_v2_imacb("tests/programs/amo_write_permission");
+        let mut machine_asm = machine_build::asm(
+            "tests/programs/amo_write_permission",
+            vec![],
+            VERSION2,
+            ISA_IMC | ISA_A,
+        );
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_err());
         assert_eq!(ret_asm.err(), Some(Error::MemWriteOnExecutablePage(16)));
@@ -21,14 +31,24 @@ pub fn test_write_permission_bug() {
 
 #[test]
 pub fn test_sc_after_sc() {
-    let mut machine = machine_build::int_v2_imacb("tests/programs/sc_after_sc");
+    let mut machine = machine_build::int(
+        "tests/programs/sc_after_sc",
+        vec![],
+        VERSION2,
+        ISA_IMC | ISA_A,
+    );
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
 
     #[cfg(has_asm)]
     {
-        let mut machine_asm = machine_build::asm_v2_imacb("tests/programs/sc_after_sc");
+        let mut machine_asm = machine_build::asm(
+            "tests/programs/sc_after_sc",
+            vec![],
+            VERSION2,
+            ISA_IMC | ISA_A,
+        );
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
@@ -37,14 +57,16 @@ pub fn test_sc_after_sc() {
 
 #[test]
 pub fn test_sc_only() {
-    let mut machine = machine_build::int_v2_imacb("tests/programs/sc_only");
+    let mut machine =
+        machine_build::int("tests/programs/sc_only", vec![], VERSION2, ISA_IMC | ISA_A);
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
 
     #[cfg(has_asm)]
     {
-        let mut machine_asm = machine_build::asm_v2_imacb("tests/programs/sc_only");
+        let mut machine_asm =
+            machine_build::asm("tests/programs/sc_only", vec![], VERSION2, ISA_IMC | ISA_A);
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
@@ -53,14 +75,24 @@ pub fn test_sc_only() {
 
 #[test]
 pub fn test_amo_compare() {
-    let mut machine = machine_build::int_v2_imacb("tests/programs/amo_compare");
+    let mut machine = machine_build::int(
+        "tests/programs/amo_compare",
+        vec![],
+        VERSION2,
+        ISA_IMC | ISA_A,
+    );
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
 
     #[cfg(has_asm)]
     {
-        let mut machine_asm = machine_build::asm_v2_imacb("tests/programs/amo_compare");
+        let mut machine_asm = machine_build::asm(
+            "tests/programs/amo_compare",
+            vec![],
+            VERSION2,
+            ISA_IMC | ISA_A,
+        );
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
@@ -71,7 +103,12 @@ pub fn test_amo_compare() {
 pub fn test_amo_check_write() {
     #[cfg(has_asm)]
     {
-        let mut machine_asm = machine_build::asm_v2_imacb("tests/programs/amo_check_write");
+        let mut machine_asm = machine_build::asm(
+            "tests/programs/amo_check_write",
+            vec![],
+            VERSION2,
+            ISA_IMC | ISA_A,
+        );
         let page_a = 0;
         let page_b = 17;
         let flag_a = machine_asm.machine.memory_mut().fetch_flag(page_a).unwrap();

--- a/tests/test_b_extension.rs
+++ b/tests/test_b_extension.rs
@@ -1,15 +1,19 @@
+use ckb_vm::{machine::VERSION1, ISA_B, ISA_IMC};
+
 pub mod machine_build;
 
 #[test]
 pub fn test_clzw_bug() {
-    let mut machine = machine_build::int_v1_imcb("tests/programs/clzw_bug");
+    let mut machine =
+        machine_build::int("tests/programs/clzw_bug", vec![], VERSION1, ISA_IMC | ISA_B);
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
 
     #[cfg(has_asm)]
     {
-        let mut machine_asm = machine_build::asm_v1_imcb("tests/programs/clzw_bug");
+        let mut machine_asm =
+            machine_build::asm("tests/programs/clzw_bug", vec![], VERSION1, ISA_IMC | ISA_B);
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
@@ -18,14 +22,24 @@ pub fn test_clzw_bug() {
 
 #[test]
 pub fn test_sbinvi_aot_load_imm_bug() {
-    let mut machine = machine_build::int_v1_imcb("tests/programs/sbinvi_aot_load_imm_bug");
+    let mut machine = machine_build::int(
+        "tests/programs/sbinvi_aot_load_imm_bug",
+        vec![],
+        VERSION1,
+        ISA_IMC | ISA_B,
+    );
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
 
     #[cfg(has_asm)]
     {
-        let mut machine_asm = machine_build::asm_v1_imcb("tests/programs/sbinvi_aot_load_imm_bug");
+        let mut machine_asm = machine_build::asm(
+            "tests/programs/sbinvi_aot_load_imm_bug",
+            vec![],
+            VERSION1,
+            ISA_IMC | ISA_B,
+        );
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
@@ -35,14 +49,24 @@ pub fn test_sbinvi_aot_load_imm_bug() {
 #[test]
 pub fn test_rorw_in_end_of_aot_block() {
     // The 1024th instruction will use one more temporary register than normal.
-    let mut machine = machine_build::int_v1_imcb("tests/programs/rorw_in_end_of_aot_block");
+    let mut machine = machine_build::int(
+        "tests/programs/rorw_in_end_of_aot_block",
+        vec![],
+        VERSION1,
+        ISA_IMC | ISA_B,
+    );
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
 
     #[cfg(has_asm)]
     {
-        let mut machine_asm = machine_build::asm_v1_imcb("tests/programs/rorw_in_end_of_aot_block");
+        let mut machine_asm = machine_build::asm(
+            "tests/programs/rorw_in_end_of_aot_block",
+            vec![],
+            VERSION1,
+            ISA_IMC | ISA_B,
+        );
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
@@ -51,14 +75,15 @@ pub fn test_rorw_in_end_of_aot_block() {
 
 #[test]
 pub fn test_pcnt() {
-    let mut machine = machine_build::int_v1_imcb("tests/programs/pcnt");
+    let mut machine = machine_build::int("tests/programs/pcnt", vec![], VERSION1, ISA_IMC | ISA_B);
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
 
     #[cfg(has_asm)]
     {
-        let mut machine_asm = machine_build::asm_v1_imcb("tests/programs/pcnt");
+        let mut machine_asm =
+            machine_build::asm("tests/programs/pcnt", vec![], VERSION1, ISA_IMC | ISA_B);
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
@@ -67,14 +92,24 @@ pub fn test_pcnt() {
 
 #[test]
 pub fn test_clmul_bug() {
-    let mut machine = machine_build::int_v1_imcb("tests/programs/clmul_bug");
+    let mut machine = machine_build::int(
+        "tests/programs/clmul_bug",
+        vec![],
+        VERSION1,
+        ISA_IMC | ISA_B,
+    );
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
 
     #[cfg(has_asm)]
     {
-        let mut machine_asm = machine_build::asm_v1_imcb("tests/programs/clmul_bug");
+        let mut machine_asm = machine_build::asm(
+            "tests/programs/clmul_bug",
+            vec![],
+            VERSION1,
+            ISA_IMC | ISA_B,
+        );
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
@@ -83,14 +118,16 @@ pub fn test_clmul_bug() {
 
 #[test]
 pub fn test_orc_bug() {
-    let mut machine = machine_build::int_v1_imcb("tests/programs/orc_bug");
+    let mut machine =
+        machine_build::int("tests/programs/orc_bug", vec![], VERSION1, ISA_IMC | ISA_B);
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
 
     #[cfg(has_asm)]
     {
-        let mut machine_asm = machine_build::asm_v1_imcb("tests/programs/orc_bug");
+        let mut machine_asm =
+            machine_build::asm("tests/programs/orc_bug", vec![], VERSION1, ISA_IMC | ISA_B);
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);

--- a/tests/test_dy_memory.rs
+++ b/tests/test_dy_memory.rs
@@ -5,7 +5,7 @@ use ckb_vm::{
         asm::{AsmCoreMachine, AsmMachine},
         DefaultMachineBuilder, VERSION0, VERSION2,
     },
-    ISA_A, ISA_B, ISA_IMC, ISA_MOP,
+    ISA_B, ISA_IMC, ISA_MOP,
 };
 use std::fs;
 
@@ -79,7 +79,7 @@ fn test_memory_out_of_bounds() {
     #[cfg(has_asm)]
     {
         let asm_core = AsmCoreMachine::new_with_memory(
-            ISA_IMC | ISA_A | ISA_B | ISA_MOP,
+            ISA_IMC | ISA_B | ISA_MOP,
             VERSION2,
             u64::MAX,
             memory_size,

--- a/tests/test_misc.rs
+++ b/tests/test_misc.rs
@@ -1,11 +1,11 @@
 use ckb_vm::cost_model::constant_cycles;
 use ckb_vm::error::OutOfBoundKind;
-use ckb_vm::machine::VERSION0;
+use ckb_vm::machine::{VERSION0, VERSION1, VERSION2};
 use ckb_vm::registers::{A0, A1, A2, A3, A4, A5, A7};
 use ckb_vm::{
     run, CoreMachine, Debugger, DefaultCoreMachine, DefaultMachineBuilder, Error, FlatMemory,
     Memory, Register, SparseMemory, SupportMachine, Syscalls, WXorXMemory, DEFAULT_MEMORY_SIZE,
-    ISA_IMC, RISCV_PAGESIZE,
+    ISA_B, ISA_IMC, RISCV_PAGESIZE,
 };
 #[cfg(has_asm)]
 use ckb_vm_definitions::asm::AsmCoreMachine;
@@ -435,27 +435,47 @@ pub fn test_outofcycles_in_syscall() {
 #[test]
 pub fn test_clang() {
     {
-        let mut machine = machine_build::int_v1_imcb("tests/programs/clang_sample");
+        let mut machine = machine_build::int(
+            "tests/programs/clang_sample",
+            vec![],
+            VERSION1,
+            ISA_IMC | ISA_B,
+        );
         let ret = machine.run();
         assert!(ret.is_ok());
     }
 
     #[cfg(has_asm)]
     {
-        let mut machine_asm = machine_build::asm_v1_imcb("tests/programs/clang_sample");
+        let mut machine_asm = machine_build::asm(
+            "tests/programs/clang_sample",
+            vec![],
+            VERSION1,
+            ISA_IMC | ISA_B,
+        );
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
     }
 
     {
-        let mut machine = machine_build::int_v2_imacb("tests/programs/clang_sample");
+        let mut machine = machine_build::int(
+            "tests/programs/clang_sample",
+            vec![],
+            VERSION2,
+            ISA_IMC | ISA_B,
+        );
         let ret = machine.run();
         assert!(ret.is_ok());
     }
 
     #[cfg(has_asm)]
     {
-        let mut machine_asm = machine_build::asm_v2_imacb("tests/programs/clang_sample");
+        let mut machine_asm = machine_build::asm(
+            "tests/programs/clang_sample",
+            vec![],
+            VERSION2,
+            ISA_IMC | ISA_B,
+        );
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
     }

--- a/tests/test_mop.rs
+++ b/tests/test_mop.rs
@@ -1,16 +1,28 @@
 pub mod machine_build;
 use bytes::Bytes;
-use ckb_vm::{error::OutOfBoundKind, registers::A0, CoreMachine, Error, SupportMachine};
+use ckb_vm::error::OutOfBoundKind;
+use ckb_vm::machine::{VERSION1, VERSION2};
+use ckb_vm::{registers::A0, CoreMachine, Error, SupportMachine, ISA_B, ISA_IMC, ISA_MOP};
 
 #[test]
 #[cfg_attr(miri, ignore)]
 pub fn test_mop_wide_multiply() {
-    let mut machine = machine_build::int_v1_imcb("tests/programs/mop_wide_multiply");
+    let mut machine = machine_build::int(
+        "tests/programs/mop_wide_multiply",
+        vec![],
+        VERSION1,
+        ISA_IMC | ISA_B,
+    );
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
 
-    let mut machine = machine_build::int_v1_mop("tests/programs/mop_wide_multiply", vec![]);
+    let mut machine = machine_build::int(
+        "tests/programs/mop_wide_multiply",
+        vec![],
+        VERSION1,
+        ISA_IMC | ISA_B | ISA_MOP,
+    );
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
@@ -18,7 +30,12 @@ pub fn test_mop_wide_multiply() {
 
     #[cfg(has_asm)]
     {
-        let mut machine_asm = machine_build::asm_v1_mop("tests/programs/mop_wide_multiply", vec![]);
+        let mut machine_asm = machine_build::asm(
+            "tests/programs/mop_wide_multiply",
+            vec![],
+            VERSION1,
+            ISA_IMC | ISA_B | ISA_MOP,
+        );
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
@@ -29,12 +46,22 @@ pub fn test_mop_wide_multiply() {
 #[test]
 #[cfg_attr(miri, ignore)]
 pub fn test_mop_wide_divide() {
-    let mut machine = machine_build::int_v1_imcb("tests/programs/mop_wide_divide");
+    let mut machine = machine_build::int(
+        "tests/programs/mop_wide_divide",
+        vec![],
+        VERSION1,
+        ISA_IMC | ISA_B,
+    );
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
 
-    let mut machine = machine_build::int_v1_mop("tests/programs/mop_wide_divide", vec![]);
+    let mut machine = machine_build::int(
+        "tests/programs/mop_wide_divide",
+        vec![],
+        VERSION1,
+        ISA_IMC | ISA_B | ISA_MOP,
+    );
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
@@ -42,7 +69,12 @@ pub fn test_mop_wide_divide() {
 
     #[cfg(has_asm)]
     {
-        let mut machine_asm = machine_build::asm_v1_mop("tests/programs/mop_wide_divide", vec![]);
+        let mut machine_asm = machine_build::asm(
+            "tests/programs/mop_wide_divide",
+            vec![],
+            VERSION1,
+            ISA_IMC | ISA_B | ISA_MOP,
+        );
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
@@ -52,12 +84,22 @@ pub fn test_mop_wide_divide() {
 
 #[test]
 pub fn test_mop_far_jump() {
-    let mut machine = machine_build::int_v1_imcb("tests/programs/mop_far_jump");
+    let mut machine = machine_build::int(
+        "tests/programs/mop_far_jump",
+        vec![],
+        VERSION1,
+        ISA_IMC | ISA_B,
+    );
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
 
-    let mut machine = machine_build::int_v1_mop("tests/programs/mop_far_jump", vec![]);
+    let mut machine = machine_build::int(
+        "tests/programs/mop_far_jump",
+        vec![],
+        VERSION1,
+        ISA_IMC | ISA_B | ISA_MOP,
+    );
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
@@ -65,7 +107,12 @@ pub fn test_mop_far_jump() {
 
     #[cfg(has_asm)]
     {
-        let mut machine_asm = machine_build::asm_v1_mop("tests/programs/mop_far_jump", vec![]);
+        let mut machine_asm = machine_build::asm(
+            "tests/programs/mop_far_jump",
+            vec![],
+            VERSION1,
+            ISA_IMC | ISA_B | ISA_MOP,
+        );
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
@@ -76,20 +123,34 @@ pub fn test_mop_far_jump() {
 #[test]
 #[cfg_attr(miri, ignore)]
 pub fn test_mop_ld_32_constants() {
-    let mut machine = machine_build::int_v1_imcb("tests/programs/mop_ld_signextend_32");
+    let mut machine = machine_build::int(
+        "tests/programs/mop_ld_signextend_32",
+        vec![],
+        VERSION1,
+        ISA_IMC | ISA_B,
+    );
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
 
-    let mut machine = machine_build::int_v1_mop("tests/programs/mop_ld_signextend_32", vec![]);
+    let mut machine = machine_build::int(
+        "tests/programs/mop_ld_signextend_32",
+        vec![],
+        VERSION1,
+        ISA_IMC | ISA_B | ISA_MOP,
+    );
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
 
     #[cfg(has_asm)]
     {
-        let mut machine_asm =
-            machine_build::asm_v1_mop("tests/programs/mop_ld_signextend_32", vec![]);
+        let mut machine_asm = machine_build::asm(
+            "tests/programs/mop_ld_signextend_32",
+            vec![],
+            VERSION1,
+            ISA_IMC | ISA_B | ISA_MOP,
+        );
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
@@ -106,13 +167,23 @@ pub fn test_mop_secp256k1() {
         Bytes::from("bar"),
     ];
 
-    let mut machine = machine_build::int_v1_mop("benches/data/secp256k1_bench", args.clone());
+    let mut machine = machine_build::int(
+        "benches/data/secp256k1_bench",
+        args.clone(),
+        VERSION1,
+        ISA_IMC | ISA_B | ISA_MOP,
+    );
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
     assert_eq!(machine.machine.cycles(), 611871);
 
-    let mut machine = machine_build::int_mop("benches/data/secp256k1_bench", args.clone(), 2);
+    let mut machine = machine_build::int(
+        "benches/data/secp256k1_bench",
+        args.clone(),
+        VERSION2,
+        ISA_IMC | ISA_B | ISA_MOP,
+    );
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
@@ -120,15 +191,23 @@ pub fn test_mop_secp256k1() {
 
     #[cfg(has_asm)]
     {
-        let mut machine_asm =
-            machine_build::asm_v1_mop("benches/data/secp256k1_bench", args.clone());
+        let mut machine_asm = machine_build::asm(
+            "benches/data/secp256k1_bench",
+            args.clone(),
+            VERSION1,
+            ISA_IMC | ISA_B | ISA_MOP,
+        );
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
         assert_eq!(machine_asm.machine.cycles(), 611871);
 
-        let mut machine_asm =
-            machine_build::asm_mop("benches/data/secp256k1_bench", args.clone(), 2);
+        let mut machine_asm = machine_build::asm(
+            "benches/data/secp256k1_bench",
+            args.clone(),
+            VERSION2,
+            ISA_IMC | ISA_B | ISA_MOP,
+        );
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
@@ -138,13 +217,19 @@ pub fn test_mop_secp256k1() {
 
 #[test]
 pub fn test_mop_adc() {
-    let mut machine = machine_build::int_v1_imcb("tests/programs/mop_adc");
+    let mut machine =
+        machine_build::int("tests/programs/mop_adc", vec![], VERSION1, ISA_IMC | ISA_B);
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
     assert_eq!(machine.machine.cycles(), 73);
 
-    let mut machine = machine_build::int_v1_mop("tests/programs/mop_adc", vec![]);
+    let mut machine = machine_build::int(
+        "tests/programs/mop_adc",
+        vec![],
+        VERSION1,
+        ISA_IMC | ISA_B | ISA_MOP,
+    );
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
@@ -152,7 +237,12 @@ pub fn test_mop_adc() {
 
     #[cfg(has_asm)]
     {
-        let mut machine_asm = machine_build::asm_v1_mop("tests/programs/mop_adc", vec![]);
+        let mut machine_asm = machine_build::asm(
+            "tests/programs/mop_adc",
+            vec![],
+            VERSION1,
+            ISA_IMC | ISA_B | ISA_MOP,
+        );
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
@@ -162,19 +252,30 @@ pub fn test_mop_adc() {
 
 #[test]
 pub fn test_mop_adcs() {
-    let mut machine = machine_build::int_v1_imcb("tests/programs/mop_adcs");
+    let mut machine =
+        machine_build::int("tests/programs/mop_adcs", vec![], VERSION1, ISA_IMC | ISA_B);
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
     assert_eq!(machine.machine.cycles(), 53);
 
-    let mut machine = machine_build::int_v1_mop("tests/programs/mop_adcs", vec![]);
+    let mut machine = machine_build::int(
+        "tests/programs/mop_adcs",
+        vec![],
+        VERSION1,
+        ISA_IMC | ISA_B | ISA_MOP,
+    );
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
     assert_eq!(machine.machine.cycles(), 53);
 
-    let mut machine = machine_build::int_mop("tests/programs/mop_adcs", vec![], 2);
+    let mut machine = machine_build::int(
+        "tests/programs/mop_adcs",
+        vec![],
+        VERSION2,
+        ISA_IMC | ISA_B | ISA_MOP,
+    );
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
@@ -182,13 +283,23 @@ pub fn test_mop_adcs() {
 
     #[cfg(has_asm)]
     {
-        let mut machine_asm = machine_build::asm_v1_mop("tests/programs/mop_adcs", vec![]);
+        let mut machine_asm = machine_build::asm(
+            "tests/programs/mop_adcs",
+            vec![],
+            VERSION1,
+            ISA_IMC | ISA_B | ISA_MOP,
+        );
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
         assert_eq!(machine_asm.machine.cycles(), 53);
 
-        let mut machine_asm = machine_build::asm_mop("tests/programs/mop_adcs", vec![], 2);
+        let mut machine_asm = machine_build::asm(
+            "tests/programs/mop_adcs",
+            vec![],
+            VERSION2,
+            ISA_IMC | ISA_B | ISA_MOP,
+        );
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
@@ -198,19 +309,30 @@ pub fn test_mop_adcs() {
 
 #[test]
 pub fn test_mop_add3() {
-    let mut machine = machine_build::int_v1_imcb("tests/programs/mop_add3");
+    let mut machine =
+        machine_build::int("tests/programs/mop_add3", vec![], VERSION1, ISA_IMC | ISA_B);
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0, "Machine state: {}", machine.machine);
     assert_eq!(machine.machine.cycles(), 1047);
 
-    let mut machine = machine_build::int_v1_mop("tests/programs/mop_add3", vec![]);
+    let mut machine = machine_build::int(
+        "tests/programs/mop_add3",
+        vec![],
+        VERSION1,
+        ISA_IMC | ISA_B | ISA_MOP,
+    );
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
     assert_eq!(machine.machine.cycles(), 939);
 
-    let mut machine = machine_build::int_mop("tests/programs/mop_add3", vec![], 2);
+    let mut machine = machine_build::int(
+        "tests/programs/mop_add3",
+        vec![],
+        VERSION2,
+        ISA_IMC | ISA_B | ISA_MOP,
+    );
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
@@ -218,13 +340,23 @@ pub fn test_mop_add3() {
 
     #[cfg(has_asm)]
     {
-        let mut machine_asm = machine_build::asm_v1_mop("tests/programs/mop_add3", vec![]);
+        let mut machine_asm = machine_build::asm(
+            "tests/programs/mop_add3",
+            vec![],
+            VERSION1,
+            ISA_IMC | ISA_B | ISA_MOP,
+        );
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
         assert_eq!(machine_asm.machine.cycles(), 939);
 
-        let mut machine_asm = machine_build::asm_mop("tests/programs/mop_add3", vec![], 2);
+        let mut machine_asm = machine_build::asm(
+            "tests/programs/mop_add3",
+            vec![],
+            VERSION2,
+            ISA_IMC | ISA_B | ISA_MOP,
+        );
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
@@ -234,13 +366,19 @@ pub fn test_mop_add3() {
 
 #[test]
 pub fn test_mop_sbb() {
-    let mut machine = machine_build::int_v1_imcb("tests/programs/mop_sbb");
+    let mut machine =
+        machine_build::int("tests/programs/mop_sbb", vec![], VERSION1, ISA_IMC | ISA_B);
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
     assert_eq!(machine.machine.cycles(), 35);
 
-    let mut machine = machine_build::int_v1_mop("tests/programs/mop_sbb", vec![]);
+    let mut machine = machine_build::int(
+        "tests/programs/mop_sbb",
+        vec![],
+        VERSION1,
+        ISA_IMC | ISA_B | ISA_MOP,
+    );
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
@@ -248,7 +386,12 @@ pub fn test_mop_sbb() {
 
     #[cfg(has_asm)]
     {
-        let mut machine_asm = machine_build::asm_v1_mop("tests/programs/mop_sbb", vec![]);
+        let mut machine_asm = machine_build::asm(
+            "tests/programs/mop_sbb",
+            vec![],
+            VERSION1,
+            ISA_IMC | ISA_B | ISA_MOP,
+        );
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
@@ -258,19 +401,30 @@ pub fn test_mop_sbb() {
 
 #[test]
 pub fn test_mop_sbbs() {
-    let mut machine = machine_build::int_v1_imcb("tests/programs/mop_sbbs");
+    let mut machine =
+        machine_build::int("tests/programs/mop_sbbs", vec![], VERSION1, ISA_IMC | ISA_B);
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0, "Machine state: {}", machine.machine);
     assert_eq!(machine.machine.cycles(), 87);
 
-    let mut machine = machine_build::int_v1_mop("tests/programs/mop_sbbs", vec![]);
+    let mut machine = machine_build::int(
+        "tests/programs/mop_sbbs",
+        vec![],
+        VERSION1,
+        ISA_IMC | ISA_B | ISA_MOP,
+    );
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
     assert_eq!(machine.machine.cycles(), 81);
 
-    let mut machine = machine_build::int_mop("tests/programs/mop_sbbs", vec![], 2);
+    let mut machine = machine_build::int(
+        "tests/programs/mop_sbbs",
+        vec![],
+        VERSION2,
+        ISA_IMC | ISA_B | ISA_MOP,
+    );
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
@@ -278,13 +432,23 @@ pub fn test_mop_sbbs() {
 
     #[cfg(has_asm)]
     {
-        let mut machine_asm = machine_build::asm_v1_mop("tests/programs/mop_sbbs", vec![]);
+        let mut machine_asm = machine_build::asm(
+            "tests/programs/mop_sbbs",
+            vec![],
+            VERSION1,
+            ISA_IMC | ISA_B | ISA_MOP,
+        );
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
         assert_eq!(machine_asm.machine.cycles(), 81);
 
-        let mut machine_asm = machine_build::asm_mop("tests/programs/mop_sbbs", vec![], 2);
+        let mut machine_asm = machine_build::asm(
+            "tests/programs/mop_sbbs",
+            vec![],
+            VERSION2,
+            ISA_IMC | ISA_B | ISA_MOP,
+        );
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
@@ -294,19 +458,34 @@ pub fn test_mop_sbbs() {
 
 #[test]
 pub fn test_mop_random_adc_sbb() {
-    let mut machine = machine_build::int_v1_imcb("tests/programs/mop_random_adc_sbb");
+    let mut machine = machine_build::int(
+        "tests/programs/mop_random_adc_sbb",
+        vec![],
+        VERSION1,
+        ISA_IMC | ISA_B,
+    );
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
     assert_eq!(machine.machine.cycles(), 9458);
 
-    let mut machine = machine_build::int_v1_mop("tests/programs/mop_random_adc_sbb", vec![]);
+    let mut machine = machine_build::int(
+        "tests/programs/mop_random_adc_sbb",
+        vec![],
+        VERSION1,
+        ISA_IMC | ISA_B | ISA_MOP,
+    );
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
     assert_eq!(machine.machine.cycles(), 6755);
 
-    let mut machine = machine_build::int_mop("tests/programs/mop_random_adc_sbb", vec![], 2);
+    let mut machine = machine_build::int(
+        "tests/programs/mop_random_adc_sbb",
+        vec![],
+        VERSION2,
+        ISA_IMC | ISA_B | ISA_MOP,
+    );
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
@@ -314,15 +493,23 @@ pub fn test_mop_random_adc_sbb() {
 
     #[cfg(has_asm)]
     {
-        let mut machine_asm =
-            machine_build::asm_v1_mop("tests/programs/mop_random_adc_sbb", vec![]);
+        let mut machine_asm = machine_build::asm(
+            "tests/programs/mop_random_adc_sbb",
+            vec![],
+            VERSION1,
+            ISA_IMC | ISA_B | ISA_MOP,
+        );
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
         assert_eq!(machine_asm.machine.cycles(), 6755);
 
-        let mut machine_asm =
-            machine_build::asm_mop("tests/programs/mop_random_adc_sbb", vec![], 2);
+        let mut machine_asm = machine_build::asm(
+            "tests/programs/mop_random_adc_sbb",
+            vec![],
+            VERSION2,
+            ISA_IMC | ISA_B | ISA_MOP,
+        );
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
@@ -332,16 +519,24 @@ pub fn test_mop_random_adc_sbb() {
 
 #[test]
 pub fn test_mop_ld_signextend_32_overflow_bug() {
-    let mut machine =
-        machine_build::int_v1_mop("tests/programs/mop_ld_signextend_32_overflow_bug", vec![]);
+    let mut machine = machine_build::int(
+        "tests/programs/mop_ld_signextend_32_overflow_bug",
+        vec![],
+        VERSION1,
+        ISA_IMC | ISA_B | ISA_MOP,
+    );
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
 
     #[cfg(has_asm)]
     {
-        let mut machine_asm =
-            machine_build::asm_v1_mop("tests/programs/mop_ld_signextend_32_overflow_bug", vec![]);
+        let mut machine_asm = machine_build::asm(
+            "tests/programs/mop_ld_signextend_32_overflow_bug",
+            vec![],
+            VERSION1,
+            ISA_IMC | ISA_B | ISA_MOP,
+        );
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
@@ -350,14 +545,24 @@ pub fn test_mop_ld_signextend_32_overflow_bug() {
 
 #[test]
 pub fn test_mop_wide_mul_zero() {
-    let mut machine = machine_build::int_v1_mop("tests/programs/mop_wide_mul_zero", vec![]);
+    let mut machine = machine_build::int(
+        "tests/programs/mop_wide_mul_zero",
+        vec![],
+        VERSION1,
+        ISA_IMC | ISA_B | ISA_MOP,
+    );
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
 
     #[cfg(has_asm)]
     {
-        let mut machine_asm = machine_build::asm_v1_mop("tests/programs/mop_wide_mul_zero", vec![]);
+        let mut machine_asm = machine_build::asm(
+            "tests/programs/mop_wide_mul_zero",
+            vec![],
+            VERSION1,
+            ISA_IMC | ISA_B | ISA_MOP,
+        );
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
@@ -366,14 +571,24 @@ pub fn test_mop_wide_mul_zero() {
 
 #[test]
 pub fn test_mop_wide_div_zero() {
-    let mut machine = machine_build::int_v1_mop("tests/programs/mop_wide_div_zero", vec![]);
+    let mut machine = machine_build::int(
+        "tests/programs/mop_wide_div_zero",
+        vec![],
+        VERSION1,
+        ISA_IMC | ISA_B | ISA_MOP,
+    );
     let ret = machine.run();
     assert!(ret.is_ok());
     assert_eq!(ret.unwrap(), 0);
 
     #[cfg(has_asm)]
     {
-        let mut machine_asm = machine_build::asm_v1_mop("tests/programs/mop_wide_div_zero", vec![]);
+        let mut machine_asm = machine_build::asm(
+            "tests/programs/mop_wide_div_zero",
+            vec![],
+            VERSION1,
+            ISA_IMC | ISA_B | ISA_MOP,
+        );
         let ret_asm = machine_asm.run();
         assert!(ret_asm.is_ok());
         assert_eq!(ret_asm.unwrap(), 0);
@@ -382,7 +597,12 @@ pub fn test_mop_wide_div_zero() {
 
 #[test]
 pub fn test_mop_jump_rel_version1_bug() {
-    let mut machine = machine_build::int_v1_imcb("tests/programs/mop_jump_rel_version1_bug");
+    let mut machine = machine_build::int(
+        "tests/programs/mop_jump_rel_version1_bug",
+        vec![],
+        VERSION1,
+        ISA_IMC | ISA_B,
+    );
     let ret = machine.run();
     assert_eq!(
         ret,
@@ -393,7 +613,12 @@ pub fn test_mop_jump_rel_version1_bug() {
     );
     assert_eq!(*machine.pc(), 0xffffffff8000f878);
 
-    let mut machine = machine_build::int_v1_mop("tests/programs/mop_jump_rel_version1_bug", vec![]);
+    let mut machine = machine_build::int(
+        "tests/programs/mop_jump_rel_version1_bug",
+        vec![],
+        VERSION1,
+        ISA_IMC | ISA_B | ISA_MOP,
+    );
     let ret = machine.run();
     assert_eq!(
         ret,
@@ -401,7 +626,12 @@ pub fn test_mop_jump_rel_version1_bug() {
     );
     assert_eq!(*machine.pc(), 0x8000f878);
 
-    let mut machine = machine_build::int_mop("tests/programs/mop_jump_rel_version1_bug", vec![], 2);
+    let mut machine = machine_build::int(
+        "tests/programs/mop_jump_rel_version1_bug",
+        vec![],
+        VERSION2,
+        ISA_IMC | ISA_B | ISA_MOP,
+    );
     let ret = machine.run();
     assert_eq!(
         ret,
@@ -414,8 +644,12 @@ pub fn test_mop_jump_rel_version1_bug() {
 
     #[cfg(has_asm)]
     {
-        let mut machine_asm =
-            machine_build::asm_v1_mop("tests/programs/mop_jump_rel_version1_bug", vec![]);
+        let mut machine_asm = machine_build::asm(
+            "tests/programs/mop_jump_rel_version1_bug",
+            vec![],
+            VERSION1,
+            ISA_IMC | ISA_B | ISA_MOP,
+        );
         let ret_asm = machine_asm.run();
         assert_eq!(
             ret_asm,
@@ -423,8 +657,12 @@ pub fn test_mop_jump_rel_version1_bug() {
         );
         assert_eq!(*machine_asm.machine.pc(), 0x8000f878);
 
-        let mut machine_asm =
-            machine_build::asm_mop("tests/programs/mop_jump_rel_version1_bug", vec![], 2);
+        let mut machine_asm = machine_build::asm(
+            "tests/programs/mop_jump_rel_version1_bug",
+            vec![],
+            VERSION2,
+            ISA_IMC | ISA_B | ISA_MOP,
+        );
         let ret_asm = machine_asm.run();
         assert_eq!(
             ret_asm,
@@ -439,8 +677,12 @@ pub fn test_mop_jump_rel_version1_bug() {
 
 #[test]
 pub fn test_mop_jump_rel_version1_reg_not_updated_bug() {
-    let mut machine =
-        machine_build::int_v1_imcb("tests/programs/mop_jump_rel_version1_reg_not_updated_bug");
+    let mut machine = machine_build::int(
+        "tests/programs/mop_jump_rel_version1_reg_not_updated_bug",
+        vec![],
+        VERSION1,
+        ISA_IMC | ISA_B,
+    );
     let ret = machine.run();
     assert_eq!(
         ret,
@@ -448,9 +690,11 @@ pub fn test_mop_jump_rel_version1_reg_not_updated_bug() {
     );
     assert_eq!(machine.registers()[A0], 67174520);
 
-    let mut machine = machine_build::int_v1_mop(
+    let mut machine = machine_build::int(
         "tests/programs/mop_jump_rel_version1_reg_not_updated_bug",
         vec![],
+        VERSION1,
+        ISA_IMC | ISA_B | ISA_MOP,
     );
     let ret = machine.run();
     assert_eq!(
@@ -459,10 +703,11 @@ pub fn test_mop_jump_rel_version1_reg_not_updated_bug() {
     );
     assert_eq!(machine.registers()[A0], 0);
 
-    let mut machine = machine_build::int_mop(
+    let mut machine = machine_build::int(
         "tests/programs/mop_jump_rel_version1_reg_not_updated_bug",
         vec![],
-        2,
+        VERSION2,
+        ISA_IMC | ISA_B | ISA_MOP,
     );
     let ret = machine.run();
     assert_eq!(
@@ -473,9 +718,11 @@ pub fn test_mop_jump_rel_version1_reg_not_updated_bug() {
 
     #[cfg(has_asm)]
     {
-        let mut machine_asm = machine_build::asm_v1_mop(
+        let mut machine_asm = machine_build::asm(
             "tests/programs/mop_jump_rel_version1_reg_not_updated_bug",
             vec![],
+            VERSION1,
+            ISA_IMC | ISA_B | ISA_MOP,
         );
         let ret_asm = machine_asm.run();
         assert_eq!(
@@ -484,10 +731,11 @@ pub fn test_mop_jump_rel_version1_reg_not_updated_bug() {
         );
         assert_eq!(machine_asm.machine.registers()[A0], 0);
 
-        let mut machine_asm = machine_build::asm_mop(
+        let mut machine_asm = machine_build::asm(
             "tests/programs/mop_jump_rel_version1_reg_not_updated_bug",
             vec![],
-            2,
+            VERSION2,
+            ISA_IMC | ISA_B | ISA_MOP,
         );
         let ret_asm = machine_asm.run();
         assert_eq!(
@@ -500,8 +748,12 @@ pub fn test_mop_jump_rel_version1_reg_not_updated_bug() {
 
 #[test]
 pub fn test_mop_jump_abs_version1_reg_not_updated_bug() {
-    let mut machine =
-        machine_build::int_v1_imcb("tests/programs/mop_jump_abs_version1_reg_not_updated_bug");
+    let mut machine = machine_build::int(
+        "tests/programs/mop_jump_abs_version1_reg_not_updated_bug",
+        vec![],
+        VERSION1,
+        ISA_IMC | ISA_B,
+    );
     let ret = machine.run();
     assert_eq!(
         ret,
@@ -509,9 +761,11 @@ pub fn test_mop_jump_abs_version1_reg_not_updated_bug() {
     );
     assert_eq!(machine.registers()[A0], 67108864);
 
-    let mut machine = machine_build::int_v1_mop(
+    let mut machine = machine_build::int(
         "tests/programs/mop_jump_abs_version1_reg_not_updated_bug",
         vec![],
+        VERSION1,
+        ISA_IMC | ISA_B | ISA_MOP,
     );
     let ret = machine.run();
     assert_eq!(
@@ -520,10 +774,11 @@ pub fn test_mop_jump_abs_version1_reg_not_updated_bug() {
     );
     assert_eq!(machine.registers()[A0], 0);
 
-    let mut machine = machine_build::int_mop(
+    let mut machine = machine_build::int(
         "tests/programs/mop_jump_abs_version1_reg_not_updated_bug",
         vec![],
-        2,
+        VERSION2,
+        ISA_IMC | ISA_B | ISA_MOP,
     );
     let ret = machine.run();
     assert_eq!(
@@ -534,9 +789,11 @@ pub fn test_mop_jump_abs_version1_reg_not_updated_bug() {
 
     #[cfg(has_asm)]
     {
-        let mut machine_asm = machine_build::asm_v1_mop(
+        let mut machine_asm = machine_build::asm(
             "tests/programs/mop_jump_abs_version1_reg_not_updated_bug",
             vec![],
+            VERSION1,
+            ISA_IMC | ISA_B | ISA_MOP,
         );
         let ret_asm = machine_asm.run();
         assert_eq!(
@@ -545,10 +802,11 @@ pub fn test_mop_jump_abs_version1_reg_not_updated_bug() {
         );
         assert_eq!(machine_asm.machine.registers()[A0], 0);
 
-        let mut machine_asm = machine_build::asm_mop(
+        let mut machine_asm = machine_build::asm(
             "tests/programs/mop_jump_abs_version1_reg_not_updated_bug",
             vec![],
-            2,
+            VERSION2,
+            ISA_IMC | ISA_B | ISA_MOP,
         );
         let ret_asm = machine_asm.run();
         assert_eq!(

--- a/tests/test_resume.rs
+++ b/tests/test_resume.rs
@@ -299,7 +299,12 @@ impl Machine {
 
 #[test]
 pub fn test_sc_after_snapshot() {
-    let mut machine = machine_build::int_v2_imacb("tests/programs/sc_after_snapshot");
+    let mut machine = machine_build::int(
+        "tests/programs/sc_after_snapshot",
+        vec![],
+        VERSION2,
+        ISA_IMC | ISA_A,
+    );
     machine.machine.set_max_cycles(5);
     let ret = machine.run();
     assert!(ret.is_err());

--- a/tests/test_signal_pause.rs
+++ b/tests/test_signal_pause.rs
@@ -1,4 +1,5 @@
-use ckb_vm::{Error, SupportMachine};
+use ckb_vm::machine::VERSION2;
+use ckb_vm::{Error, SupportMachine, ISA_B, ISA_IMC};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 pub mod machine_build;
@@ -6,13 +7,25 @@ pub mod machine_build;
 #[cfg(has_asm)]
 #[test]
 pub fn test_asm_pause() {
+    use ckb_vm::machine::VERSION2;
+
     let expect_cycles = {
-        let mut machine = machine_build::asm_v2_imacb("tests/programs/pause_resume");
+        let mut machine = machine_build::asm(
+            "tests/programs/pause_resume",
+            vec![],
+            VERSION2,
+            ISA_IMC | ISA_B,
+        );
         machine.run().unwrap();
         machine.machine.cycles()
     };
 
-    let mut machine = machine_build::asm_v2_imacb("tests/programs/pause_resume");
+    let mut machine = machine_build::asm(
+        "tests/programs/pause_resume",
+        vec![],
+        VERSION2,
+        ISA_IMC | ISA_B,
+    );
     let branch_pause_cnt = Arc::new(AtomicU32::new(0));
     let branch_pause_cnt_jh = branch_pause_cnt.clone();
 
@@ -40,12 +53,22 @@ pub fn test_asm_pause() {
 #[test]
 pub fn test_int_pause() {
     let expect_cycles = {
-        let mut machine = machine_build::int_v2_imacb("tests/programs/pause_resume");
+        let mut machine = machine_build::int(
+            "tests/programs/pause_resume",
+            vec![],
+            VERSION2,
+            ISA_IMC | ISA_B,
+        );
         machine.run().unwrap();
         machine.machine.cycles()
     };
 
-    let mut machine = machine_build::int_v2_imacb("tests/programs/pause_resume");
+    let mut machine = machine_build::int(
+        "tests/programs/pause_resume",
+        vec![],
+        VERSION2,
+        ISA_IMC | ISA_B,
+    );
     let branch_pause_cnt = Arc::new(AtomicU32::new(0));
     let branch_pause_cnt_jh = branch_pause_cnt.clone();
     let signal = machine.machine.pause();

--- a/tests/test_spawn.rs
+++ b/tests/test_spawn.rs
@@ -6,7 +6,7 @@ use ckb_vm::machine::{trace::TraceMachine, DefaultCoreMachine, VERSION2};
 use ckb_vm::registers::{A0, A1, A2, A7};
 use ckb_vm::{
     DefaultMachineBuilder, Error, Memory, Register, SparseMemory, SupportMachine, Syscalls,
-    WXorXMemory, ISA_A, ISA_B, ISA_IMC, ISA_MOP,
+    WXorXMemory, ISA_B, ISA_IMC, ISA_MOP,
 };
 use std::sync::{Arc, Mutex};
 
@@ -80,7 +80,7 @@ impl<Mac: SupportMachine> Syscalls<Mac> for IntSpawnSyscall {
         }
         let buffer: Bytes = std::fs::read(path).unwrap().into();
         let machine_core = DefaultCoreMachine::<u64, WXorXMemory<SparseMemory<u64>>>::new(
-            ISA_IMC | ISA_A | ISA_B | ISA_MOP,
+            ISA_IMC | ISA_B | ISA_MOP,
             VERSION2,
             u64::MAX,
         );
@@ -141,8 +141,7 @@ impl<Mac: SupportMachine> Syscalls<Mac> for AsmSpawnSyscall {
             addr += 8;
         }
         let buffer: Bytes = std::fs::read(path).unwrap().into();
-        let machine_core_asm =
-            AsmCoreMachine::new(ISA_IMC | ISA_A | ISA_B | ISA_MOP, VERSION2, u64::MAX);
+        let machine_core_asm = AsmCoreMachine::new(ISA_IMC | ISA_B | ISA_MOP, VERSION2, u64::MAX);
         let machine_core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(machine_core_asm)
             .instruction_cycle_func(Box::new(constant_cycles))
             .syscall(Box::new(AsmSpawnSyscall {
@@ -163,7 +162,7 @@ pub fn test_spawn_int() {
     let cur_sp = stack_depth();
     let min_sp = Arc::new(Mutex::new(u64::MAX));
     let machine_core = DefaultCoreMachine::<u64, WXorXMemory<SparseMemory<u64>>>::new(
-        ISA_IMC | ISA_A | ISA_B | ISA_MOP,
+        ISA_IMC | ISA_B | ISA_MOP,
         VERSION2,
         u64::MAX,
     );
@@ -190,8 +189,7 @@ pub fn test_spawn_asm() {
     let buffer = std::fs::read("tests/programs/spawn").unwrap().into();
     let cur_sp = stack_depth();
     let min_sp = Arc::new(Mutex::new(u64::MAX));
-    let machine_core_asm =
-        AsmCoreMachine::new(ISA_IMC | ISA_A | ISA_B | ISA_MOP, VERSION2, u64::MAX);
+    let machine_core_asm = AsmCoreMachine::new(ISA_IMC | ISA_B | ISA_MOP, VERSION2, u64::MAX);
     let machine_core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(machine_core_asm)
         .instruction_cycle_func(Box::new(constant_cycles))
         .syscall(Box::new(AsmSpawnSyscall {

--- a/tests/test_versions.rs
+++ b/tests/test_versions.rs
@@ -6,7 +6,7 @@ use ckb_vm::machine::{VERSION0, VERSION1, VERSION2};
 use ckb_vm::memory::{FLAG_DIRTY, FLAG_FREEZED};
 use ckb_vm::{
     CoreMachine, DefaultCoreMachine, DefaultMachine, DefaultMachineBuilder, Error, Memory,
-    SparseMemory, TraceMachine, WXorXMemory, ISA_A, ISA_B, ISA_IMC, ISA_MOP, RISCV_PAGESIZE,
+    SparseMemory, TraceMachine, WXorXMemory, ISA_B, ISA_IMC, ISA_MOP, RISCV_PAGESIZE,
 };
 use std::fs;
 
@@ -345,7 +345,7 @@ pub fn test_asm_version1_asm_trace_bug() {
     let buffer = fs::read("tests/programs/asm_trace_bug").unwrap().into();
 
     let mut machine = {
-        let asm_core = AsmCoreMachine::new(ISA_IMC | ISA_A | ISA_B | ISA_MOP, VERSION1, 2000);
+        let asm_core = AsmCoreMachine::new(ISA_IMC | ISA_B | ISA_MOP, VERSION1, 2000);
         let machine = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
             .instruction_cycle_func(Box::new(constant_cycles))
             .build();
@@ -362,7 +362,7 @@ pub fn test_asm_version2_asm_trace_bug() {
     let buffer = fs::read("tests/programs/asm_trace_bug").unwrap().into();
 
     let mut machine = {
-        let asm_core = AsmCoreMachine::new(ISA_IMC | ISA_A | ISA_B | ISA_MOP, VERSION2, 2000);
+        let asm_core = AsmCoreMachine::new(ISA_IMC | ISA_B | ISA_MOP, VERSION2, 2000);
         let machine = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
             .instruction_cycle_func(Box::new(constant_cycles))
             .build();
@@ -383,7 +383,7 @@ pub fn test_trace_version1_asm_trace_bug() {
 
     let mut machine = {
         let core_machine = DefaultCoreMachine::<u64, WXorXMemory<SparseMemory<u64>>>::new(
-            ISA_IMC | ISA_A | ISA_B | ISA_MOP,
+            ISA_IMC | ISA_B | ISA_MOP,
             VERSION1,
             2000,
         );
@@ -405,7 +405,7 @@ pub fn test_trace_version2_asm_trace_bug() {
 
     let mut machine = {
         let core_machine = DefaultCoreMachine::<u64, WXorXMemory<SparseMemory<u64>>>::new(
-            ISA_IMC | ISA_A | ISA_B | ISA_MOP,
+            ISA_IMC | ISA_B | ISA_MOP,
             VERSION2,
             2000,
         );


### PR DESCRIPTION
- A is no longer enabled by default in `examples/ckb_vm_runner.rs`
- A is no longer enabled by default in `ckb_vm::run()` and `ckb_vm::run_with_memory()`
- Refactored test cases to no longer pass in the ISA_A Flag for tests that do not nedd A