### PR TITLE
refactor: replace byteorder crate usage with native rust methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ miri-ci = []
 pprof = []
 
 [dependencies]
-byteorder = "1"
 bytes = "1"
 goblin_v023 = { package = "goblin", version = "=0.2.3" }
 goblin_v040 = { package = "goblin", version = "=0.4.0" }

--- a/src/machine/asm/mod.rs
+++ b/src/machine/asm/mod.rs
@@ -1,6 +1,5 @@
 pub mod traces;
 
-use byteorder::{ByteOrder, LittleEndian};
 use bytes::Bytes;
 pub use ckb_vm_definitions::asm::AsmCoreMachine;
 use ckb_vm_definitions::{
@@ -571,13 +570,17 @@ where
     fn execute_load16(&mut self, addr: u64) -> Result<u16, Error> {
         check_memory_executable(self, addr, 2)?;
         let slice = cast_ptr_to_slice(self, self.as_ref().memory_ptr, addr as usize, 2);
-        Ok(LittleEndian::read_u16(slice))
+        let mut bytes = [0u8; 2];
+        bytes.copy_from_slice(slice);
+        Ok(u16::from_le_bytes(bytes))
     }
 
     fn execute_load32(&mut self, addr: u64) -> Result<u32, Error> {
         check_memory_executable(self, addr, 4)?;
         let slice = cast_ptr_to_slice(self, self.as_ref().memory_ptr, addr as usize, 4);
-        Ok(LittleEndian::read_u32(slice))
+        let mut bytes = [0u8; 4];
+        bytes.copy_from_slice(slice);
+        Ok(u32::from_le_bytes(bytes))
     }
 
     fn load8(&mut self, addr: &u64) -> Result<u64, Error> {
@@ -591,21 +594,27 @@ where
         let addr = *addr;
         check_memory_inited(self, addr, 2)?;
         let slice = cast_ptr_to_slice(self, self.as_ref().memory_ptr, addr as usize, 2);
-        Ok(u64::from(LittleEndian::read_u16(slice)))
+        let mut bytes = [0u8; 2];
+        bytes.copy_from_slice(slice);
+        Ok(u64::from(u16::from_le_bytes(bytes)))
     }
 
     fn load32(&mut self, addr: &u64) -> Result<u64, Error> {
         let addr = *addr;
         check_memory_inited(self, addr, 4)?;
         let slice = cast_ptr_to_slice(self, self.as_ref().memory_ptr, addr as usize, 4);
-        Ok(u64::from(LittleEndian::read_u32(slice)))
+        let mut bytes = [0u8; 4];
+        bytes.copy_from_slice(slice);
+        Ok(u64::from(u32::from_le_bytes(bytes)))
     }
 
     fn load64(&mut self, addr: &u64) -> Result<u64, Error> {
         let addr = *addr;
         check_memory_inited(self, addr, 8)?;
         let slice = cast_ptr_to_slice(self, self.as_ref().memory_ptr, addr as usize, 8);
-        Ok(LittleEndian::read_u64(slice))
+        let mut bytes = [0u8; 8];
+        bytes.copy_from_slice(slice);
+        Ok(u64::from_le_bytes(bytes))
     }
 
     fn store8(&mut self, addr: &u64, value: &u64) -> Result<(), Error> {
@@ -620,7 +629,8 @@ where
         let addr = *addr;
         check_memory_writable(self, addr, 2)?;
         let slice = cast_ptr_to_slice_mut(self, self.as_ref().memory_ptr, addr as usize, 2);
-        LittleEndian::write_u16(slice, *value as u16);
+        let bytes = (*value as u16).to_le_bytes();
+        slice.copy_from_slice(&bytes);
         Ok(())
     }
 
@@ -628,7 +638,8 @@ where
         let addr = *addr;
         check_memory_writable(self, addr, 4)?;
         let slice = cast_ptr_to_slice_mut(self, self.as_ref().memory_ptr, addr as usize, 4);
-        LittleEndian::write_u32(slice, *value as u32);
+        let bytes = (*value as u32).to_le_bytes();
+        slice.copy_from_slice(&bytes);
         Ok(())
     }
 
@@ -636,7 +647,8 @@ where
         let addr = *addr;
         check_memory_writable(self, addr, 8)?;
         let slice = cast_ptr_to_slice_mut(self, self.as_ref().memory_ptr, addr as usize, 8);
-        LittleEndian::write_u64(slice, *value as u64);
+        let bytes = (*value as u64).to_le_bytes();
+        slice.copy_from_slice(&bytes);
         Ok(())
     }
 

--- a/src/memory/flat.rs
+++ b/src/memory/flat.rs
@@ -1,9 +1,7 @@
 use super::super::{Error, RISCV_PAGE_SHIFTS, RISCV_PAGESIZE, Register, error::OutOfBoundKind};
 use super::{Memory, check_no_overflow, fill_page_data, get_page_indices, memset, set_dirty};
 
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use bytes::Bytes;
-use std::io::{Cursor, Seek, SeekFrom};
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 
@@ -108,39 +106,37 @@ impl<R: Register> Memory for FlatMemory<R> {
     fn load8(&mut self, addr: &Self::REG) -> Result<Self::REG, Error> {
         let addr = addr.to_u64();
         check_no_overflow(addr, 1, self.memory_size as u64)?;
-        let mut reader = Cursor::new(&self.data);
-        reader.seek(SeekFrom::Start(addr as u64))?;
-        let v = reader.read_u8()?;
+        let v = self.data[addr as usize];
         Ok(Self::REG::from_u8(v))
     }
 
     fn load16(&mut self, addr: &Self::REG) -> Result<Self::REG, Error> {
         let addr = addr.to_u64();
         check_no_overflow(addr, 2, self.memory_size as u64)?;
-        let mut reader = Cursor::new(&self.data);
-        reader.seek(SeekFrom::Start(addr as u64))?;
         // NOTE: Base RISC-V ISA is defined as a little-endian memory system.
-        let v = reader.read_u16::<LittleEndian>()?;
+        let mut bytes = [0u8; 2];
+        bytes.copy_from_slice(&self.data[addr as usize..addr as usize + 2]);
+        let v = u16::from_le_bytes(bytes);
         Ok(Self::REG::from_u16(v))
     }
 
     fn load32(&mut self, addr: &Self::REG) -> Result<Self::REG, Error> {
         let addr = addr.to_u64();
         check_no_overflow(addr, 4, self.memory_size as u64)?;
-        let mut reader = Cursor::new(&self.data);
-        reader.seek(SeekFrom::Start(addr as u64))?;
         // NOTE: Base RISC-V ISA is defined as a little-endian memory system.
-        let v = reader.read_u32::<LittleEndian>()?;
+        let mut bytes = [0u8; 4];
+        bytes.copy_from_slice(&self.data[addr as usize..addr as usize + 4]);
+        let v = u32::from_le_bytes(bytes);
         Ok(Self::REG::from_u32(v))
     }
 
     fn load64(&mut self, addr: &Self::REG) -> Result<Self::REG, Error> {
         let addr = addr.to_u64();
         check_no_overflow(addr, 8, self.memory_size as u64)?;
-        let mut reader = Cursor::new(&self.data);
-        reader.seek(SeekFrom::Start(addr as u64))?;
         // NOTE: Base RISC-V ISA is defined as a little-endian memory system.
-        let v = reader.read_u64::<LittleEndian>()?;
+        let mut bytes = [0u8; 8];
+        bytes.copy_from_slice(&self.data[addr as usize..addr as usize + 8]);
+        let v = u64::from_le_bytes(bytes);
         Ok(Self::REG::from_u64(v))
     }
 
@@ -149,9 +145,7 @@ impl<R: Register> Memory for FlatMemory<R> {
         check_no_overflow(addr, 1, self.memory_size as u64)?;
         let page_indices = get_page_indices(addr, 1);
         set_dirty(self, &page_indices)?;
-        let mut writer = Cursor::new(&mut self.data);
-        writer.seek(SeekFrom::Start(addr as u64))?;
-        writer.write_u8(value.to_u8())?;
+        self.data[addr as usize] = value.to_u8();
         Ok(())
     }
 
@@ -160,9 +154,8 @@ impl<R: Register> Memory for FlatMemory<R> {
         check_no_overflow(addr, 2, self.memory_size as u64)?;
         let page_indices = get_page_indices(addr, 2);
         set_dirty(self, &page_indices)?;
-        let mut writer = Cursor::new(&mut self.data);
-        writer.seek(SeekFrom::Start(addr as u64))?;
-        writer.write_u16::<LittleEndian>(value.to_u16())?;
+        let bytes = value.to_u16().to_le_bytes();
+        self.data[addr as usize..addr as usize + 2].copy_from_slice(&bytes);
         Ok(())
     }
 
@@ -171,9 +164,8 @@ impl<R: Register> Memory for FlatMemory<R> {
         check_no_overflow(addr, 4, self.memory_size as u64)?;
         let page_indices = get_page_indices(addr, 4);
         set_dirty(self, &page_indices)?;
-        let mut writer = Cursor::new(&mut self.data);
-        writer.seek(SeekFrom::Start(addr as u64))?;
-        writer.write_u32::<LittleEndian>(value.to_u32())?;
+        let bytes = value.to_u32().to_le_bytes();
+        self.data[addr as usize..addr as usize + 4].copy_from_slice(&bytes);
         Ok(())
     }
 
@@ -182,9 +174,8 @@ impl<R: Register> Memory for FlatMemory<R> {
         check_no_overflow(addr, 8, self.memory_size as u64)?;
         let page_indices = get_page_indices(addr, 8);
         set_dirty(self, &page_indices)?;
-        let mut writer = Cursor::new(&mut self.data);
-        writer.seek(SeekFrom::Start(addr as u64))?;
-        writer.write_u64::<LittleEndian>(value.to_u64())?;
+        let bytes = value.to_u64().to_le_bytes();
+        self.data[addr as usize..addr as usize + 8].copy_from_slice(&bytes);
         Ok(())
     }
 


### PR DESCRIPTION
ckb-vm relied on the `byteorder` library to handle byte order. However, Rust's standard library (since version 1.44) already provides sufficient functionality to handle byte order, so we can consider removing the byteorder dependency.

https://doc.rust-lang.org/std/primitive.u32.html#method.from_le_bytes

Meanwhile, the byteorder repository appears to be no longer maintained, furthermore, the author no longer recommends its use: https://github.com/BurntSushi/byteorder?tab=readme-ov-file#alternatives

I believe we didn't choose byteorder over the Rust standard library, but simply because the ckb-vm repository was created before Rust 1.44
