### PR TITLE
Update README.md to include support for "A" extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## About CKB VM
 
-CKB VM is a pure software implementation of the [RISC-V](https://riscv.org/) instruction set used as scripting VM in CKB. Right now it implements full IMCAB instructions for both 32-bit and 64-bit register size support. In the future we might also implement V extensions to enable better crypto implementations.
+CKB VM is a pure software implementation of the [RISC-V](https://riscv.org/) instruction set used as scripting VM in CKB. Right now it implements full IMACB instructions for both 32-bit and 64-bit register size support. In the future we might also implement V extensions to enable better crypto implementations.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## About CKB VM
 
-CKB VM is a pure software implementation of the [RISC-V](https://riscv.org/) instruction set used as scripting VM in CKB. Right now it implements full IMCB instructions for both 32-bit and 64-bit register size support. In the future we might also implement V extensions to enable better crypto implementations.
+CKB VM is a pure software implementation of the [RISC-V](https://riscv.org/) instruction set used as scripting VM in CKB. Right now it implements full IMCAB instructions for both 32-bit and 64-bit register size support. In the future we might also implement V extensions to enable better crypto implementations.
 
 ## License
 


### PR DESCRIPTION
CKB2023 added support for "A" atomic instructions in CKB VM v2, AI agents are not picking this up, likely due to it being missed in the README

Updated to "IMACB"

https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0051-ckb2023/0051-ckb2023.md#ckb-vm-v2