### PR TITLE
Fix: update RVC instruction handling to enforce reserved bit checks

### DIFF
--- a/src/instructions/rvc.rs
+++ b/src/instructions/rvc.rs
@@ -338,12 +338,16 @@ pub fn factory<R: Register>(instruction_bits: u32, version: u32) -> Option<Instr
                     match (instruction_bits & 0b_11_000_00000_00, uimm) {
                         // Invalid instruction
                         (0b_00_000_00000_00, 0) => None,
+                        // C.SRLI, RV32C reserved: shamt[5] (bit 12) must be 0 for C.SRLI
+                        (0b_00_000_00000_00, uimm) if rv32 && (uimm & 0x20) != 0 => None,
                         // C.SRLI
                         (0b_00_000_00000_00, uimm) => Some(
                             Itype::new_u(insts::OP_SRLI, rd, rd, uimm & u32::from(R::SHIFT_MASK)).0,
                         ),
                         // Invalid instruction
                         (0b_01_000_00000_00, 0) => None,
+                        // C.SRAI, RV32C reserved: shamt[5] (bit 12) must be 0 for C.SRAI
+                        (0b_01_000_00000_00, uimm) if rv32 && (uimm & 0x20) != 0 => None,
                         // C.SRAI
                         (0b_01_000_00000_00, uimm) => Some(
                             Itype::new_u(insts::OP_SRAI, rd, rd, uimm & u32::from(R::SHIFT_MASK)).0,
@@ -385,7 +389,10 @@ pub fn factory<R: Register>(instruction_bits: u32, version: u32) -> Option<Instr
         0b_000_00000000000_10 => {
             let uimm = uimmediate(instruction_bits);
             let rd = rd(instruction_bits);
-            if rd != 0 && uimm != 0 {
+            if rv32 && (uimm & 0x20) != 0 {
+                // C.SLLI, RV32C reserved: shamt[5] (bit 12) must be 0 for C.SLLI
+                None
+            } else if rd != 0 && uimm != 0 {
                 // C.SLLI
                 Some(Itype::new_u(insts::OP_SLLI, rd, rd, uimm & u32::from(R::SHIFT_MASK)).0)
             } else if version >= 1 {

--- a/tests/test_misc.rs
+++ b/tests/test_misc.rs
@@ -156,33 +156,39 @@ pub fn test_invalid_file_offset64() {
 }
 
 #[test]
-#[cfg_attr(all(miri, feature = "miri-ci"), ignore)]
 pub fn test_op_rvc_srli_crash_32() {
     let buffer = fs::read("tests/programs/op_rvc_srli_crash_32")
         .unwrap()
         .into();
     let result = run::<u32, SparseMemory<u32>>(&buffer, &vec!["op_rvc_srli_crash_32".into()]);
-    assert_eq!(result.err(), Some(Error::MemWriteOnExecutablePage(0)));
+    assert!(matches!(
+        result.err(),
+        Some(Error::InvalidInstruction { .. })
+    ));
 }
 
 #[test]
-#[cfg_attr(all(miri, feature = "miri-ci"), ignore)]
 pub fn test_op_rvc_srai_crash_32() {
     let buffer = fs::read("tests/programs/op_rvc_srai_crash_32")
         .unwrap()
         .into();
     let result = run::<u32, SparseMemory<u32>>(&buffer, &vec!["op_rvc_srai_crash_32".into()]);
-    assert!(result.is_ok());
+    assert!(matches!(
+        result.err(),
+        Some(Error::InvalidInstruction { .. })
+    ));
 }
 
 #[test]
-#[cfg_attr(all(miri, feature = "miri-ci"), ignore)]
 pub fn test_op_rvc_slli_crash_32() {
     let buffer = fs::read("tests/programs/op_rvc_slli_crash_32")
         .unwrap()
         .into();
     let result = run::<u32, SparseMemory<u32>>(&buffer, &vec!["op_rvc_slli_crash_32".into()]);
-    assert!(result.is_ok());
+    assert!(matches!(
+        result.err(),
+        Some(Error::InvalidInstruction { .. })
+    ));
 }
 
 #[test]


### PR DESCRIPTION
From the spec: https://docs.riscv.org/reference/isa/unpriv/c-st-ext.html

> For RV32C, shamt[5] must be zero; the code points with shamt[5]=1 are designated for custom extensions.

We seem to have discovered this issue 5 years ago, but haven't addressed it.

It only affects RV32; it has no impact on the mainnet.