### PR TITLE
examples/check_real_memory: use a hand written buddy allocator instead of jemalloc

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       # https://github.com/EmbarkStudios/cargo-deny-action
-      - uses: EmbarkStudios/cargo-deny-action@v1
+      - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           arguments: --all-features
           command: check advisories licenses sources bans

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ cc = "1.0"
 argparse = "0.2"
 criterion = "0.5.1"
 proptest = "1.5.0"
+buddy-alloc = "0.6.0"
 
 [[bench]]
 name = "bits_benchmark"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,10 +41,6 @@ argparse = "0.2"
 criterion = "0.5.1"
 proptest = "1.5.0"
 
-[target.'cfg(not(target_os = "windows"))'.dev-dependencies]
-jemallocator = "0.5.0"
-jemalloc-ctl = "0.5.0"
-
 [[bench]]
 name = "bits_benchmark"
 path = "benches/bits_benchmark.rs"

--- a/definitions/Cargo.toml
+++ b/definitions/Cargo.toml
@@ -18,4 +18,4 @@ name = "generate_asm_constants"
 path = "src/generate_asm_constants.rs"
 
 [dependencies]
-paste = "1.0.12"
+paste = { package = "pastey", version = "0.2.1" }

--- a/examples/check_real_memory.rs
+++ b/examples/check_real_memory.rs
@@ -1,8 +1,6 @@
 // This example is mainly to test whether there is memory overflow.
-// Under linux, we choose to use smem, which can monitor memory changes more accurately
 
-use ckb_vm::{Bytes, FlatMemory, SparseMemory, run_with_memory};
-use std::process::{Command, id};
+use ckb_vm::{Bytes, DEFAULT_MEMORY_SIZE, SparseMemory, run_with_memory};
 
 #[cfg(has_asm)]
 use ckb_vm::{
@@ -13,162 +11,247 @@ use ckb_vm::{
     },
 };
 
-#[cfg(has_asm)]
-use std::thread;
+mod balloc {
+    //! A hand written buddy allocator implementation for no_std environments.
+    //!
+    //! This module implements a buddy memory allocator that manages a fixed-size memory pool.
+    //! The buddy allocator works by recursively splitting memory blocks into pairs of equal-sized "buddies" until it
+    //! finds a block of the appropriate size. When memory is freed, it attempts to merge adjacent buddy blocks back
+    //! together to reduce fragmentation.
+
+    use core::alloc::{GlobalAlloc, Layout};
+    use core::cell::UnsafeCell;
+    use core::cmp::min;
+    use core::ptr::addr_of_mut;
+
+    pub const MIN_BLOCK: usize = 64;
+    pub const MAX_ORDER: usize = 18;
+    pub const MAX_TOTAL: usize = MIN_BLOCK * (1 << MAX_ORDER);
+    pub const PTR_ALLOC: *mut u8 = addr_of_mut!(PRE_ALLOC) as *mut u8;
+    pub static mut FREE_LIST: [usize; MAX_ORDER + 1] = {
+        let mut list = [usize::MAX; MAX_ORDER + 1];
+        list[MAX_ORDER] = 0;
+        list
+    };
+    pub static mut PRE_ALLOC: [u8; MAX_TOTAL] = {
+        assert!(matches!(usize::BITS, 32 | 64));
+        let mut alloc = [0; MAX_TOTAL];
+        if usize::BITS >= 32 {
+            alloc[0] = 0xff;
+            alloc[1] = 0xff;
+            alloc[2] = 0xff;
+            alloc[3] = 0xff;
+        }
+        if usize::BITS >= 64 {
+            alloc[4] = 0xff;
+            alloc[5] = 0xff;
+            alloc[6] = 0xff;
+            alloc[7] = 0xff;
+        }
+        alloc
+    };
+
+    /// Buddy allocation algorithm implementation.
+    pub struct Algorithm;
+    /// Information about allocated memory blocks.
+    #[derive(Clone, Copy)]
+    pub struct Blockinfo {
+        /// Offset of the allocated block within the memory pool.
+        pub offset: usize,
+        /// Length of the allocated block.
+        pub length: usize,
+    }
+
+    impl Algorithm {
+        pub fn alloc(&mut self, order: usize) -> Blockinfo {
+            unsafe {
+                if order > MAX_ORDER {
+                    let block_offset = usize::MAX;
+                    return Blockinfo {
+                        offset: block_offset,
+                        length: 0,
+                    };
+                }
+                let block_size = MIN_BLOCK << order;
+                if FREE_LIST[order] != usize::MAX {
+                    let block_offset = FREE_LIST[order];
+                    let block_ptr = PTR_ALLOC.add(block_offset);
+                    FREE_LIST[order] = uldr(block_ptr);
+                    return Blockinfo {
+                        offset: block_offset,
+                        length: block_size,
+                    };
+                }
+                let block = self.alloc(order + 1);
+                let block_offset = block.offset;
+                if block_offset == usize::MAX {
+                    return Blockinfo {
+                        offset: block_offset,
+                        length: 0,
+                    };
+                }
+                let buddy_offset = block_offset + block_size;
+                let buddy_ptr = PTR_ALLOC.add(buddy_offset);
+                ustr(buddy_ptr, usize::MAX);
+                FREE_LIST[order] = buddy_offset;
+                Blockinfo {
+                    offset: block_offset,
+                    length: block_size,
+                }
+            }
+        }
+
+        pub fn close(&mut self, block: Blockinfo) {
+            unsafe {
+                if block.offset == usize::MAX {
+                    return;
+                }
+                let order = log2(MIN_BLOCK, block.length);
+                let block_idx = block.offset / block.length;
+                let buddy_idx = block_idx ^ 1;
+                let buddy_offset = buddy_idx * block.length;
+                let buddy = Blockinfo {
+                    offset: buddy_offset,
+                    length: block.length,
+                };
+                let upper = Blockinfo {
+                    offset: min(block.offset, buddy_offset),
+                    length: block.length << 1,
+                };
+                let mut n = FREE_LIST[order];
+                let mut m: usize;
+                loop {
+                    if n == usize::MAX {
+                        let block_ptr = PTR_ALLOC.add(block.offset);
+                        ustr(block_ptr, FREE_LIST[order]);
+                        FREE_LIST[order] = block.offset;
+                        break;
+                    }
+                    m = uldr(PTR_ALLOC.add(n));
+                    if n == buddy.offset {
+                        FREE_LIST[order] = m;
+                        self.close(upper);
+                        break;
+                    }
+                    if m == buddy.offset {
+                        ustr(PTR_ALLOC.add(n), uldr(PTR_ALLOC.add(m)));
+                        self.close(upper);
+                        break;
+                    }
+                    n = m;
+                }
+            }
+        }
+    }
+
+    /// Global allocator struct that uses the buddy allocation algorithm.
+    pub struct Allocator {
+        inner: UnsafeCell<Algorithm>,
+    }
+
+    impl Allocator {
+        /// Creates a new global allocator instance.
+        pub const fn global() -> Self {
+            Allocator {
+                inner: UnsafeCell::new(Algorithm {}),
+            }
+        }
+    }
+
+    unsafe impl GlobalAlloc for Allocator {
+        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+            unsafe {
+                let inner = &mut *self.inner.get();
+                let order = log2(MIN_BLOCK, clp2(layout.size()).max(MIN_BLOCK));
+                let block = inner.alloc(order);
+                if block.offset == usize::MAX {
+                    return core::ptr::null_mut();
+                }
+                PTR_ALLOC.add(block.offset)
+            }
+        }
+
+        unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+            unsafe {
+                let inner = &mut *self.inner.get();
+                let order = log2(MIN_BLOCK, clp2(layout.size()).max(MIN_BLOCK));
+                let block = Blockinfo {
+                    offset: ptr.offset_from(PTR_ALLOC) as usize,
+                    length: MIN_BLOCK << order,
+                };
+                inner.close(block);
+            }
+        }
+    }
+
+    unsafe impl Sync for Allocator {}
+
+    pub fn clp2(n: usize) -> usize {
+        n.next_power_of_two()
+    }
+
+    pub fn log2(m: usize, n: usize) -> usize {
+        n.next_power_of_two().trailing_zeros() as usize - m.trailing_zeros() as usize
+    }
+
+    pub fn uldr(p: *mut u8) -> usize {
+        unsafe { *(p as *const usize) }
+    }
+
+    pub fn ustr(p: *mut u8, n: usize) {
+        unsafe {
+            *(p as *mut usize) = n;
+        }
+    }
+
+    pub fn used() -> usize {
+        let mut s = 0usize;
+        for order in 0..=MAX_ORDER {
+            unsafe {
+                let mut n = FREE_LIST[order];
+                while n != usize::MAX {
+                    s += MIN_BLOCK << order;
+                    n = uldr(PTR_ALLOC.add(n));
+                }
+            }
+        }
+        MAX_TOTAL - s
+    }
+}
 
 static BIN_PATH_BUFFER: &'static [u8] = include_bytes!("../tests/programs/alloc_many");
 static BIN_NAME: &str = "alloc_many";
-
-#[cfg(not(target_os = "windows"))]
-#[global_allocator]
-static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
-
 static G_CHECK_LOOP: usize = 10;
+#[global_allocator]
+pub static LALC: balloc::Allocator = balloc::Allocator::global();
 
-fn get_current_memory_linux() -> usize {
-    let output = String::from_utf8(
-        Command::new("smem")
-            .arg("-P")
-            .arg("check_real_memory")   // current process name
-            .arg("-c")
-            .arg("pid uss")
-            .output()
-            .expect("run ps failed")
-            .stdout,
-    )
-    .unwrap();
-
-    let outputs = output.split("\n").collect::<Vec<&str>>();
-    for i in 1..outputs.len() {
-        let mut has_pid = false;
-        let mut memory_size: u32 = 0;
-        for d in outputs[i].split(" ").collect::<Vec<&str>>() {
-            if d == " " || d == "" {
-                continue;
-            }
-            let val: u32 = d.parse().unwrap();
-            if !has_pid {
-                if val != id() {
-                    continue;
-                }
-                has_pid = true;
-            } else {
-                memory_size = val;
-            }
-        }
-        if memory_size != 0 {
-            return memory_size as usize;
-        }
-    }
-
-    0
-}
-
-fn get_current_memory() -> usize {
-    if !cfg!(target_os = "linux") {
-        get_current_memory_linux()
-    } else {
-        let pid = format!("{}", id());
-        let output = String::from_utf8(
-            Command::new("ps")
-                .arg("-p")
-                .arg(pid)
-                .arg("-o")
-                .arg("rss")
-                .output()
-                .expect("run ps failed")
-                .stdout,
-        )
-        .unwrap();
-
-        let output = output.split("\n").collect::<Vec<&str>>();
-
-        let memory_size = output[1].replace(" ", "");
-        memory_size.parse().unwrap()
-    }
-}
-
-struct MemoryOverflow {
-    #[cfg(not(target_os = "windows"))]
-    base_allocated: usize,
-
-    #[cfg(not(target_os = "windows"))]
-    base_resident: usize,
-}
-
-impl MemoryOverflow {
-    pub fn new() -> Self {
-        Self {
-            #[cfg(not(target_os = "windows"))]
-            base_allocated: jemalloc_ctl::stats::allocated::read().unwrap(),
-
-            #[cfg(not(target_os = "windows"))]
-            base_resident: jemalloc_ctl::stats::resident::read().unwrap(),
-        }
-    }
-
-    pub fn check(&self) {
-        #[cfg(not(target_os = "windows"))]
-        assert!(jemalloc_ctl::stats::allocated::read().unwrap() <= self.base_allocated);
-
-        #[cfg(not(target_os = "windows"))]
-        assert!(jemalloc_ctl::stats::resident::read().unwrap() <= self.base_resident);
-    }
-}
-
-fn check_interpreter(memory_size: usize) -> Result<(), ()> {
-    println!(
-        "Check interpreter memory overflow, ckb-vm memory size: {}",
-        memory_size
-    );
-    println!("Base memory: {}", get_current_memory());
+fn check_interpreter() -> Result<(), Box<dyn std::error::Error>> {
+    println!("Check interpreter: init");
+    println!("Check interpreter: base memory used {}", balloc::used());
     for _ in 0..G_CHECK_LOOP {
         let result = run_with_memory::<u64, SparseMemory<u64>>(
             &Bytes::from(BIN_PATH_BUFFER),
             &vec![Bytes::from(BIN_NAME)],
-            memory_size,
+            DEFAULT_MEMORY_SIZE,
         );
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), 0);
-        println!("Current memory: {}", get_current_memory());
+        println!("Check interpreter: step memory used {}", balloc::used());
     }
-    println!("End of check");
-    Ok(())
-}
-
-fn check_falt(memory_size: usize) -> Result<(), ()> {
-    println!(
-        "Check falt memory overflow, ckb-vm memory size: {}",
-        memory_size
-    );
-    println!("Base memory: {}", get_current_memory());
-    for _ in 0..G_CHECK_LOOP {
-        let result = run_with_memory::<u64, FlatMemory<u64>>(
-            &Bytes::from(BIN_PATH_BUFFER),
-            &vec![Bytes::from(BIN_NAME)],
-            memory_size,
-        );
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), 0);
-        println!("Current memory: {}", get_current_memory());
-    }
-    println!("End of check");
+    println!("Check interpreter: done memory used {}", balloc::used());
     Ok(())
 }
 
 #[cfg(has_asm)]
-fn check_asm(memory_size: usize) -> Result<(), ()> {
-    println!(
-        "Check asm memory overflow, ckb-vm memory size: {}",
-        memory_size
-    );
-    println!("Base memory: {}", get_current_memory());
+fn check_asm() -> Result<(), Box<dyn std::error::Error>> {
+    println!("Check asm: init",);
+    println!("Check asm: base memory used {}", balloc::used());
     for _ in 0..G_CHECK_LOOP {
         let asm_core = <AsmCoreMachine as SupportMachine>::new_with_memory(
             ISA_IMC,
             VERSION0,
             u64::MAX,
-            memory_size,
+            DEFAULT_MEMORY_SIZE,
         );
         let core = AsmDefaultMachineBuilder::new(asm_core).build();
         let mut machine = AsmMachine::new(core);
@@ -181,84 +264,15 @@ fn check_asm(memory_size: usize) -> Result<(), ()> {
         let result = machine.run();
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), 0);
-
-        println!("Current memory: {}", get_current_memory());
+        println!("Check asm: step memory used {}", balloc::used());
     }
-    println!("End of check");
+    println!("Check asm: done memory used {}", balloc::used());
     Ok(())
 }
 
-#[cfg(has_asm)]
-fn check_asm_in_thread(memory_size: usize) -> Result<(), ()> {
-    println!(
-        "Check asm in thread memory overflow, ckb-vm memory size: {}",
-        memory_size
-    );
-    println!("Base memory: {}", get_current_memory());
-    for _ in 0..G_CHECK_LOOP {
-        let asm_core = <AsmCoreMachine as SupportMachine>::new_with_memory(
-            ISA_IMC,
-            VERSION0,
-            u64::MAX,
-            memory_size,
-        );
-        let core = AsmDefaultMachineBuilder::new(asm_core).build();
-        let mut machine = AsmMachine::new(core);
-        machine
-            .load_program(
-                &Bytes::from(BIN_PATH_BUFFER),
-                [Ok(Bytes::from(BIN_NAME))].into_iter(),
-            )
-            .unwrap();
-        let thread_join_handle = thread::spawn(move || {
-            let result = machine.run();
-            assert!(result.is_ok());
-            assert_eq!(result.unwrap(), 0);
-        });
-        thread_join_handle.join().unwrap();
-        println!("Current memory: {}", get_current_memory());
-    }
-    println!("End of check");
-    Ok(())
-}
-
-fn test_memory(memory_size: usize) -> Result<(), ()> {
-    if check_interpreter(memory_size).is_err() {
-        return Err(());
-    }
-    if check_falt(memory_size).is_err() {
-        return Err(());
-    }
-
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    check_interpreter()?;
     #[cfg(has_asm)]
-    if check_asm(memory_size).is_err() {
-        return Err(());
-    }
-
-    #[cfg(has_asm)]
-    if check_asm_in_thread(memory_size).is_err() {
-        return Err(());
-    }
+    check_asm()?;
     Ok(())
-}
-
-fn main() {
-    #[cfg(not(target_os = "windows"))]
-    jemalloc_ctl::epoch::advance().unwrap();
-
-    let memory_overflow = MemoryOverflow::new();
-
-    let memory_size = 1024 * 1024 * 4;
-    if test_memory(memory_size).is_err() {
-        panic!("run testcase failed");
-    }
-
-    memory_overflow.check();
-
-    let memory_size = 1024 * 1024 * 2;
-    if test_memory(memory_size).is_err() {
-        panic!("run testcase failed");
-    }
-
-    memory_overflow.check();
 }

--- a/examples/check_real_memory.rs
+++ b/examples/check_real_memory.rs
@@ -11,223 +11,73 @@ use ckb_vm::{
     },
 };
 
-mod balloc {
-    //! A hand written buddy allocator implementation for no_std environments.
-    //!
-    //! This module implements a buddy memory allocator that manages a fixed-size memory pool.
-    //! The buddy allocator works by recursively splitting memory blocks into pairs of equal-sized "buddies" until it
-    //! finds a block of the appropriate size. When memory is freed, it attempts to merge adjacent buddy blocks back
-    //! together to reduce fragmentation.
+use buddy_alloc::{BuddyAllocParam, buddy_alloc::BuddyAlloc};
+use std::alloc::GlobalAlloc;
+use std::alloc::Layout;
+use std::cell::RefCell;
 
-    use core::alloc::{GlobalAlloc, Layout};
-    use core::cell::UnsafeCell;
-    use core::cmp::min;
-    use core::ptr::addr_of_mut;
+const HEAP_SIZE: usize = 16 * 1024 * 1024;
+const LEAF_SIZE: usize = 64;
+#[repr(align(64))]
+struct Heap<const S: usize>([u8; S]);
+static mut HEAP: Heap<HEAP_SIZE> = Heap([0u8; HEAP_SIZE]);
 
-    pub const MIN_BLOCK: usize = 64;
-    pub const MAX_ORDER: usize = 18;
-    pub const MAX_TOTAL: usize = MIN_BLOCK * (1 << MAX_ORDER);
-    pub const PTR_ALLOC: *mut u8 = addr_of_mut!(PRE_ALLOC) as *mut u8;
-    pub static mut FREE_LIST: [usize; MAX_ORDER + 1] = {
-        let mut list = [usize::MAX; MAX_ORDER + 1];
-        list[MAX_ORDER] = 0;
-        list
-    };
-    pub static mut PRE_ALLOC: [u8; MAX_TOTAL] = {
-        assert!(matches!(usize::BITS, 32 | 64));
-        let mut alloc = [0; MAX_TOTAL];
-        if usize::BITS >= 32 {
-            alloc[0] = 0xff;
-            alloc[1] = 0xff;
-            alloc[2] = 0xff;
-            alloc[3] = 0xff;
-        }
-        if usize::BITS >= 64 {
-            alloc[4] = 0xff;
-            alloc[5] = 0xff;
-            alloc[6] = 0xff;
-            alloc[7] = 0xff;
-        }
-        alloc
-    };
+pub struct NonThreadsafeAlloc {
+    buddy_alloc_param: BuddyAllocParam,
+    inner_buddy_alloc: RefCell<Option<BuddyAlloc>>,
+}
 
-    /// Buddy allocation algorithm implementation.
-    pub struct Algorithm;
-    /// Information about allocated memory blocks.
-    #[derive(Clone, Copy)]
-    pub struct Blockinfo {
-        /// Offset of the allocated block within the memory pool.
-        pub offset: usize,
-        /// Length of the allocated block.
-        pub length: usize,
-    }
-
-    impl Algorithm {
-        pub fn alloc(&mut self, order: usize) -> Blockinfo {
-            unsafe {
-                if order > MAX_ORDER {
-                    let block_offset = usize::MAX;
-                    return Blockinfo {
-                        offset: block_offset,
-                        length: 0,
-                    };
-                }
-                let block_size = MIN_BLOCK << order;
-                if FREE_LIST[order] != usize::MAX {
-                    let block_offset = FREE_LIST[order];
-                    let block_ptr = PTR_ALLOC.add(block_offset);
-                    FREE_LIST[order] = uldr(block_ptr);
-                    return Blockinfo {
-                        offset: block_offset,
-                        length: block_size,
-                    };
-                }
-                let block = self.alloc(order + 1);
-                let block_offset = block.offset;
-                if block_offset == usize::MAX {
-                    return Blockinfo {
-                        offset: block_offset,
-                        length: 0,
-                    };
-                }
-                let buddy_offset = block_offset + block_size;
-                let buddy_ptr = PTR_ALLOC.add(buddy_offset);
-                ustr(buddy_ptr, usize::MAX);
-                FREE_LIST[order] = buddy_offset;
-                Blockinfo {
-                    offset: block_offset,
-                    length: block_size,
-                }
-            }
-        }
-
-        pub fn close(&mut self, block: Blockinfo) {
-            unsafe {
-                if block.offset == usize::MAX {
-                    return;
-                }
-                let order = log2(MIN_BLOCK, block.length);
-                let block_idx = block.offset / block.length;
-                let buddy_idx = block_idx ^ 1;
-                let buddy_offset = buddy_idx * block.length;
-                let buddy = Blockinfo {
-                    offset: buddy_offset,
-                    length: block.length,
-                };
-                let upper = Blockinfo {
-                    offset: min(block.offset, buddy_offset),
-                    length: block.length << 1,
-                };
-                let mut n = FREE_LIST[order];
-                let mut m: usize;
-                loop {
-                    if n == usize::MAX {
-                        let block_ptr = PTR_ALLOC.add(block.offset);
-                        ustr(block_ptr, FREE_LIST[order]);
-                        FREE_LIST[order] = block.offset;
-                        break;
-                    }
-                    m = uldr(PTR_ALLOC.add(n));
-                    if n == buddy.offset {
-                        FREE_LIST[order] = m;
-                        self.close(upper);
-                        break;
-                    }
-                    if m == buddy.offset {
-                        ustr(PTR_ALLOC.add(n), uldr(PTR_ALLOC.add(m)));
-                        self.close(upper);
-                        break;
-                    }
-                    n = m;
-                }
-            }
+impl NonThreadsafeAlloc {
+    /// see BuddyAlloc::new
+    pub const fn new(buddy_alloc_param: BuddyAllocParam) -> Self {
+        NonThreadsafeAlloc {
+            inner_buddy_alloc: RefCell::new(None),
+            buddy_alloc_param,
         }
     }
 
-    /// Global allocator struct that uses the buddy allocation algorithm.
-    pub struct Allocator {
-        inner: UnsafeCell<Algorithm>,
+    unsafe fn with_buddy_alloc<R, F: FnOnce(&mut BuddyAlloc) -> R>(&self, f: F) -> R {
+        let mut inner = self.inner_buddy_alloc.borrow_mut();
+        let alloc = inner.get_or_insert_with(|| unsafe { BuddyAlloc::new(self.buddy_alloc_param) });
+        f(alloc)
     }
 
-    impl Allocator {
-        /// Creates a new global allocator instance.
-        pub const fn global() -> Self {
-            Allocator {
-                inner: UnsafeCell::new(Algorithm {}),
-            }
-        }
-    }
-
-    unsafe impl GlobalAlloc for Allocator {
-        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-            unsafe {
-                let inner = &mut *self.inner.get();
-                let order = log2(MIN_BLOCK, clp2(layout.size()).max(MIN_BLOCK));
-                let block = inner.alloc(order);
-                if block.offset == usize::MAX {
-                    return core::ptr::null_mut();
-                }
-                PTR_ALLOC.add(block.offset)
-            }
-        }
-
-        unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-            unsafe {
-                let inner = &mut *self.inner.get();
-                let order = log2(MIN_BLOCK, clp2(layout.size()).max(MIN_BLOCK));
-                let block = Blockinfo {
-                    offset: ptr.offset_from(PTR_ALLOC) as usize,
-                    length: MIN_BLOCK << order,
-                };
-                inner.close(block);
-            }
-        }
-    }
-
-    unsafe impl Sync for Allocator {}
-
-    pub fn clp2(n: usize) -> usize {
-        n.next_power_of_two()
-    }
-
-    pub fn log2(m: usize, n: usize) -> usize {
-        n.next_power_of_two().trailing_zeros() as usize - m.trailing_zeros() as usize
-    }
-
-    pub fn uldr(p: *mut u8) -> usize {
-        unsafe { *(p as *const usize) }
-    }
-
-    pub fn ustr(p: *mut u8, n: usize) {
-        unsafe {
-            *(p as *mut usize) = n;
-        }
-    }
-
-    pub fn used() -> usize {
-        let mut s = 0usize;
-        for order in 0..=MAX_ORDER {
-            unsafe {
-                let mut n = FREE_LIST[order];
-                while n != usize::MAX {
-                    s += MIN_BLOCK << order;
-                    n = uldr(PTR_ALLOC.add(n));
-                }
-            }
-        }
-        MAX_TOTAL - s
+    fn used(&self) -> usize {
+        HEAP_SIZE
+            - self
+                .inner_buddy_alloc
+                .borrow()
+                .as_ref()
+                .unwrap()
+                .available_bytes()
     }
 }
+
+unsafe impl GlobalAlloc for NonThreadsafeAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let bytes = layout.size();
+        unsafe { self.with_buddy_alloc(|alloc| alloc.malloc(bytes)) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
+        unsafe { self.with_buddy_alloc(|alloc| alloc.free(ptr)) };
+    }
+}
+
+unsafe impl Sync for NonThreadsafeAlloc {}
+
+#[allow(static_mut_refs)]
+#[global_allocator]
+static ALLOC: NonThreadsafeAlloc =
+    unsafe { NonThreadsafeAlloc::new(BuddyAllocParam::new(HEAP.0.as_ptr(), HEAP_SIZE, LEAF_SIZE)) };
 
 static BIN_PATH_BUFFER: &'static [u8] = include_bytes!("../tests/programs/alloc_many");
 static BIN_NAME: &str = "alloc_many";
 static G_CHECK_LOOP: usize = 10;
-#[global_allocator]
-pub static LALC: balloc::Allocator = balloc::Allocator::global();
 
 fn check_interpreter() -> Result<(), Box<dyn std::error::Error>> {
     println!("Check interpreter: init");
-    println!("Check interpreter: base memory used {}", balloc::used());
+    println!("Check interpreter: base memory used {}", ALLOC.used());
     for _ in 0..G_CHECK_LOOP {
         let result = run_with_memory::<u64, SparseMemory<u64>>(
             &Bytes::from(BIN_PATH_BUFFER),
@@ -236,16 +86,16 @@ fn check_interpreter() -> Result<(), Box<dyn std::error::Error>> {
         );
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), 0);
-        println!("Check interpreter: step memory used {}", balloc::used());
+        println!("Check interpreter: step memory used {}", ALLOC.used());
     }
-    println!("Check interpreter: done memory used {}", balloc::used());
+    println!("Check interpreter: done memory used {}", ALLOC.used());
     Ok(())
 }
 
 #[cfg(has_asm)]
 fn check_asm() -> Result<(), Box<dyn std::error::Error>> {
     println!("Check asm: init",);
-    println!("Check asm: base memory used {}", balloc::used());
+    println!("Check asm: base memory used {}", ALLOC.used());
     for _ in 0..G_CHECK_LOOP {
         let asm_core = <AsmCoreMachine as SupportMachine>::new_with_memory(
             ISA_IMC,
@@ -264,9 +114,9 @@ fn check_asm() -> Result<(), Box<dyn std::error::Error>> {
         let result = machine.run();
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), 0);
-        println!("Check asm: step memory used {}", balloc::used());
+        println!("Check asm: step memory used {}", ALLOC.used());
     }
-    println!("Check asm: done memory used {}", balloc::used());
+    println!("Check asm: done memory used {}", ALLOC.used());
     Ok(())
 }
 


### PR DESCRIPTION
Using a hand-written allocator can provide accurate information about the memory used by a ckb-vm machine instance, which is better than using jemalloc.