### PR TITLE
perf: optimize cmp zero and jump with test

### DIFF
--- a/src/machine/asm/execute_x64.S
+++ b/src/machine/asm/execute_x64.S
@@ -193,7 +193,7 @@
   shr $CKB_VM_ASM_MEMORY_FRAME_SHIFTS, TEMP1; \
   movq TEMP1, CKB_VM_ASM_ASM_CORE_MACHINE_OFFSET_LAST_READ_FRAME(MACHINE); \
   movzbl CKB_VM_ASM_ASM_CORE_MACHINE_OFFSET_FRAMES(MACHINE, TEMP1), TEMP2d; \
-  cmp $0, TEMP2d; \
+  test TEMP2d, TEMP2d; \
   jne 1f; \
   movb $1, CKB_VM_ASM_ASM_CORE_MACHINE_OFFSET_FRAMES(MACHINE, TEMP1); \
   PREPCALL; \
@@ -207,7 +207,7 @@
   subq $1, TEMP1; \
   shr $CKB_VM_ASM_MEMORY_FRAME_SHIFTS, TEMP1; \
   movzbl CKB_VM_ASM_ASM_CORE_MACHINE_OFFSET_FRAMES(MACHINE, TEMP1), TEMP2d; \
-  cmp $0, TEMP2d; \
+  test TEMP2d, TEMP2d; \
   jne 2f; \
   movb $1, CKB_VM_ASM_ASM_CORE_MACHINE_OFFSET_FRAMES(MACHINE, TEMP1);\
   PREPCALL; \
@@ -283,7 +283,7 @@
   movq TEMP1, TEMP2; \
   shr $CKB_VM_ASM_MEMORY_FRAME_PAGE_SHIFTS, TEMP1; \
   movzbl CKB_VM_ASM_ASM_CORE_MACHINE_OFFSET_FRAMES(MACHINE, TEMP1), temp_regd; \
-  cmp $0, temp_regd; \
+  test temp_regd, temp_regd; \
   jne 1f; \
   movb $1, CKB_VM_ASM_ASM_CORE_MACHINE_OFFSET_FRAMES(MACHINE, TEMP1); \
   PREPCALL; \
@@ -312,7 +312,7 @@
   movb TEMP2b, CKB_VM_ASM_ASM_CORE_MACHINE_OFFSET_FLAGS(MACHINE, TEMP1); \
   shr $CKB_VM_ASM_MEMORY_FRAME_PAGE_SHIFTS, TEMP1; \
   movzbl CKB_VM_ASM_ASM_CORE_MACHINE_OFFSET_FRAMES(MACHINE, TEMP1), temp_regd; \
-  cmp $0, temp_regd; \
+  test temp_regd, temp_regd; \
   jne 2f; \
   movb $1, CKB_VM_ASM_ASM_CORE_MACHINE_OFFSET_FRAMES(MACHINE, TEMP1); \
   PREPCALL; \
@@ -441,7 +441,7 @@ ckb_vm_x64_execute:
   cmp %rcx, %rdx
   jne .exit_trace
   movzbl CKB_VM_ASM_TRACE_OFFSET_LENGTH(TRACE), %edx
-  cmp $0, %rdx
+  test %rdx, %rdx
   je .exit_trace
   movq CKB_VM_ASM_ASM_CORE_MACHINE_OFFSET_CYCLES(MACHINE), %rax
   addq CKB_VM_ASM_TRACE_OFFSET_CYCLES(TRACE), %rax
@@ -462,7 +462,7 @@ ckb_vm_x64_execute:
 .p2align 3
 .prepare_trace:
   movzbl 0(PAUSE), %eax
-  cmp $0, %rax
+  test %rax, %rax
   jnz .exit_pause
   LOAD_PC(%rax, %eax, %rcx, %ecx, TEMP3d)
   shr $2, %eax
@@ -473,7 +473,7 @@ ckb_vm_x64_execute:
   cmp %rcx, %rdx
   jne .exit_trace
   movzbl CKB_VM_ASM_TRACE_OFFSET_LENGTH(TRACE), %edx
-  cmp $0, %rdx
+  test %rdx, %rdx
   je .exit_trace
   movq CKB_VM_ASM_ASM_CORE_MACHINE_OFFSET_CYCLES(MACHINE), %rax
   addq CKB_VM_ASM_TRACE_OFFSET_CYCLES(TRACE), %rax
@@ -609,7 +609,7 @@ ckb_vm_x64_execute:
   jne .div_branch1
   jmp .div_branch3
 .div_branch1:
-  cmp $0, RS2r
+  test RS2r, RS2r
   jne .div_branch2
   movq $UINT64_MAX, RS1
   jmp .div_branch3
@@ -626,7 +626,7 @@ ckb_vm_x64_execute:
 .CKB_VM_ASM_LABEL_OP_DIVU:
   DECODE_R
   movq REGISTER_ADDRESS(RS2r), RS2r
-  cmp $0, RS2r
+  test RS2r, RS2r
   jne .divu_branch1
   WRITE_RD_VALUE($UINT64_MAX, RS2r)
   NEXT_INST
@@ -646,7 +646,7 @@ ckb_vm_x64_execute:
   DECODE_R
   movq REGISTER_ADDRESS(RS2r), RS2r
   mov RS2rd, RS2rd
-  cmp $0, RS2r
+  test RS2r, RS2r
   jne .divuw_branch1
   WRITE_RD_VALUE($UINT64_MAX, RS2r)
   NEXT_INST
@@ -678,7 +678,7 @@ ckb_vm_x64_execute:
   jne .divw_branch1
   jmp .divw_branch3
 .divw_branch1:
-  cmp $0, RS2r
+  test RS2r, RS2r
   jne .divw_branch2
   movq $UINT64_MAX, RS1
   jmp .divw_branch3
@@ -983,7 +983,7 @@ ckb_vm_x64_execute:
   xorq RS1, RS1
   jmp .rem_branch3
 .rem_branch1:
-  cmp $0, RS2r
+  test RS2r, RS2r
   jne .rem_branch2
   jmp .rem_branch3
 .rem_branch2:
@@ -999,7 +999,7 @@ ckb_vm_x64_execute:
 .CKB_VM_ASM_LABEL_OP_REMU:
   DECODE_R
   movq REGISTER_ADDRESS(RS2r), RS2r
-  cmp $0, RS2r
+  test RS2r, RS2r
   jne .remu_branch2
   movq REGISTER_ADDRESS(RS1), RS1
   WRITE_RD(RS1)
@@ -1020,7 +1020,7 @@ ckb_vm_x64_execute:
   DECODE_R
   movq REGISTER_ADDRESS(RS2r), RS2r
   mov RS2rd, RS2rd
-  cmp $0, RS2r
+  test RS2r, RS2r
   jne .remuw_branch2
   movq REGISTER_ADDRESS(RS1), RS1
   movslq RS1d, RS1
@@ -1055,7 +1055,7 @@ ckb_vm_x64_execute:
   xorq RS1, RS1
   jmp .remw_branch3
 .remw_branch1:
-  cmp $0, RS2r
+  test RS2r, RS2r
   jne .remw_branch2
   jmp .remw_branch3
 .remw_branch2:
@@ -1696,7 +1696,7 @@ ckb_vm_x64_execute:
 .CKB_VM_ASM_LABEL_OP_CLZ:
   DECODE_R
   movq REGISTER_ADDRESS(RS1), RS1
-  cmp $0, RS1
+  test RS1, RS1
   je .clz_branch
   bsr RS1, RS1
   neg RS1
@@ -1710,7 +1710,7 @@ ckb_vm_x64_execute:
 .CKB_VM_ASM_LABEL_OP_CLZW:
   DECODE_R
   movq REGISTER_ADDRESS(RS1), RS1
-  cmp $0, RS1d
+  test RS1d, RS1d
   je .clzw_branch
   bsr RS1d, RS1d
   neg RS1
@@ -1807,7 +1807,7 @@ ckb_vm_x64_execute:
 .CKB_VM_ASM_LABEL_OP_CTZ:
   DECODE_R
   movq REGISTER_ADDRESS(RS1), RS1
-  cmp $0, RS1
+  test RS1, RS1
   je .ctz_branch
   bsf RS1, RS1
   WRITE_RD(RS1)
@@ -1819,7 +1819,7 @@ ckb_vm_x64_execute:
 .CKB_VM_ASM_LABEL_OP_CTZW:
   DECODE_R
   movq REGISTER_ADDRESS(RS1), RS1
-  cmp $0, RS1d
+  test RS1d, RS1d
   je .ctzw_branch
   bsf RS1d, RS1d
   WRITE_RD(RS1)
@@ -2221,7 +2221,7 @@ ckb_vm_x64_execute:
   xorq TEMP1, TEMP1
   jmp .wide_div_branch3
 .wide_div_branch1:
-  cmp $0, RS2r
+  test RS2r, RS2r
   jne .wide_div_branch2
   movq RS1, TEMP1
   movq $UINT64_MAX, RS1
@@ -2242,7 +2242,7 @@ ckb_vm_x64_execute:
   DECODE_R4
   movq REGISTER_ADDRESS(RS1), RS1
   movq REGISTER_ADDRESS(RS2r), RS2r
-  cmp $0, RS2r
+  test RS2r, RS2r
   jne .wide_divu_branch1
   WRITE_RS3(RS1)
   WRITE_RD_VALUE($UINT64_MAX, RS2r)


### PR DESCRIPTION
When checking if a register is zero (`cmp $0, reg`), `test reg, reg` achieves the same result while using fewer bytes in encoding.

I tested on 3 different machines, got a 1%~4% improvement.

