### PR TITLE
Use rust edition 2024 in rustfmt.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
+edition = "2024"
 max_width = 100
 tab_spaces = 4
 reorder_imports = true


### PR DESCRIPTION
Consistent with ckb https://github.com/nervosnetwork/ckb/blob/develop/rustfmt.toml