### PR TITLE
perf: optimize instruction cache indexing to reduce local hotspots

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -10,7 +10,7 @@ use crate::memory::Memory;
 use crate::{Error, ISA_A, ISA_B, ISA_MOP, RISCV_PAGESIZE};
 
 const RISCV_PAGESIZE_MASK: u64 = RISCV_PAGESIZE as u64 - 1;
-const INSTRUCTION_CACHE_SIZE: usize = 4096;
+const INSTRUCTION_CACHE_SIZE: usize = 2048;
 
 pub struct Decoder {
     factories: Vec<InstructionFactory>,
@@ -99,14 +99,14 @@ impl Decoder {
         let instruction_cache_key = {
             // according to RISC-V instruction encoding, the lowest bit in PC will always be zero
             let pc = pc >> 1;
-            // Here we try to balance between local code and remote code. At times,
-            // we can find the code jumping to a remote function(e.g., memcpy or
-            // alloc), then resumes execution at a local location. Previous cache
-            // key only optimizes for local operations, while this new cache key
-            // balances the code between a 8192-byte local region, and certain remote
-            // code region. Notice the value 12 and 8 here are chosen by empirical
-            // evidence.
-            ((pc & 0xFF) | (pc >> 12 << 8)) as usize % INSTRUCTION_CACHE_SIZE
+            // This indexing strategy optimizes instruction cache utilization by improving the distribution of addresses.
+            // - `pc >> 5`: Incorporates higher bits to ensure a more even spread across cache indices.
+            // - `pc << 1`: Spreads lower-bit information into higher positions, enhancing variability.
+            // - `^` (XOR): Further randomizes index distribution, reducing cache conflicts and improving hit rates.
+            //
+            // This approach helps balance cache efficiency between local execution and remote function calls,
+            // reducing hotspots and improving overall performance.
+            ((pc >> 5) ^ (pc << 1)) as usize % INSTRUCTION_CACHE_SIZE
         };
         let cached_instruction = self.instructions_cache[instruction_cache_key];
         if cached_instruction.0 == pc {


### PR DESCRIPTION
The prior approach relied heavily on the lower 8 bits of `pc` and some higher bits (bit 12 and beyond). While this worked for local operations, it often resulted in **local hotspots**, where certain cache indices were accessed disproportionately. (we may output all pc values and run a [script](https://gist.github.com/quake/0eda87936ee40d6ea56c37367a94a92d) to check the cache utilization)

This PR introduces **bit shifts (`>> 5` and `<< 1`) and XOR (`^`)** to improve cache index distribution:
  - `pc >> 5` ensures that higher bits contribute to indexing, reducing excessive clustering in local address ranges.
  - `pc << 1` spreads lower-bit information across a broader index range, improving cache efficiency.
  - `^` (XOR) further disperses address patterns, minimizing cache collisions and improving hit rates.

I tested on 3 different machines, got a 2%~4% improvement
```
cargo bench "interpret secp256k1_bench via assembly" --features asm`

interpret secp256k1_bench via assembly
                        time:   [3.5024 ms 3.5040 ms 3.5058 ms]
                        change: [-2.9627% -2.8742% -2.7923%] (p = 0.00 < 0.05)
                        Performance has improved.
```
