### PR TITLE
Enable `Clone` for `DefaultCoreMachine`

### DIFF
--- a/src/machine/mod.rs
+++ b/src/machine/mod.rs
@@ -328,7 +328,7 @@ pub trait DefaultMachineRunner {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct DefaultCoreMachine<R, M> {
     registers: [R; RISCV_GENERAL_REGISTER_NUMBER],
     pc: R,

--- a/src/memory/sparse.rs
+++ b/src/memory/sparse.rs
@@ -9,6 +9,7 @@ const INVALID_PAGE_INDEX: u16 = 0xFFFF;
 
 /// A sparse flat memory implementation, it allocates pages only when requested,
 /// but besides that, it does not permission checking.
+#[derive(Clone)]
 pub struct SparseMemory<R> {
     // Stores the indices of each page in pages data structure, if a page hasn't
     // been initialized, the corresponding position will be filled with


### PR DESCRIPTION
Derive `Clone` for `DefaultCoreMachine` and `SparseMemory`, so that a VM instance could be directly reused without resorting to snapshots. This is especially useful in testing.