### PR TITLE
Rewrite build.rs

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -9,7 +9,7 @@ jobs:
   linux-arm64:
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Build
         run: cargo test --features=asm --release
@@ -17,7 +17,7 @@ jobs:
   linux-x64:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Build
         run: cargo test --features=asm --release
@@ -25,7 +25,7 @@ jobs:
   macos-arm64:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Build
         run: cargo test --features=asm --release
@@ -33,7 +33,7 @@ jobs:
   macos-x64:
     runs-on: macos-15-intel
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Build
         run: cargo test --features=asm --release
@@ -41,7 +41,7 @@ jobs:
   qemu-arm64:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup
         run: |
           sudo apt-get update -y
@@ -58,7 +58,7 @@ jobs:
   qemu-riscv64:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup
         run: |
           sudo apt-get update -y
@@ -75,13 +75,13 @@ jobs:
   windows-x64:
     runs-on: windows-2025
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup
         shell: pwsh
         # https://github.com/ScoopInstaller/Install#for-admin
         run: |
           iex "& {$(irm get.scoop.sh)} -RunAsAdmin"
-          scoop install mingw
+          scoop install llvm
       - name: Build
         shell: pwsh
         run: cargo test --features=asm --release
@@ -89,7 +89,7 @@ jobs:
   misc:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       # https://github.com/EmbarkStudios/cargo-deny-action
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ derive_more = { version = "1", features = ["full"] }
 
 [build-dependencies]
 cc = "1.0"
-clang-finder = "0.1"
 
 [dev-dependencies]
 argparse = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ derive_more = { version = "1", features = ["full"] }
 
 [build-dependencies]
 cc = "1.0"
+clang-finder = "0.1"
 
 [dev-dependencies]
 argparse = "0.2"

--- a/build.rs
+++ b/build.rs
@@ -7,6 +7,7 @@ use std::env;
 
 fn main() {
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    let target_family = env::var("CARGO_CFG_TARGET_FAMILY").unwrap_or_default();
     let support_asm = ["aarch64", "riscv64", "x86_64"].contains(&target_arch.as_str());
     if !support_asm {
         if cfg!(feature = "asm") {
@@ -38,12 +39,21 @@ fn main() {
                 .file("src/machine/asm/execute_riscv64.S")
                 .compile("asm");
         }
-        "x86_64" => {
-            cc::Build::new()
-                .include("src/machine/asm")
-                .file("src/machine/asm/execute_x64.S")
-                .compile("asm");
-        }
+        "x86_64" => match target_family.as_str() {
+            "windows" => {
+                cc::Build::new()
+                    .compiler(clang_finder::find())
+                    .include("src/machine/asm")
+                    .file("src/machine/asm/execute_x64.S")
+                    .compile("asm");
+            }
+            _ => {
+                cc::Build::new()
+                    .include("src/machine/asm")
+                    .file("src/machine/asm/execute_x64.S")
+                    .compile("asm");
+            }
+        },
         _ => {}
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,7 @@ use std::env;
 
 fn main() {
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
-    let support_asm = vec!["aarch64", "riscv64", "x86_64"].contains(&target_arch.as_str());
+    let support_asm = ["aarch64", "riscv64", "x86_64"].contains(&target_arch.as_str());
     if !support_asm {
         if cfg!(feature = "asm") {
             panic!("Asm is not available for {}!", target_arch);

--- a/build.rs
+++ b/build.rs
@@ -3,61 +3,50 @@
 // have to keep features always on, and do conditional compilation within the
 // source code
 
+use std::env;
+
 fn main() {
-    use std::env;
-
-    let target_family = env::var("CARGO_CFG_TARGET_FAMILY").unwrap_or_default();
     let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
-    let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
-    let target = env::var("TARGET").unwrap_or_default();
-    let is_windows = target_family == "windows";
-    let is_msvc = is_windows && (target_env == "msvc");
-    let is_unix = target_family == "unix";
-    let is_x86_64 = target_arch == "x86_64";
-    let is_aarch64 = target_arch == "aarch64";
-    let is_riscv64 = target_arch == "riscv64";
-    let x64_asm = is_x86_64 && (is_windows || is_unix);
-    let aarch64_asm = is_aarch64 && is_unix;
-    // toolchain on sp1 has empty target_family
-    let riscv64_asm = is_riscv64 && (is_unix || target_family.is_empty());
-    let can_enable_asm = x64_asm || aarch64_asm || riscv64_asm;
-
-    if cfg!(feature = "asm") && (!can_enable_asm) {
-        panic!(
-            "Asm feature is not available for target {} on {}!",
-            target_arch, target_family
-        );
+    let support_asm = vec!["aarch64", "riscv64", "x86_64"].contains(&target_arch.as_str());
+    if !support_asm {
+        if cfg!(feature = "asm") {
+            panic!("Asm is not available for {}!", target_arch);
+        }
+        return;
+    }
+    let request_asm = cfg!(feature = "asm") || cfg!(feature = "detect-asm");
+    if !request_asm {
+        return;
     }
 
-    if cfg!(any(feature = "asm", feature = "detect-asm")) && can_enable_asm {
-        println!("cargo:rerun-if-changed=src/machine/asm/execute_x64.S");
-        println!("cargo:rerun-if-changed=src/machine/asm/execute_aarch64.S");
-        println!("cargo:rerun-if-changed=src/machine/asm/execute_riscv64.S");
-        println!("cargo:rerun-if-changed=src/machine/asm/cdefinitions_generated.h");
+    println!("cargo:rustc-cfg=has_asm");
+    println!("cargo:rerun-if-changed=src/machine/asm/execute_x64.S");
+    println!("cargo:rerun-if-changed=src/machine/asm/execute_aarch64.S");
+    println!("cargo:rerun-if-changed=src/machine/asm/execute_riscv64.S");
+    println!("cargo:rerun-if-changed=src/machine/asm/cdefinitions_generated.h");
 
-        let mut build = cc::Build::new();
-
-        if x64_asm {
-            build.file("src/machine/asm/execute_x64.S");
-            if is_msvc {
-                // For now, only an assembly source code is required for CKB-VM, we won't
-                // need to build any C source file here. Hence we can use this simpler solution
-                // to set the default compiler to GCC. We will need to manually trigger the
-                // command to assemble the assembly code file, should any C source file is also
-                // required here.
-                build.compiler("gcc");
-            }
-        } else if aarch64_asm {
-            build.file("src/machine/asm/execute_aarch64.S");
-        } else if riscv64_asm {
-            if target.contains("zkvm") || target.contains("succinct") {
-                build.compiler("riscv64-linux-gnu-gcc");
-            }
-            build.file("src/machine/asm/execute_riscv64.S");
+    match target_arch.as_str() {
+        "aarch64" => {
+            cc::Build::new()
+                .compiler(clang_finder::find())
+                .include("src/machine/asm")
+                .file("src/machine/asm/execute_aarch64.S")
+                .compile("asm");
         }
-
-        build.include("src/machine/asm").compile("asm");
-
-        println!("cargo:rustc-cfg=has_asm")
+        "riscv64" => {
+            cc::Build::new()
+                .compiler(clang_finder::find())
+                .include("src/machine/asm")
+                .file("src/machine/asm/execute_riscv64.S")
+                .compile("asm");
+        }
+        "x86_64" => {
+            cc::Build::new()
+                .compiler(clang_finder::find())
+                .include("src/machine/asm")
+                .file("src/machine/asm/execute_x64.S")
+                .compile("asm");
+        }
+        _ => {}
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -28,21 +28,18 @@ fn main() {
     match target_arch.as_str() {
         "aarch64" => {
             cc::Build::new()
-                .compiler(clang_finder::find())
                 .include("src/machine/asm")
                 .file("src/machine/asm/execute_aarch64.S")
                 .compile("asm");
         }
         "riscv64" => {
             cc::Build::new()
-                .compiler(clang_finder::find())
                 .include("src/machine/asm")
                 .file("src/machine/asm/execute_riscv64.S")
                 .compile("asm");
         }
         "x86_64" => {
             cc::Build::new()
-                .compiler(clang_finder::find())
                 .include("src/machine/asm")
                 .file("src/machine/asm/execute_x64.S")
                 .compile("asm");


### PR DESCRIPTION
1. Build using clang instead of gcc on Windows.
2. The code in build.rs has been significantly simplified. 
3. The test worked fine on SP1.

Ref https://github.com/nervosnetwork/ckb-vm/issues/511
