### PR TITLE
perf: Optimize NEXT_INST macro by reordering memory loads for better performance

### DIFF
--- a/src/machine/asm/execute_x64.S
+++ b/src/machine/asm/execute_x64.S
@@ -374,11 +374,11 @@
  */
 #define NEXT_INST \
   movq (INST_ARGS), %rcx; \
+  movq (INST_PC), TEMP1; \
   addq $16, INST_ARGS; \
+  addq $16, INST_PC; \
   movzbl %ch, RDd_RS2sd; \
   sar $32, %rcx; \
-  movq (INST_PC), TEMP1; \
-  addq $16, INST_PC; \
   jmp *TEMP1
 
 #define NEXT_INST_V2 \


### PR DESCRIPTION
A simple instruction reordering in the NEXT_INST macro may reduce memory access latency and improve instruction-level parallelism. This change improves performance by approximately 2% on my env (2 diferenet spec cpu) because of hot path.

CPU1
```
interpret secp256k1_bench via assembly
                        time:   [4.6390 ms 4.6434 ms 4.6492 ms]
                        change: [-2.7022% -2.5134% -2.3102%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe

interpret secp256k1_bench via assembly mop
                        time:   [4.7361 ms 4.7442 ms 4.7534 ms]
                        change: [-2.0556% -1.7441% -1.4555%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe

interpret secp256k1_bench via assembly mop (memoized decoder)
                        time:   [3.8854 ms 3.9218 ms 3.9775 ms]
                        change: [-1.7528% -0.8066% +0.7752%] (p = 0.21 > 0.05)
                        No change in performance detected.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe

interpret secp256k1_bench via assembly mop (memoized dynamic length decoder)
                        time:   [3.2486 ms 3.2510 ms 3.2537 ms]
                        change: [-2.6563% -2.4866% -2.3305%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  5 (5.00%) high mild
  9 (9.00%) high severe
```

CPU2
```
interpret secp256k1_bench via assembly
                        time:   [3.4991 ms 3.5017 ms 3.5046 ms]
                        change: [-2.0495% -1.8489% -1.6756%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 16 outliers among 100 measurements (16.00%)
  2 (2.00%) high mild
  14 (14.00%) high severe

interpret secp256k1_bench via assembly mop
                        time:   [3.4559 ms 3.4607 ms 3.4677 ms]
                        change: [-1.5877% -1.4303% -1.2230%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  1 (1.00%) high mild
  12 (12.00%) high severe

interpret secp256k1_bench via assembly mop (memoized decoder)
                        time:   [2.9029 ms 2.9051 ms 2.9077 ms]
                        change: [-1.6066% -1.5125% -1.4196%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) high mild
  8 (8.00%) high severe

interpret secp256k1_bench via assembly mop (memoized dynamic length decoder)
                        time:   [2.4625 ms 2.4633 ms 2.4642 ms]
                        change: [-2.3027% -2.2052% -2.1223%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
```