### PR TITLE
feat: Add new DefaultMachineRunner trait for initialization work

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -69,7 +69,7 @@ jobs:
           ln -snf .. ckb-vm-test-suite/ckb-vm
           docker run --rm -v `pwd`:/code nervos/ckb-riscv-gnu-toolchain:bionic-20210804 cp -r /riscv /code/riscv
           cd ckb-vm-test-suite
-          git checkout 898edc351eeb4de974ca4f0ff8d1e4943a95aecb
+          git checkout 6082bb2710615297f3a9fec95629636e146882c8
           git submodule update --init --recursive
           RISCV=`pwd`/../riscv ./test.sh
 
@@ -136,7 +136,7 @@ jobs:
           ln -snf .. ckb-vm-test-suite/ckb-vm
           docker run --rm -v `pwd`:/code nervos/ckb-riscv-gnu-toolchain:bionic-20210804 cp -r /riscv /code/riscv
           cd ckb-vm-test-suite
-          git checkout 898edc351eeb4de974ca4f0ff8d1e4943a95aecb
+          git checkout 6082bb2710615297f3a9fec95629636e146882c8
           git submodule update --init --recursive
           RISCV=`pwd`/../riscv ./test.sh --build-only
           cd ..

--- a/benches/vm_benchmark.rs
+++ b/benches/vm_benchmark.rs
@@ -6,7 +6,7 @@ use bytes::Bytes;
 use ckb_vm::{
     machine::{
         asm::{AsmCoreMachine, AsmMachine},
-        DefaultMachineBuilder, VERSION0, VERSION2,
+        DefaultMachineBuilder, DefaultMachineRunner, SupportMachine, VERSION0, VERSION2,
     },
     ISA_B, ISA_IMC, ISA_MOP,
 };
@@ -40,7 +40,7 @@ fn asm_benchmark(c: &mut Criterion) {
             "bar",
         ].into_iter().map(|a| Ok(a.into()));
         b.iter(|| {
-            let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::MAX);
+            let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC, VERSION0, u64::MAX);
             let core = DefaultMachineBuilder::new(asm_core).build();
             let mut machine = AsmMachine::new(core);
             machine.load_program(&buffer, args.clone()).unwrap();
@@ -61,7 +61,7 @@ fn mop_benchmark(c: &mut Criterion) {
             "bar",
         ].into_iter().map(|a| Ok(a.into()));
         b.iter(|| {
-            let asm_core = AsmCoreMachine::new(ISA_IMC | ISA_B | ISA_MOP, VERSION2, u64::MAX);
+            let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC | ISA_B | ISA_MOP, VERSION2, u64::MAX);
             let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
                 .build();
             let mut machine = AsmMachine::new(core);

--- a/definitions/src/asm.rs
+++ b/definitions/src/asm.rs
@@ -1,8 +1,7 @@
 use crate::{
-    instructions::Instruction, MEMORY_FRAMES, MEMORY_FRAMESIZE, MEMORY_FRAME_SHIFTS,
-    RISCV_GENERAL_REGISTER_NUMBER, RISCV_MAX_MEMORY, RISCV_PAGES, RISCV_PAGESIZE,
+    instructions::Instruction, MEMORY_FRAMES, RISCV_GENERAL_REGISTER_NUMBER, RISCV_MAX_MEMORY,
+    RISCV_PAGES,
 };
-use std::alloc::{alloc, Layout};
 
 // The number of trace items to keep
 pub const TRACE_SIZE: usize = 8192;
@@ -66,60 +65,4 @@ pub struct AsmCoreMachine {
     pub traces: [Trace; TRACE_SIZE],
 
     pub memory: [u8; RISCV_MAX_MEMORY],
-}
-
-impl AsmCoreMachine {
-    pub fn new(isa: u8, version: u32, max_cycles: u64) -> Box<AsmCoreMachine> {
-        Self::new_with_memory(isa, version, max_cycles, RISCV_MAX_MEMORY)
-    }
-
-    pub fn new_with_memory(
-        isa: u8,
-        version: u32,
-        max_cycles: u64,
-        memory_size: usize,
-    ) -> Box<AsmCoreMachine> {
-        assert_ne!(memory_size, 0);
-        assert_eq!(memory_size % RISCV_PAGESIZE, 0);
-        assert_eq!(memory_size % (1 << MEMORY_FRAME_SHIFTS), 0);
-
-        let mut machine = unsafe {
-            let machine_size =
-                std::mem::size_of::<AsmCoreMachine>() - RISCV_MAX_MEMORY + memory_size;
-
-            let layout = Layout::array::<u8>(machine_size).unwrap();
-            let raw_allocation = alloc(layout) as *mut AsmCoreMachine;
-            Box::from_raw(raw_allocation)
-        };
-        machine.registers = [0; RISCV_GENERAL_REGISTER_NUMBER];
-        machine.pc = 0;
-        machine.next_pc = 0;
-        machine.running = 0;
-        machine.cycles = 0;
-        machine.max_cycles = max_cycles;
-        if cfg!(feature = "enable-chaos-mode-by-default") {
-            machine.chaos_mode = 1;
-        } else {
-            machine.chaos_mode = 0;
-        }
-        machine.chaos_seed = 0;
-        machine.load_reservation_address = u64::MAX;
-        machine.reset_signal = 0;
-        machine.version = version;
-        machine.isa = isa;
-        machine.flags = [0; RISCV_PAGES];
-        for i in 0..TRACE_SIZE {
-            machine.traces[i] = Trace::default();
-        }
-        machine.frames = [0; MEMORY_FRAMES];
-
-        machine.memory_size = memory_size as u64;
-        machine.frames_size = (memory_size / MEMORY_FRAMESIZE) as u64;
-        machine.flags_size = (memory_size / RISCV_PAGESIZE) as u64;
-
-        machine.last_read_frame = u64::MAX;
-        machine.last_write_page = u64::MAX;
-
-        machine
-    }
 }

--- a/definitions/src/generate_asm_constants.rs
+++ b/definitions/src/generate_asm_constants.rs
@@ -11,6 +11,7 @@ use ckb_vm_definitions::{
     MEMORY_FRAMES, MEMORY_FRAMESIZE, MEMORY_FRAME_PAGE_SHIFTS, MEMORY_FRAME_SHIFTS,
     RISCV_MAX_MEMORY, RISCV_PAGES, RISCV_PAGESIZE, RISCV_PAGE_SHIFTS,
 };
+use std::alloc::{alloc, Layout};
 use std::mem::{size_of, zeroed};
 
 macro_rules! print_inst_label {
@@ -120,7 +121,15 @@ fn main() {
     );
     println!();
 
-    let m: Box<AsmCoreMachine> = AsmCoreMachine::new(0, 0, 0);
+    // We don't need a fully initialized AsmCoreMachine, only a dummy
+    // structure here will do.
+    let m: Box<AsmCoreMachine> = unsafe {
+        let machine_size = std::mem::size_of::<AsmCoreMachine>();
+
+        let layout = Layout::array::<u8>(machine_size).unwrap();
+        let raw_allocation = alloc(layout) as *mut AsmCoreMachine;
+        Box::from_raw(raw_allocation)
+    };
     let m_address = &*m as *const AsmCoreMachine as usize;
     println!(
         "#define CKB_VM_ASM_ASM_CORE_MACHINE_OFFSET_REGISTERS {}",

--- a/examples/check_real_memory.rs
+++ b/examples/check_real_memory.rs
@@ -9,7 +9,7 @@ use std::process::{id, Command};
 use ckb_vm::{
     machine::{
         asm::{AsmCoreMachine, AsmMachine},
-        DefaultMachineBuilder, VERSION0,
+        DefaultMachineBuilder, DefaultMachineRunner, SupportMachine, VERSION0,
     },
     ISA_IMC,
 };
@@ -168,7 +168,12 @@ fn check_asm(memory_size: usize) -> Result<(), ()> {
     );
     println!("Base memory: {}", get_current_memory());
     for _ in 0..G_CHECK_LOOP {
-        let asm_core = AsmCoreMachine::new_with_memory(ISA_IMC, VERSION0, u64::MAX, memory_size);
+        let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new_with_memory(
+            ISA_IMC,
+            VERSION0,
+            u64::MAX,
+            memory_size,
+        );
         let core = DefaultMachineBuilder::new(asm_core).build();
         let mut machine = AsmMachine::new(core);
         machine
@@ -192,7 +197,12 @@ fn check_asm_in_thread(memory_size: usize) -> Result<(), ()> {
     );
     println!("Base memory: {}", get_current_memory());
     for _ in 0..G_CHECK_LOOP {
-        let asm_core = AsmCoreMachine::new_with_memory(ISA_IMC, VERSION0, u64::MAX, memory_size);
+        let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new_with_memory(
+            ISA_IMC,
+            VERSION0,
+            u64::MAX,
+            memory_size,
+        );
         let core = DefaultMachineBuilder::new(asm_core).build();
         let mut machine = AsmMachine::new(core);
         machine

--- a/examples/ckb-vm-runner.rs
+++ b/examples/ckb-vm-runner.rs
@@ -39,7 +39,9 @@ impl<Mac: SupportMachine> Syscalls<Mac> for DebugSyscall {
 
 #[cfg(has_asm)]
 fn main_asm(code: Bytes, args: Vec<Bytes>) -> Result<(), Box<dyn std::error::Error>> {
-    let asm_core = ckb_vm::machine::asm::AsmCoreMachine::new(
+    use ckb_vm::DefaultMachineRunner;
+
+    let asm_core = <Box<ckb_vm::machine::asm::AsmCoreMachine> as SupportMachine>::new(
         ckb_vm::ISA_IMC | ckb_vm::ISA_B | ckb_vm::ISA_MOP | ckb_vm::ISA_A,
         ckb_vm::machine::VERSION2,
         u64::MAX,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,8 @@ pub use crate::{
     instructions::{Instruction, Register},
     machine::{
         trace::TraceMachine, CoreMachine, DefaultCoreMachine, DefaultMachine,
-        DefaultMachineBuilder, FlattenedArgsReader, InstructionCycleFunc, Machine, SupportMachine,
+        DefaultMachineBuilder, DefaultMachineRunner, FlattenedArgsReader, InstructionCycleFunc,
+        Machine, SupportMachine,
     },
     memory::{flat::FlatMemory, sparse::SparseMemory, wxorx::WXorXMemory, Memory},
     syscalls::Syscalls,

--- a/src/machine/asm/mod.rs
+++ b/src/machine/asm/mod.rs
@@ -8,10 +8,11 @@ use ckb_vm_definitions::{
         RET_SLOWPATH, TRACE_ITEM_LENGTH, TRACE_SIZE,
     },
     instructions::OP_CUSTOM_TRACE_END,
-    ISA_MOP, MEMORY_FRAMES, MEMORY_FRAME_PAGE_SHIFTS, RISCV_GENERAL_REGISTER_NUMBER,
-    RISCV_PAGE_SHIFTS,
+    ISA_MOP, MEMORY_FRAMES, MEMORY_FRAMESIZE, MEMORY_FRAME_PAGE_SHIFTS,
+    RISCV_GENERAL_REGISTER_NUMBER, RISCV_MAX_MEMORY, RISCV_PAGE_SHIFTS,
 };
 use rand::{prelude::RngCore, SeedableRng};
+use std::alloc::{alloc, Layout};
 use std::os::raw::c_uchar;
 
 use crate::{
@@ -26,8 +27,8 @@ use crate::{
         fill_page_data, get_page_indices, memset, round_page_down, round_page_up, FLAG_DIRTY,
         FLAG_EXECUTABLE, FLAG_FREEZED, FLAG_WRITABLE, FLAG_WXORX_BIT,
     },
-    CoreMachine, DefaultMachine, Error, Machine, Memory, SupportMachine, MEMORY_FRAME_SHIFTS,
-    RISCV_PAGES, RISCV_PAGESIZE,
+    CoreMachine, DefaultMachine, DefaultMachineRunner, Error, Machine, Memory, SupportMachine,
+    MEMORY_FRAME_SHIFTS, RISCV_PAGES, RISCV_PAGESIZE,
 };
 
 impl CoreMachine for Box<AsmCoreMachine> {
@@ -412,6 +413,56 @@ impl Memory for Box<AsmCoreMachine> {
 }
 
 impl SupportMachine for Box<AsmCoreMachine> {
+    fn new_with_memory(
+        isa: u8,
+        version: u32,
+        max_cycles: u64,
+        memory_size: usize,
+    ) -> Box<AsmCoreMachine> {
+        assert_ne!(memory_size, 0);
+        assert_eq!(memory_size % RISCV_PAGESIZE, 0);
+        assert_eq!(memory_size % (1 << MEMORY_FRAME_SHIFTS), 0);
+
+        let mut machine = unsafe {
+            let machine_size =
+                std::mem::size_of::<AsmCoreMachine>() - RISCV_MAX_MEMORY + memory_size;
+
+            let layout = Layout::array::<u8>(machine_size).unwrap();
+            let raw_allocation = alloc(layout) as *mut AsmCoreMachine;
+            Box::from_raw(raw_allocation)
+        };
+        machine.registers = [0; RISCV_GENERAL_REGISTER_NUMBER];
+        machine.pc = 0;
+        machine.next_pc = 0;
+        machine.running = 0;
+        machine.cycles = 0;
+        machine.max_cycles = max_cycles;
+        if cfg!(feature = "enable-chaos-mode-by-default") {
+            machine.chaos_mode = 1;
+        } else {
+            machine.chaos_mode = 0;
+        }
+        machine.chaos_seed = 0;
+        machine.load_reservation_address = u64::MAX;
+        machine.reset_signal = 0;
+        machine.version = version;
+        machine.isa = isa;
+        machine.flags = [0; RISCV_PAGES];
+        for i in 0..TRACE_SIZE {
+            machine.traces[i] = Trace::default();
+        }
+        machine.frames = [0; MEMORY_FRAMES];
+
+        machine.memory_size = memory_size as u64;
+        machine.frames_size = (memory_size / MEMORY_FRAMESIZE) as u64;
+        machine.flags_size = (memory_size / RISCV_PAGESIZE) as u64;
+
+        machine.last_read_frame = u64::MAX;
+        machine.last_write_page = u64::MAX;
+
+        machine
+    }
+
     fn cycles(&self) -> u64 {
         self.cycles
     }
@@ -473,34 +524,22 @@ pub struct AsmMachine {
     pub machine: DefaultMachine<Box<AsmCoreMachine>>,
 }
 
-impl AsmMachine {
-    pub fn new(machine: DefaultMachine<Box<AsmCoreMachine>>) -> Self {
+impl DefaultMachineRunner for AsmMachine {
+    type Inner = Box<AsmCoreMachine>;
+
+    fn new(machine: DefaultMachine<Box<AsmCoreMachine>>) -> Self {
         Self { machine }
     }
 
-    pub fn set_max_cycles(&mut self, cycles: u64) {
-        self.machine.inner.max_cycles = cycles;
+    fn machine(&self) -> &DefaultMachine<Box<AsmCoreMachine>> {
+        &self.machine
     }
 
-    pub fn load_program(
-        &mut self,
-        program: &Bytes,
-        args: impl ExactSizeIterator<Item = Result<Bytes, Error>>,
-    ) -> Result<u64, Error> {
-        self.machine.load_program(program, args)
+    fn machine_mut(&mut self) -> &mut DefaultMachine<Box<AsmCoreMachine>> {
+        &mut self.machine
     }
 
-    pub fn load_program_with_metadata(
-        &mut self,
-        program: &Bytes,
-        metadata: &ProgramMetadata,
-        args: impl ExactSizeIterator<Item = Result<Bytes, Error>>,
-    ) -> Result<u64, Error> {
-        self.machine
-            .load_program_with_metadata(program, metadata, args)
-    }
-
-    pub fn run(&mut self) -> Result<i8, Error> {
+    fn run(&mut self) -> Result<i8, Error> {
         if self.machine.isa() & ISA_MOP != 0 && self.machine.version() == VERSION0 {
             return Err(Error::InvalidVersion);
         }
@@ -572,6 +611,30 @@ impl AsmMachine {
             }
         }
         Ok(self.machine.exit_code())
+    }
+}
+
+impl AsmMachine {
+    pub fn set_max_cycles(&mut self, cycles: u64) {
+        self.machine.inner.max_cycles = cycles;
+    }
+
+    pub fn load_program(
+        &mut self,
+        program: &Bytes,
+        args: impl ExactSizeIterator<Item = Result<Bytes, Error>>,
+    ) -> Result<u64, Error> {
+        self.machine.load_program(program, args)
+    }
+
+    pub fn load_program_with_metadata(
+        &mut self,
+        program: &Bytes,
+        metadata: &ProgramMetadata,
+        args: impl ExactSizeIterator<Item = Result<Bytes, Error>>,
+    ) -> Result<u64, Error> {
+        self.machine
+            .load_program_with_metadata(program, metadata, args)
     }
 
     pub fn step(&mut self, decoder: &mut Decoder) -> Result<(), Error> {

--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -62,6 +62,19 @@ pub trait Machine: CoreMachine {
 /// such as ELF range, cycles which might be needed on Rust side of the logic,
 /// such as runner or syscall implementations.
 pub trait SupportMachine: CoreMachine {
+    /// Instantiate using default memory size
+    fn new(isa: u8, version: u32, max_cycles: u64) -> Self
+    where
+        Self: Sized,
+    {
+        Self::new_with_memory(isa, version, max_cycles, RISCV_MAX_MEMORY)
+    }
+
+    /// Instantiation function
+    fn new_with_memory(isa: u8, version: u32, max_cycles: u64, memory_size: usize) -> Self
+    where
+        Self: Sized;
+
     // Current execution cycles, it's up to the actual implementation to
     // call add_cycles for each instruction/operation to provide cycles.
     // The implementation might also choose not to do this to ignore this
@@ -262,6 +275,48 @@ pub trait SupportMachine: CoreMachine {
     fn code(&self) -> &Bytes;
 }
 
+/// A runner trait providing APIs to drive the included DefaultMachine
+pub trait DefaultMachineRunner {
+    type Inner: SupportMachine;
+
+    /// Creates a new runner
+    fn new(machine: DefaultMachine<Self::Inner>) -> Self;
+
+    /// Fetches DefaultMachine
+    fn machine(&self) -> &DefaultMachine<Self::Inner>;
+
+    /// Fetches mutable DefaultMachine
+    fn machine_mut(&mut self) -> &mut DefaultMachine<Self::Inner>;
+
+    /// Runs the VM till paused
+    fn run(&mut self) -> Result<i8, Error>;
+
+    /// Fetches the inner SupportMachine for more processing
+    fn inner_mut(&mut self) -> &mut Self::Inner {
+        self.machine_mut().inner_mut()
+    }
+
+    /// Loads program
+    fn load_program(
+        &mut self,
+        program: &Bytes,
+        args: impl ExactSizeIterator<Item = Result<Bytes, Error>>,
+    ) -> Result<u64, Error> {
+        self.machine_mut().load_program(program, args)
+    }
+
+    /// Loads program with lazy loading metadata
+    fn load_program_with_metadata(
+        &mut self,
+        program: &Bytes,
+        metadata: &ProgramMetadata,
+        args: impl ExactSizeIterator<Item = Result<Bytes, Error>>,
+    ) -> Result<u64, Error> {
+        self.machine_mut()
+            .load_program_with_metadata(program, metadata, args)
+    }
+}
+
 #[derive(Default)]
 pub struct DefaultCoreMachine<R, M> {
     registers: [R; RISCV_GENERAL_REGISTER_NUMBER],
@@ -319,6 +374,23 @@ impl<R: Register, M: Memory<REG = R>> CoreMachine for DefaultCoreMachine<R, M> {
 }
 
 impl<R: Register, M: Memory<REG = R>> SupportMachine for DefaultCoreMachine<R, M> {
+    fn new_with_memory(isa: u8, version: u32, max_cycles: u64, memory_size: usize) -> Self {
+        Self {
+            registers: Default::default(),
+            pc: Default::default(),
+            next_pc: Default::default(),
+            reset_signal: Default::default(),
+            memory: M::new_with_memory(memory_size),
+            cycles: Default::default(),
+            max_cycles,
+            running: Default::default(),
+            isa,
+            version,
+            #[cfg(feature = "pprof")]
+            code: Default::default(),
+        }
+    }
+
     fn cycles(&self) -> u64 {
         self.cycles
     }
@@ -387,27 +459,6 @@ impl<R: Register, M: Memory<REG = R>> SupportMachine for DefaultCoreMachine<R, M
 }
 
 impl<R: Register, M: Memory> DefaultCoreMachine<R, M> {
-    pub fn new(isa: u8, version: u32, max_cycles: u64) -> Self {
-        Self::new_with_memory(isa, version, max_cycles, RISCV_MAX_MEMORY)
-    }
-
-    pub fn new_with_memory(isa: u8, version: u32, max_cycles: u64, memory_size: usize) -> Self {
-        Self {
-            registers: Default::default(),
-            pc: Default::default(),
-            next_pc: Default::default(),
-            reset_signal: Default::default(),
-            memory: M::new_with_memory(memory_size),
-            cycles: Default::default(),
-            max_cycles,
-            running: Default::default(),
-            isa,
-            version,
-            #[cfg(feature = "pprof")]
-            code: Default::default(),
-        }
-    }
-
     pub fn set_max_cycles(&mut self, cycles: u64) {
         self.max_cycles = cycles;
     }
@@ -475,6 +526,10 @@ impl<Inner: CoreMachine> CoreMachine for DefaultMachine<Inner> {
 }
 
 impl<Inner: SupportMachine> SupportMachine for DefaultMachine<Inner> {
+    fn new_with_memory(_isa: u8, _version: u32, _max_cycles: u64, _memory_size: usize) -> Self {
+        panic!("Please instantiate DefaultMachine using DefaultMachineBuilder!");
+    }
+
     fn cycles(&self) -> u64 {
         self.inner.cycles()
     }
@@ -574,6 +629,26 @@ impl<Inner: CoreMachine> Display for DefaultMachine<Inner> {
             }
         }
         Ok(())
+    }
+}
+
+impl<Inner: SupportMachine> DefaultMachineRunner for DefaultMachine<Inner> {
+    type Inner = Inner;
+
+    fn new(machine: DefaultMachine<Inner>) -> Self {
+        machine
+    }
+
+    fn machine(&self) -> &DefaultMachine<Inner> {
+        self
+    }
+
+    fn machine_mut(&mut self) -> &mut DefaultMachine<Inner> {
+        self
+    }
+
+    fn run(&mut self) -> Result<i8, Error> {
+        self.run()
     }
 }
 

--- a/src/machine/trace.rs
+++ b/src/machine/trace.rs
@@ -8,7 +8,7 @@ use super::{
         },
         Error,
     },
-    CoreMachine, DefaultMachine, Machine, SupportMachine, VERSION2,
+    CoreMachine, DefaultMachine, DefaultMachineRunner, Machine, SupportMachine, VERSION2,
 };
 use bytes::Bytes;
 
@@ -104,8 +104,10 @@ impl<Inner: SupportMachine> Machine for TraceMachine<Inner> {
     }
 }
 
-impl<Inner: SupportMachine> TraceMachine<Inner> {
-    pub fn new(machine: DefaultMachine<Inner>) -> Self {
+impl<Inner: SupportMachine> DefaultMachineRunner for TraceMachine<Inner> {
+    type Inner = Inner;
+
+    fn new(machine: DefaultMachine<Inner>) -> Self {
         Self {
             machine,
             factory: ThreadFactory::create(),
@@ -113,29 +115,15 @@ impl<Inner: SupportMachine> TraceMachine<Inner> {
         }
     }
 
-    pub fn load_program(
-        &mut self,
-        program: &Bytes,
-        args: impl ExactSizeIterator<Item = Result<Bytes, Error>>,
-    ) -> Result<u64, Error> {
-        self.machine.load_program(program, args)
+    fn machine(&self) -> &DefaultMachine<Inner> {
+        &self.machine
     }
 
-    pub fn load_program_with_metadata(
-        &mut self,
-        program: &Bytes,
-        metadata: &ProgramMetadata,
-        args: impl ExactSizeIterator<Item = Result<Bytes, Error>>,
-    ) -> Result<u64, Error> {
-        self.machine
-            .load_program_with_metadata(program, metadata, args)
+    fn machine_mut(&mut self) -> &mut DefaultMachine<Inner> {
+        &mut self.machine
     }
 
-    pub fn set_max_cycles(&mut self, cycles: u64) {
-        self.machine.inner_mut().set_max_cycles(cycles)
-    }
-
-    pub fn run(&mut self) -> Result<i8, Error> {
+    fn run(&mut self) -> Result<i8, Error> {
         let mut decoder = build_decoder::<Inner::REG>(self.isa(), self.version());
         self.machine.set_running(true);
         // For current trace size this is acceptable, however we might want
@@ -192,6 +180,30 @@ impl<Inner: SupportMachine> TraceMachine<Inner> {
             }
         }
         Ok(self.machine.exit_code())
+    }
+}
+
+impl<Inner: SupportMachine> TraceMachine<Inner> {
+    pub fn load_program(
+        &mut self,
+        program: &Bytes,
+        args: impl ExactSizeIterator<Item = Result<Bytes, Error>>,
+    ) -> Result<u64, Error> {
+        self.machine.load_program(program, args)
+    }
+
+    pub fn load_program_with_metadata(
+        &mut self,
+        program: &Bytes,
+        metadata: &ProgramMetadata,
+        args: impl ExactSizeIterator<Item = Result<Bytes, Error>>,
+    ) -> Result<u64, Error> {
+        self.machine
+            .load_program_with_metadata(program, metadata, args)
+    }
+
+    pub fn set_max_cycles(&mut self, cycles: u64) {
+        self.machine.inner_mut().set_max_cycles(cycles)
     }
 }
 

--- a/tests/machine_build.rs
+++ b/tests/machine_build.rs
@@ -5,8 +5,8 @@ use ckb_vm::machine::asm::{AsmCoreMachine, AsmMachine};
 use ckb_vm::machine::{trace::TraceMachine, DefaultCoreMachine, VERSION1, VERSION2};
 use ckb_vm::registers::{A0, A7};
 use ckb_vm::{
-    DefaultMachineBuilder, Error, Register, SparseMemory, SupportMachine, Syscalls, WXorXMemory,
-    ISA_A, ISA_B, ISA_IMC, ISA_MOP,
+    DefaultMachineBuilder, DefaultMachineRunner, Error, Register, SparseMemory, SupportMachine,
+    Syscalls, WXorXMemory, ISA_A, ISA_B, ISA_IMC, ISA_MOP,
 };
 
 pub struct SleepSyscall {}
@@ -32,7 +32,8 @@ impl<Mac: SupportMachine> Syscalls<Mac> for SleepSyscall {
 #[cfg(has_asm)]
 pub fn asm_v1_imcb(path: &str) -> AsmMachine {
     let buffer: Bytes = std::fs::read(path).unwrap().into();
-    let asm_core = AsmCoreMachine::new(ISA_IMC | ISA_B, VERSION1, u64::MAX);
+    let asm_core =
+        <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC | ISA_B, VERSION1, u64::MAX);
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
         .instruction_cycle_func(Box::new(constant_cycles))
         .syscall(Box::new(SleepSyscall {}))
@@ -73,7 +74,8 @@ pub fn asm_v1_mop(path: &str, args: Vec<Bytes>) -> AsmMachine {
 #[cfg(has_asm)]
 pub fn asm_mop(path: &str, args: Vec<Bytes>, version: u32) -> AsmMachine {
     let buffer: Bytes = std::fs::read(path).unwrap().into();
-    let asm_core = AsmCoreMachine::new(ISA_IMC | ISA_B | ISA_MOP, version, u64::MAX);
+    let asm_core =
+        <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC | ISA_B | ISA_MOP, version, u64::MAX);
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
         .instruction_cycle_func(Box::new(constant_cycles))
         .syscall(Box::new(SleepSyscall {}))
@@ -122,7 +124,8 @@ pub fn int_mop(
 #[cfg(has_asm)]
 pub fn asm_v2_imacb(path: &str) -> AsmMachine {
     let buffer: Bytes = std::fs::read(path).unwrap().into();
-    let asm_core = AsmCoreMachine::new(ISA_IMC | ISA_A | ISA_B, VERSION2, u64::MAX);
+    let asm_core =
+        <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC | ISA_A | ISA_B, VERSION2, u64::MAX);
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
         .instruction_cycle_func(Box::new(constant_cycles))
         .syscall(Box::new(SleepSyscall {}))

--- a/tests/test_a_extension.rs
+++ b/tests/test_a_extension.rs
@@ -1,6 +1,6 @@
-use ckb_vm::Error;
 #[cfg(has_asm)]
 use ckb_vm::{CoreMachine, Memory};
+use ckb_vm::{DefaultMachineRunner, Error};
 pub mod machine_build;
 
 #[test]

--- a/tests/test_asm.rs
+++ b/tests/test_asm.rs
@@ -5,7 +5,10 @@ use ckb_vm::machine::asm::{AsmCoreMachine, AsmMachine};
 use ckb_vm::machine::{CoreMachine, VERSION0, VERSION1, VERSION2};
 use ckb_vm::memory::Memory;
 use ckb_vm::registers::{A0, A1, A2, A3, A4, A5, A7};
-use ckb_vm::{Debugger, DefaultMachineBuilder, Error, Register, SupportMachine, Syscalls, ISA_IMC};
+use ckb_vm::{
+    Debugger, DefaultMachineBuilder, DefaultMachineRunner, Error, Register, SupportMachine,
+    Syscalls, ISA_IMC,
+};
 use std::fs;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
@@ -15,7 +18,7 @@ pub mod machine_build;
 #[test]
 pub fn test_asm_simple64() {
     let buffer = fs::read("tests/programs/simple64").unwrap().into();
-    let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::MAX);
+    let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC, VERSION0, u64::MAX);
     let core = DefaultMachineBuilder::new(asm_core).build();
     let mut machine = AsmMachine::new(core);
     machine
@@ -52,7 +55,7 @@ impl<Mac: SupportMachine> Syscalls<Mac> for CustomSyscall {
 #[test]
 pub fn test_asm_with_custom_syscall() {
     let buffer = fs::read("tests/programs/syscall64").unwrap().into();
-    let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::MAX);
+    let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC, VERSION0, u64::MAX);
     let core = DefaultMachineBuilder::new(asm_core)
         .syscall(Box::new(CustomSyscall {}))
         .build();
@@ -86,7 +89,7 @@ pub fn test_asm_ebreak() {
     let buffer = fs::read("tests/programs/ebreak64").unwrap().into();
     let value = Arc::new(AtomicU8::new(0));
 
-    let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::MAX);
+    let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC, VERSION0, u64::MAX);
     let core = DefaultMachineBuilder::new(asm_core)
         .debugger(Box::new(CustomDebugger {
             value: Arc::clone(&value),
@@ -105,7 +108,7 @@ pub fn test_asm_ebreak() {
 #[test]
 pub fn test_asm_simple_cycles() {
     let buffer = fs::read("tests/programs/simple64").unwrap().into();
-    let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, 708);
+    let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC, VERSION0, 708);
     let core = DefaultMachineBuilder::new(asm_core)
         .instruction_cycle_func(Box::new(constant_cycles))
         .build();
@@ -124,7 +127,7 @@ pub fn test_asm_simple_cycles() {
 pub fn test_asm_simple_max_cycles_reached() {
     let buffer = fs::read("tests/programs/simple64").unwrap().into();
     // Running simple64 should consume 708 cycles using dummy cycle func
-    let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, 700);
+    let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC, VERSION0, 700);
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
         .instruction_cycle_func(Box::new(constant_cycles))
         .build();
@@ -140,7 +143,7 @@ pub fn test_asm_simple_max_cycles_reached() {
 #[test]
 pub fn test_asm_trace() {
     let buffer = fs::read("tests/programs/trace64").unwrap().into();
-    let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::MAX);
+    let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC, VERSION0, u64::MAX);
     let core = DefaultMachineBuilder::new(asm_core).build();
     let mut machine = AsmMachine::new(core);
     machine
@@ -154,7 +157,7 @@ pub fn test_asm_trace() {
 #[test]
 pub fn test_asm_jump0() {
     let buffer = fs::read("tests/programs/jump0_64").unwrap().into();
-    let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::MAX);
+    let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC, VERSION0, u64::MAX);
     let core = DefaultMachineBuilder::new(asm_core).build();
     let mut machine = AsmMachine::new(core);
     machine
@@ -170,7 +173,7 @@ pub fn test_asm_write_large_address() {
     let buffer = fs::read("tests/programs/write_large_address64")
         .unwrap()
         .into();
-    let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::MAX);
+    let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC, VERSION0, u64::MAX);
     let core = DefaultMachineBuilder::new(asm_core).build();
     let mut machine = AsmMachine::new(core);
     machine
@@ -184,7 +187,7 @@ pub fn test_asm_write_large_address() {
 #[test]
 pub fn test_misaligned_jump64() {
     let buffer = fs::read("tests/programs/misaligned_jump64").unwrap().into();
-    let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::MAX);
+    let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC, VERSION0, u64::MAX);
     let core = DefaultMachineBuilder::new(asm_core).build();
     let mut machine = AsmMachine::new(core);
     machine
@@ -197,7 +200,7 @@ pub fn test_misaligned_jump64() {
 #[test]
 pub fn test_mulw64() {
     let buffer = fs::read("tests/programs/mulw64").unwrap().into();
-    let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::MAX);
+    let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC, VERSION0, u64::MAX);
     let core = DefaultMachineBuilder::new(asm_core).build();
     let mut machine = AsmMachine::new(core);
     machine
@@ -211,7 +214,7 @@ pub fn test_mulw64() {
 #[test]
 pub fn test_invalid_read64() {
     let buffer = fs::read("tests/programs/invalid_read64").unwrap().into();
-    let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::MAX);
+    let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC, VERSION0, u64::MAX);
     let core = DefaultMachineBuilder::new(asm_core).build();
     let mut machine = AsmMachine::new(core);
     machine
@@ -225,7 +228,7 @@ pub fn test_invalid_read64() {
 #[test]
 pub fn test_asm_load_elf_crash_64() {
     let buffer = fs::read("tests/programs/load_elf_crash_64").unwrap().into();
-    let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::MAX);
+    let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC, VERSION0, u64::MAX);
     let core = DefaultMachineBuilder::new(asm_core).build();
     let mut machine = AsmMachine::new(core);
     machine
@@ -238,7 +241,7 @@ pub fn test_asm_load_elf_crash_64() {
 #[test]
 pub fn test_asm_wxorx_crash_64() {
     let buffer = fs::read("tests/programs/wxorx_crash_64").unwrap().into();
-    let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::MAX);
+    let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC, VERSION0, u64::MAX);
     let core = DefaultMachineBuilder::new(asm_core).build();
     let mut machine = AsmMachine::new(core);
     machine
@@ -251,7 +254,7 @@ pub fn test_asm_wxorx_crash_64() {
 #[test]
 pub fn test_asm_alloc_many() {
     let buffer = fs::read("tests/programs/alloc_many").unwrap().into();
-    let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::MAX);
+    let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC, VERSION0, u64::MAX);
     let core = DefaultMachineBuilder::new(asm_core).build();
     let mut machine = AsmMachine::new(core);
     machine
@@ -264,7 +267,7 @@ pub fn test_asm_alloc_many() {
 #[test]
 pub fn test_asm_chaos_seed() {
     let buffer = fs::read("tests/programs/read_memory").unwrap().into();
-    let mut asm_core1 = AsmCoreMachine::new(ISA_IMC, VERSION1, u64::MAX);
+    let mut asm_core1 = <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC, VERSION1, u64::MAX);
     asm_core1.chaos_mode = 1;
     asm_core1.chaos_seed = 100;
     let core1 = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core1).build();
@@ -275,7 +278,7 @@ pub fn test_asm_chaos_seed() {
     let result1 = machine1.run();
     let exit1 = result1.unwrap();
 
-    let mut asm_core2 = AsmCoreMachine::new(ISA_IMC, VERSION1, u64::MAX);
+    let mut asm_core2 = <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC, VERSION1, u64::MAX);
     asm_core2.chaos_mode = 1;
     asm_core2.chaos_seed = 100;
     let core2 = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core2).build();
@@ -295,7 +298,7 @@ pub fn test_asm_chaos_seed() {
 #[test]
 pub fn test_asm_rvc_pageend() {
     let buffer = fs::read("tests/programs/rvc_pageend").unwrap().into();
-    let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::MAX);
+    let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC, VERSION0, u64::MAX);
     let core = DefaultMachineBuilder::new(asm_core).build();
     let mut machine = AsmMachine::new(core);
     machine
@@ -333,7 +336,7 @@ impl<Mac: SupportMachine> Syscalls<Mac> for OutOfCyclesSyscall {
 #[test]
 pub fn test_asm_outofcycles_in_syscall() {
     let buffer = fs::read("tests/programs/syscall64").unwrap().into();
-    let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, 20);
+    let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC, VERSION0, 20);
     let core = DefaultMachineBuilder::new(asm_core)
         .instruction_cycle_func(Box::new(constant_cycles))
         .syscall(Box::new(OutOfCyclesSyscall {}))
@@ -352,7 +355,7 @@ pub fn test_asm_outofcycles_in_syscall() {
 #[test]
 pub fn test_asm_cycles_overflow() {
     let buffer = fs::read("tests/programs/simple64").unwrap().into();
-    let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::MAX);
+    let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC, VERSION0, u64::MAX);
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
         .instruction_cycle_func(Box::new(constant_cycles))
         .build();
@@ -371,7 +374,7 @@ pub fn test_decoder_instructions_cache_pc_out_of_bound_timeout() {
     let buffer = fs::read("tests/programs/decoder_instructions_cache_pc_out_of_bound_timeout")
         .unwrap()
         .into();
-    let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::MAX);
+    let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC, VERSION0, u64::MAX);
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
         .instruction_cycle_func(Box::new(constant_cycles))
         .build();
@@ -387,7 +390,7 @@ pub fn test_decoder_instructions_cache_pc_out_of_bound_timeout() {
 
 pub fn test_asm_step() {
     let buffer = fs::read("tests/programs/simple64").unwrap().into();
-    let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::MAX);
+    let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC, VERSION0, u64::MAX);
     let core = DefaultMachineBuilder::new(asm_core).build();
     let mut machine = AsmMachine::new(core);
     machine
@@ -410,7 +413,7 @@ pub fn test_asm_step() {
 #[test]
 fn test_asm_thread_safe() {
     let buffer = fs::read("tests/programs/mulw64").unwrap().into();
-    let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::MAX);
+    let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC, VERSION0, u64::MAX);
     let core = DefaultMachineBuilder::new(asm_core).build();
     let mut machine = AsmMachine::new(core);
     machine
@@ -427,7 +430,7 @@ fn test_asm_thread_safe() {
 #[test]
 fn test_zero_address() {
     let buffer = fs::read("tests/programs/zero_address").unwrap().into();
-    let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION1, u64::MAX);
+    let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC, VERSION1, u64::MAX);
     let core = DefaultMachineBuilder::new(asm_core).build();
     let mut machine = AsmMachine::new(core);
     machine
@@ -441,7 +444,12 @@ fn test_zero_address() {
 #[test]
 pub fn test_big_binary() {
     let buffer = fs::read("tests/programs/big_binary").unwrap().into();
-    let asm_core = AsmCoreMachine::new_with_memory(ISA_IMC, VERSION2, u64::MAX, 1024 * 512);
+    let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new_with_memory(
+        ISA_IMC,
+        VERSION2,
+        u64::MAX,
+        1024 * 512,
+    );
     let core = DefaultMachineBuilder::new(asm_core).build();
     let mut machine = AsmMachine::new(core);
     let result = machine.load_program(&buffer, [Ok("simple".into())].into_iter());

--- a/tests/test_auipc_fusion.rs
+++ b/tests/test_auipc_fusion.rs
@@ -7,6 +7,7 @@ use ckb_vm::machine::VERSION1;
 use ckb_vm::{
     instructions::{blank_instruction, is_basic_block_end_instruction},
     machine::asm::{AsmCoreMachine, AsmMachine},
+    DefaultMachineRunner,
 };
 use ckb_vm::{
     CoreMachine, DefaultCoreMachine, DefaultMachineBuilder, Error, Memory, SparseMemory,
@@ -85,7 +86,7 @@ pub fn test_asm_auipc_fusion() {
         .unwrap()
         .into();
 
-    let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION1, u64::MAX);
+    let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC, VERSION1, u64::MAX);
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core).build();
     let mut machine = AsmMachine::new(core);
     machine

--- a/tests/test_b_extension.rs
+++ b/tests/test_b_extension.rs
@@ -1,5 +1,7 @@
 pub mod machine_build;
 
+use ckb_vm::DefaultMachineRunner;
+
 #[test]
 pub fn test_clzw_bug() {
     let mut machine = machine_build::int_v1_imcb("tests/programs/clzw_bug");

--- a/tests/test_dy_memory.rs
+++ b/tests/test_dy_memory.rs
@@ -2,9 +2,9 @@
 use ckb_vm::{
     machine::{
         asm::{AsmCoreMachine, AsmMachine},
-        DefaultMachineBuilder, VERSION0,
+        DefaultMachineBuilder, SupportMachine, VERSION0,
     },
-    ISA_IMC,
+    DefaultMachineRunner, ISA_IMC,
 };
 use ckb_vm::{run, FlatMemory, SparseMemory};
 use std::fs;
@@ -22,7 +22,12 @@ fn run_memory_suc(memory_size: usize, bin_path: String, bin_name: String) {
 
     #[cfg(has_asm)]
     {
-        let asm_core = AsmCoreMachine::new_with_memory(ISA_IMC, VERSION0, u64::MAX, memory_size);
+        let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new_with_memory(
+            ISA_IMC,
+            VERSION0,
+            u64::MAX,
+            memory_size,
+        );
         let core = DefaultMachineBuilder::new(asm_core).build();
         let mut machine = AsmMachine::new(core);
         machine
@@ -57,7 +62,12 @@ fn test_memory_out_of_bounds() {
 
     #[cfg(has_asm)]
     {
-        let asm_core = AsmCoreMachine::new_with_memory(ISA_IMC, VERSION0, u64::MAX, memory_size);
+        let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new_with_memory(
+            ISA_IMC,
+            VERSION0,
+            u64::MAX,
+            memory_size,
+        );
         let core = DefaultMachineBuilder::new(asm_core).build();
         let mut machine = AsmMachine::new(core);
         machine

--- a/tests/test_misc.rs
+++ b/tests/test_misc.rs
@@ -221,7 +221,9 @@ pub fn test_memory_store_empty_bytes() {
     assert_memory_store_empty_bytes(&mut SparseMemory::<u64>::new());
     assert_memory_store_empty_bytes(&mut WXorXMemory::<FlatMemory<u64>>::new());
     #[cfg(has_asm)]
-    assert_memory_store_empty_bytes(&mut AsmCoreMachine::new(ISA_IMC, VERSION0, 200_000));
+    assert_memory_store_empty_bytes(&mut <Box<AsmCoreMachine> as SupportMachine>::new(
+        ISA_IMC, VERSION0, 200_000,
+    ));
 }
 
 fn assert_memory_store_empty_bytes<M: Memory>(memory: &mut M) {
@@ -267,7 +269,7 @@ fn assert_memory_load_bytes_all<R: Rng>(
     #[cfg(has_asm)]
     assert_memory_load_bytes(
         rng,
-        &mut AsmCoreMachine::new(ISA_IMC, VERSION0, 200_000),
+        &mut <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC, VERSION0, 200_000),
         buf_size,
         addr,
     );

--- a/tests/test_mop.rs
+++ b/tests/test_mop.rs
@@ -1,6 +1,6 @@
 pub mod machine_build;
 use bytes::Bytes;
-use ckb_vm::{registers::A0, CoreMachine, Error, SupportMachine};
+use ckb_vm::{registers::A0, CoreMachine, DefaultMachineRunner, Error, SupportMachine};
 
 #[test]
 #[cfg_attr(miri, ignore)]

--- a/tests/test_reset.rs
+++ b/tests/test_reset.rs
@@ -4,8 +4,8 @@ use ckb_vm::cost_model::constant_cycles;
 use ckb_vm::machine::asm::{AsmCoreMachine, AsmMachine};
 use ckb_vm::machine::{DefaultCoreMachine, DefaultMachineBuilder, VERSION1};
 use ckb_vm::{
-    registers::A7, Error, Register, SparseMemory, SupportMachine, Syscalls, TraceMachine,
-    WXorXMemory, DEFAULT_STACK_SIZE, ISA_IMC, ISA_MOP, RISCV_MAX_MEMORY,
+    registers::A7, DefaultMachineRunner, Error, Register, SparseMemory, SupportMachine, Syscalls,
+    TraceMachine, WXorXMemory, DEFAULT_STACK_SIZE, ISA_IMC, ISA_MOP, RISCV_MAX_MEMORY,
 };
 
 #[allow(dead_code)]
@@ -90,7 +90,8 @@ fn test_reset_asm() {
     let code_data = std::fs::read("tests/programs/reset_caller").unwrap();
     let code = Bytes::from(code_data);
 
-    let asm_core = AsmCoreMachine::new(ISA_IMC | ISA_MOP, VERSION1, u64::MAX);
+    let asm_core =
+        <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC | ISA_MOP, VERSION1, u64::MAX);
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
         .instruction_cycle_func(Box::new(constant_cycles))
         .syscall(Box::new(CustomSyscall {}))

--- a/tests/test_resume.rs
+++ b/tests/test_resume.rs
@@ -5,7 +5,8 @@ use ckb_vm::cost_model::constant_cycles;
 use ckb_vm::machine::asm::{AsmCoreMachine, AsmMachine};
 use ckb_vm::machine::trace::TraceMachine;
 use ckb_vm::machine::{
-    DefaultCoreMachine, DefaultMachine, SupportMachine, VERSION0, VERSION1, VERSION2,
+    DefaultCoreMachine, DefaultMachine, DefaultMachineRunner, SupportMachine, VERSION0, VERSION1,
+    VERSION2,
 };
 use ckb_vm::memory::{sparse::SparseMemory, wxorx::WXorXMemory};
 use ckb_vm::snapshot::{make_snapshot, resume, Snapshot};
@@ -208,7 +209,8 @@ impl MachineTy {
     fn build(self, version: u32, max_cycles: u64) -> Machine {
         match self {
             MachineTy::Asm => {
-                let asm_core1 = AsmCoreMachine::new(ISA_IMC, version, max_cycles);
+                let asm_core1 =
+                    <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC, version, max_cycles);
                 let core1 = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core1)
                     .instruction_cycle_func(Box::new(constant_cycles))
                     .build();

--- a/tests/test_resume2.rs
+++ b/tests/test_resume2.rs
@@ -6,7 +6,8 @@ use ckb_vm::elf::parse_elf;
 use ckb_vm::machine::asm::{AsmCoreMachine, AsmMachine};
 use ckb_vm::machine::trace::TraceMachine;
 use ckb_vm::machine::{
-    CoreMachine, DefaultCoreMachine, DefaultMachine, SupportMachine, VERSION0, VERSION1, VERSION2,
+    CoreMachine, DefaultCoreMachine, DefaultMachine, DefaultMachineRunner, SupportMachine,
+    VERSION0, VERSION1, VERSION2,
 };
 use ckb_vm::memory::{sparse::SparseMemory, wxorx::WXorXMemory};
 use ckb_vm::registers::{A0, A1, A7};
@@ -394,7 +395,8 @@ impl MachineTy {
         match self {
             MachineTy::Asm => {
                 let context = Arc::new(Mutex::new(Snapshot2Context::new(data_source)));
-                let asm_core1 = AsmCoreMachine::new(ISA_IMC | ISA_A, version, 0);
+                let asm_core1 =
+                    <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC | ISA_A, version, 0);
                 let core1 = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core1)
                     .instruction_cycle_func(Box::new(constant_cycles))
                     .syscall(Box::new(InsertDataSyscall(context.clone())))

--- a/tests/test_signal_pause.rs
+++ b/tests/test_signal_pause.rs
@@ -1,4 +1,4 @@
-use ckb_vm::{Error, SupportMachine};
+use ckb_vm::{DefaultMachineRunner, Error, SupportMachine};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 pub mod machine_build;

--- a/tests/test_versions.rs
+++ b/tests/test_versions.rs
@@ -4,8 +4,9 @@ use ckb_vm::machine::asm::{AsmCoreMachine, AsmMachine};
 use ckb_vm::machine::{VERSION0, VERSION1, VERSION2};
 use ckb_vm::memory::{FLAG_DIRTY, FLAG_FREEZED};
 use ckb_vm::{
-    CoreMachine, DefaultCoreMachine, DefaultMachine, DefaultMachineBuilder, Error, Memory,
-    SparseMemory, TraceMachine, WXorXMemory, ISA_A, ISA_B, ISA_IMC, ISA_MOP, RISCV_PAGESIZE,
+    CoreMachine, DefaultCoreMachine, DefaultMachine, DefaultMachineBuilder, DefaultMachineRunner,
+    Error, Memory, SparseMemory, SupportMachine, TraceMachine, WXorXMemory, ISA_A, ISA_B, ISA_IMC,
+    ISA_MOP, RISCV_PAGESIZE,
 };
 use std::fs;
 
@@ -29,7 +30,7 @@ fn create_rust_machine(
 fn create_asm_machine(program: String, version: u32) -> AsmMachine {
     let path = format!("tests/programs/{}", program);
     let buffer = fs::read(path).unwrap().into();
-    let asm_core = AsmCoreMachine::new(ISA_IMC, version, u64::MAX);
+    let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC, version, u64::MAX);
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core).build();
     let mut machine = AsmMachine::new(core);
     machine
@@ -258,7 +259,7 @@ pub fn test_asm_version0_unaligned64() {
     let buffer = fs::read(format!("tests/programs/{}", program))
         .unwrap()
         .into();
-    let asm_core = AsmCoreMachine::new(ISA_IMC, VERSION0, u64::MAX);
+    let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new(ISA_IMC, VERSION0, u64::MAX);
     let core = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core).build();
     let mut machine = AsmMachine::new(core);
     let result = machine.load_program(&buffer, [Ok(program.into())].into_iter());
@@ -338,7 +339,11 @@ pub fn test_asm_version1_asm_trace_bug() {
     let buffer = fs::read("tests/programs/asm_trace_bug").unwrap().into();
 
     let mut machine = {
-        let asm_core = AsmCoreMachine::new(ISA_IMC | ISA_A | ISA_B | ISA_MOP, VERSION1, 2000);
+        let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new(
+            ISA_IMC | ISA_A | ISA_B | ISA_MOP,
+            VERSION1,
+            2000,
+        );
         let machine = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
             .instruction_cycle_func(Box::new(constant_cycles))
             .build();
@@ -355,7 +360,11 @@ pub fn test_asm_version2_asm_trace_bug() {
     let buffer = fs::read("tests/programs/asm_trace_bug").unwrap().into();
 
     let mut machine = {
-        let asm_core = AsmCoreMachine::new(ISA_IMC | ISA_A | ISA_B | ISA_MOP, VERSION2, 2000);
+        let asm_core = <Box<AsmCoreMachine> as SupportMachine>::new(
+            ISA_IMC | ISA_A | ISA_B | ISA_MOP,
+            VERSION2,
+            2000,
+        );
         let machine = DefaultMachineBuilder::<Box<AsmCoreMachine>>::new(asm_core)
             .instruction_cycle_func(Box::new(constant_cycles))
             .build();


### PR DESCRIPTION
Previously, all different machines in ckb-vm might use slightly different initialization process. This commit introduces a new DefaultMachineRunner trait, so the same initialization & usage workflow can be used for all types implementing this trait.