### PR TITLE
chore: remove Sync trait bound from Syscalls

### DIFF
--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -1,7 +1,7 @@
 use super::Error;
 use crate::machine::SupportMachine;
 
-pub trait Syscalls<Mac: SupportMachine>: Send + Sync {
+pub trait Syscalls<Mac: SupportMachine>: Send {
     fn initialize(&mut self, machine: &mut Mac) -> Result<(), Error>;
     // Returned bool means if the syscall has been processed, if
     // a module returns false, Machine would continue to leverage


### PR DESCRIPTION
remove unnecessary trait bounds