### PR TITLE
feat: Add Nix flake for RISC-V toolchain setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Cargo.lock
 /examples/is13
 *.DS_Store
 tests/programs/deps
+flake.lock

--- a/examples/is13.rs
+++ b/examples/is13.rs
@@ -5,13 +5,18 @@
 //
 // To build the "is13.c" to riscv output, you will need to install "riscv-gnu-toolchain" in your system.
 //
+// Option 1: Using Nix (Recommended - quick and easy)
+// If you have Nix installed, you can use the provided flake.nix:
+//
+//   $ nix develop
+//
+// Option 2: Building from source (takes ~1 hour)
+//
 //   $ git clone --recursive https://github.com/riscv/riscv-gnu-toolchain
 //   $ cd riscv-gnu-toolchain
 //   $ mkdir build && cd build
 //   $ ../configure --prefix=/opt/riscv --with-arch=rv64imac
 //   $ make
-//
-// On my ubuntu machine, it takes 1 hours. Sad.
 //
 // Then, you can build "is13.c" by "riscv64-unknown-elf-gcc"
 //

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,67 @@
+{
+  description = "CKB VM development environment with RISC-V toolchain";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        
+        # RISC-V toolchain
+        riscv-toolchain = pkgs.pkgsCross.riscv64-embedded.buildPackages;
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            # RISC-V cross-compiler toolchain
+            riscv-toolchain.gcc
+            riscv-toolchain.binutils
+            
+            # Rust toolchain (already in the project via rust-toolchain file)
+            cargo
+            rustc
+            rustfmt
+            clippy
+            
+            # Build tools
+            gnumake
+            pkg-config
+            
+            # Optional: useful for development
+            gcc
+            gdb
+            file
+            hexdump
+            
+            # For running the build scripts
+            bash
+          ];
+
+          shellHook = ''
+            echo "CKB VM Development Environment"
+            echo "================================"
+            echo ""
+            echo "RISC-V toolchain available:"
+            echo "  riscv64-none-elf-gcc --version"
+            riscv64-none-elf-gcc --version | head -n1
+            echo ""
+            echo "To compile the is13 example:"
+            echo "  riscv64-none-elf-gcc -o examples/is13 examples/is13.c"
+            echo ""
+            echo "To run the example:"
+            echo "  cargo run --example is13 13"
+            echo ""
+          '';
+
+          # Environment variables
+          RISCV_CC = "riscv64-none-elf-gcc";
+          RISCV_LD = "riscv64-none-elf-ld";
+          RISCV_OBJCOPY = "riscv64-none-elf-objcopy";
+          RISCV_OBJDUMP = "riscv64-none-elf-objdump";
+        };
+      });
+}


### PR DESCRIPTION
This PR adds a Nix flake script to provide an easy way to install the RISC-V toolchain required for compiling C programs to run on CKB VM. 

By running:
```
$ nix develop 
```
We can have a working `riscv64-none-elf-gcc` in our environment. 