### PR TITLE
Update spike-sys to v0.1.3

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
-spike-sys = "0.1.2"
+spike-sys = "0.1.3"
 ckb-vm = { path = "..", features = ["asm"] }
 ckb-vm-definitions = { path = "../definitions" }
 


### PR DESCRIPTION
There is a bug in spike that cause its calculation results to be inconsistent with ckb-vm.

https://github.com/riscv-software-src/riscv-isa-sim/commit/fd077496cdf2fd2491fbd387955d40f87ddece92